### PR TITLE
RN-6: Add gRPC server skeleton and unix listener auth

### DIFF
--- a/cmd/rein/main.go
+++ b/cmd/rein/main.go
@@ -1,10 +1,66 @@
 package main
 
 import (
-	"fmt"
+	"context"
+	"flag"
+	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/earchibald/rein/internal/server"
+	"github.com/earchibald/rein/internal/service"
 )
 
 func main() {
-	fmt.Fprintln(os.Stdout, "rein")
+	os.Exit(run())
+}
+
+func run() int {
+	defaults := server.DefaultListenerConfig()
+
+	network := flag.String("grpc-network", defaults.Network, "listener network: tcp or unix")
+	address := flag.String("grpc-address", defaults.Address, "listener address or unix socket path")
+	requirePeerCredentials := flag.Bool("grpc-require-peer-credentials", defaults.RequirePeerCredentials, "require SO_PEERCRED same-UID authentication for unix sockets")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	listener, err := server.Listen(server.ListenerConfig{
+		Network:                *network,
+		Address:                *address,
+		UnixSocketMode:         0o600,
+		RequirePeerCredentials: *requirePeerCredentials,
+		Logger:                 logger,
+	})
+	if err != nil {
+		logger.Error("failed to create listener", "error", err)
+		return 1
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			logger.Error("failed to close listener", "error", err)
+		}
+	}()
+
+	runtime := server.New(server.Options{
+		Services: service.NewSet(),
+	})
+
+	logger.Info("rein gRPC server starting", "network", *network, "address", listener.Addr().String())
+	logger.Info(
+		"rein HTTP/SSE gateway v2 stub ready",
+		"routes", len(runtime.Gateway().Routes()),
+		"streams", len(runtime.Gateway().Streams()),
+	)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := runtime.Serve(ctx, listener); err != nil {
+		logger.Error("rein server exited with error", "error", err)
+		return 1
+	}
+
+	return 0
 }

--- a/internal/gateway/v2.go
+++ b/internal/gateway/v2.go
@@ -1,0 +1,76 @@
+package gateway
+
+import "net/http"
+
+type Route struct {
+	Method  string
+	Path    string
+	Purpose string
+}
+
+type Stream struct {
+	Path    string
+	Event   string
+	Purpose string
+}
+
+// V2Stub captures the intended HTTP and SSE shape for the future gateway
+// without shipping transport behavior in this milestone.
+type V2Stub struct {
+	routes  []Route
+	streams []Stream
+}
+
+func NewV2Stub() *V2Stub {
+	return &V2Stub{
+		routes: []Route{
+			{Method: http.MethodGet, Path: "/v2/projects", Purpose: "list projects"},
+			{Method: http.MethodGet, Path: "/v2/issues", Purpose: "list issues"},
+			{Method: http.MethodGet, Path: "/v2/workflows", Purpose: "list workflows"},
+		},
+		streams: []Stream{
+			{Path: "/v2/executions/stream", Event: "execution.updated", Purpose: "execution state updates"},
+		},
+	}
+}
+
+func (g *V2Stub) Handler() http.Handler {
+	if g == nil {
+		return http.NotFoundHandler()
+	}
+
+	notImplemented := func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rein HTTP/SSE gateway is not implemented yet", http.StatusNotImplemented)
+	}
+
+	mux := http.NewServeMux()
+	for _, route := range g.routes {
+		mux.HandleFunc(route.Path, notImplemented)
+	}
+	for _, stream := range g.streams {
+		mux.HandleFunc(stream.Path, notImplemented)
+	}
+	mux.HandleFunc("/v2", notImplemented)
+
+	return mux
+}
+
+func (g *V2Stub) Routes() []Route {
+	if g == nil {
+		return nil
+	}
+
+	routes := make([]Route, len(g.routes))
+	copy(routes, g.routes)
+	return routes
+}
+
+func (g *V2Stub) Streams() []Stream {
+	if g == nil {
+		return nil
+	}
+
+	streams := make([]Stream, len(g.streams))
+	copy(streams, g.streams)
+	return streams
+}

--- a/internal/server/listener.go
+++ b/internal/server/listener.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const defaultUnixSocketMode fs.FileMode = 0o600
+
+type ListenerConfig struct {
+	Network                string
+	Address                string
+	UnixSocketMode         fs.FileMode
+	RequirePeerCredentials bool
+	Logger                 *slog.Logger
+}
+
+func DefaultListenerConfig() ListenerConfig {
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		return ListenerConfig{
+			Network:                "unix",
+			Address:                filepath.Join(os.TempDir(), "rein.sock"),
+			UnixSocketMode:         defaultUnixSocketMode,
+			RequirePeerCredentials: true,
+		}
+	}
+
+	return ListenerConfig{
+		Network:        "tcp",
+		Address:        "127.0.0.1:7777",
+		UnixSocketMode: defaultUnixSocketMode,
+	}
+}
+
+func Listen(config ListenerConfig) (net.Listener, error) {
+	config = config.withDefaults()
+
+	switch config.Network {
+	case "tcp":
+		return net.Listen("tcp", config.Address)
+	case "unix":
+		return listenUnix(config)
+	default:
+		return nil, fmt.Errorf("unsupported listener network %q", config.Network)
+	}
+}
+
+func (c ListenerConfig) withDefaults() ListenerConfig {
+	defaults := DefaultListenerConfig()
+
+	if c.Network == "" {
+		c.Network = defaults.Network
+	}
+	if c.Address == "" {
+		c.Address = defaults.Address
+	}
+	if c.UnixSocketMode == 0 {
+		c.UnixSocketMode = defaultUnixSocketMode
+	}
+	if c.Logger == nil {
+		c.Logger = slog.Default()
+	}
+
+	return c
+}
+
+func listenUnix(config ListenerConfig) (net.Listener, error) {
+	if config.Address == "" {
+		return nil, errors.New("unix socket path is required")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(config.Address), 0o755); err != nil {
+		return nil, fmt.Errorf("create unix socket directory: %w", err)
+	}
+	if err := removeStaleUnixSocket(config.Address); err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("unix", config.Address)
+	if err != nil {
+		return nil, fmt.Errorf("listen on unix socket %q: %w", config.Address, err)
+	}
+
+	cleanupListener := &unixSocketListener{
+		Listener: listener,
+		path:     config.Address,
+	}
+
+	if err := os.Chmod(config.Address, config.UnixSocketMode); err != nil {
+		_ = cleanupListener.Close()
+		return nil, fmt.Errorf("chmod unix socket %q: %w", config.Address, err)
+	}
+
+	if !config.RequirePeerCredentials {
+		return cleanupListener, nil
+	}
+
+	authenticatedListener, err := wrapUnixPeerCredentialListener(cleanupListener, config.Logger, 0)
+	if err != nil {
+		_ = cleanupListener.Close()
+		return nil, err
+	}
+
+	return authenticatedListener, nil
+}
+
+func removeStaleUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return fmt.Errorf("refusing to replace non-socket path %q", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove stale unix socket %q: %w", path, err)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	return fmt.Errorf("inspect unix socket path %q: %w", path, err)
+}
+
+type unixSocketListener struct {
+	net.Listener
+	path string
+}
+
+func (l *unixSocketListener) Close() error {
+	closeErr := l.Listener.Close()
+	removeErr := os.Remove(l.path)
+	if os.IsNotExist(removeErr) {
+		removeErr = nil
+	}
+
+	return errors.Join(closeErr, removeErr)
+}

--- a/internal/server/listener_test.go
+++ b/internal/server/listener_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListenUnixSocketCreates0600Socket(t *testing.T) {
+	t.Parallel()
+
+	socketPath := testSocketPath(t)
+	listener, err := Listen(ListenerConfig{
+		Network:                "unix",
+		Address:                socketPath,
+		UnixSocketMode:         0o600,
+		RequirePeerCredentials: false,
+	})
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", socketPath, err)
+	}
+
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket permissions = %#o, want %#o", got, 0o600)
+	}
+}
+
+func TestListenUnixSocketRefusesToReplaceNonSocketPath(t *testing.T) {
+	t.Parallel()
+
+	socketPath := testSocketPath(t)
+	t.Cleanup(func() {
+		_ = os.Remove(socketPath)
+	})
+	if err := os.WriteFile(socketPath, []byte("not-a-socket"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", socketPath, err)
+	}
+
+	_, err := Listen(ListenerConfig{
+		Network:                "unix",
+		Address:                socketPath,
+		RequirePeerCredentials: false,
+	})
+	if err == nil {
+		t.Fatal("Listen() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to replace non-socket") {
+		t.Fatalf("Listen() error = %v, want non-socket refusal", err)
+	}
+}
+
+func TestValidatePeerCredentialsRejectsDifferentUID(t *testing.T) {
+	t.Parallel()
+
+	err := validatePeerCredentials(42, peerCredentials{UID: 7})
+	if err == nil {
+		t.Fatal("validatePeerCredentials() error = nil, want non-nil")
+	}
+}
+
+func testSocketPath(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("rein-%d-%d.sock", os.Getpid(), time.Now().UnixNano()),
+	)
+}

--- a/internal/server/peercred.go
+++ b/internal/server/peercred.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var ErrPeerCredentialUnavailable = errors.New("peer credentials unavailable")
+
+type peerCredentials struct {
+	UID uint32
+	GID uint32
+	PID int32
+}
+
+func validatePeerCredentials(expectedUID uint32, credentials peerCredentials) error {
+	if credentials.UID != expectedUID {
+		return fmt.Errorf("peer uid %d does not match expected uid %d", credentials.UID, expectedUID)
+	}
+
+	return nil
+}
+
+func currentEffectiveUID() (uint32, error) {
+	uid := os.Geteuid()
+	if uid < 0 {
+		return 0, fmt.Errorf("invalid effective uid %d", uid)
+	}
+
+	parsed, err := strconv.ParseUint(strconv.Itoa(uid), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse effective uid %d: %w", uid, err)
+	}
+
+	return uint32(parsed), nil
+}

--- a/internal/server/peercred_darwin.go
+++ b/internal/server/peercred_darwin.go
@@ -1,0 +1,103 @@
+//go:build darwin
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func wrapUnixPeerCredentialListener(listener net.Listener, logger *slog.Logger, expectedUID uint32) (net.Listener, error) {
+	if expectedUID == 0 {
+		currentUID, err := currentEffectiveUID()
+		if err != nil {
+			return nil, err
+		}
+		expectedUID = currentUID
+	}
+
+	return &peerCredentialListener{
+		Listener:    listener,
+		logger:      logger,
+		expectedUID: expectedUID,
+	}, nil
+}
+
+type peerCredentialListener struct {
+	net.Listener
+	logger      *slog.Logger
+	expectedUID uint32
+}
+
+func (l *peerCredentialListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		unixConn, ok := conn.(*net.UnixConn)
+		if !ok {
+			_ = conn.Close()
+			return nil, fmt.Errorf("peer credential authentication requires unix connections, got %T", conn)
+		}
+
+		credentials, err := readPeerCredentials(unixConn)
+		if err != nil {
+			l.logger.Warn("rejected unix peer connection", "error", err)
+			_ = conn.Close()
+			continue
+		}
+		if err := validatePeerCredentials(l.expectedUID, credentials); err != nil {
+			l.logger.Warn(
+				"rejected unix peer connection",
+				"error", err,
+				"peer_uid", credentials.UID,
+				"expected_uid", l.expectedUID,
+			)
+			_ = conn.Close()
+			continue
+		}
+
+		return conn, nil
+	}
+}
+
+func readPeerCredentials(conn *net.UnixConn) (peerCredentials, error) {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return peerCredentials{}, fmt.Errorf("get unix syscall conn: %w", err)
+	}
+
+	var (
+		uid        uint32
+		gid        uint32
+		controlErr error
+	)
+
+	if err := rawConn.Control(func(fd uintptr) {
+		credentials, credErr := unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+		if credErr != nil {
+			controlErr = fmt.Errorf("%w: %v", ErrPeerCredentialUnavailable, credErr)
+			return
+		}
+		uid = credentials.Uid
+		if credentials.Ngroups > 0 {
+			gid = credentials.Groups[0]
+		}
+	}); err != nil {
+		return peerCredentials{}, fmt.Errorf("run unix syscall control: %w", err)
+	}
+	if controlErr != nil {
+		return peerCredentials{}, fmt.Errorf("read LOCAL_PEERCRED: %w", controlErr)
+	}
+
+	return peerCredentials{
+		UID: uid,
+		GID: gid,
+		PID: 0,
+	}, nil
+}

--- a/internal/server/peercred_linux.go
+++ b/internal/server/peercred_linux.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func wrapUnixPeerCredentialListener(listener net.Listener, logger *slog.Logger, expectedUID uint32) (net.Listener, error) {
+	if expectedUID == 0 {
+		currentUID, err := currentEffectiveUID()
+		if err != nil {
+			return nil, err
+		}
+		expectedUID = currentUID
+	}
+
+	return &peerCredentialListener{
+		Listener:    listener,
+		logger:      logger,
+		expectedUID: expectedUID,
+	}, nil
+}
+
+type peerCredentialListener struct {
+	net.Listener
+	logger      *slog.Logger
+	expectedUID uint32
+}
+
+func (l *peerCredentialListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		unixConn, ok := conn.(*net.UnixConn)
+		if !ok {
+			_ = conn.Close()
+			return nil, fmt.Errorf("peer credential authentication requires unix connections, got %T", conn)
+		}
+
+		credentials, err := readPeerCredentials(unixConn)
+		if err != nil {
+			l.logger.Warn("rejected unix peer connection", "error", err)
+			_ = conn.Close()
+			continue
+		}
+		if err := validatePeerCredentials(l.expectedUID, credentials); err != nil {
+			l.logger.Warn(
+				"rejected unix peer connection",
+				"error", err,
+				"peer_uid", credentials.UID,
+				"expected_uid", l.expectedUID,
+			)
+			_ = conn.Close()
+			continue
+		}
+
+		return conn, nil
+	}
+}
+
+func readPeerCredentials(conn *net.UnixConn) (peerCredentials, error) {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return peerCredentials{}, fmt.Errorf("get unix syscall conn: %w", err)
+	}
+
+	var credentials *unix.Ucred
+	var controlErr error
+
+	if err := rawConn.Control(func(fd uintptr) {
+		credentials, controlErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return peerCredentials{}, fmt.Errorf("run unix syscall control: %w", err)
+	}
+	if controlErr != nil {
+		return peerCredentials{}, fmt.Errorf("read SO_PEERCRED: %w", controlErr)
+	}
+
+	return peerCredentials{
+		UID: credentials.Uid,
+		GID: credentials.Gid,
+		PID: credentials.Pid,
+	}, nil
+}

--- a/internal/server/peercred_other.go
+++ b/internal/server/peercred_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin
+
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net"
+)
+
+func wrapUnixPeerCredentialListener(_ net.Listener, _ *slog.Logger, _ uint32) (net.Listener, error) {
+	return nil, errors.New("peer credential authentication is only supported on linux and darwin")
+}

--- a/internal/server/runtime.go
+++ b/internal/server/runtime.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"google.golang.org/grpc"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/gateway"
+	"github.com/earchibald/rein/internal/service"
+)
+
+type Options struct {
+	Services    service.Set
+	Gateway     *gateway.V2Stub
+	GRPCOptions []grpc.ServerOption
+}
+
+type Runtime struct {
+	grpcServer *grpc.Server
+	gateway    *gateway.V2Stub
+}
+
+func New(options Options) *Runtime {
+	services := options.Services.WithDefaults()
+	grpcOptions := append([]grpc.ServerOption(nil), options.GRPCOptions...)
+
+	grpcServer := grpc.NewServer(grpcOptions...)
+	RegisterServices(grpcServer, services)
+
+	gatewayStub := options.Gateway
+	if gatewayStub == nil {
+		gatewayStub = gateway.NewV2Stub()
+	}
+
+	return &Runtime{
+		grpcServer: grpcServer,
+		gateway:    gatewayStub,
+	}
+}
+
+func RegisterServices(registrar grpc.ServiceRegistrar, services service.Set) {
+	services = services.WithDefaults()
+
+	reinv1.RegisterAdapterServiceServer(registrar, services.Adapter)
+	reinv1.RegisterExecutionServiceServer(registrar, services.Execution)
+	reinv1.RegisterIssueServiceServer(registrar, services.Issue)
+	reinv1.RegisterProjectServiceServer(registrar, services.Project)
+	reinv1.RegisterWorkflowServiceServer(registrar, services.Workflow)
+}
+
+func (r *Runtime) GRPC() *grpc.Server {
+	return r.grpcServer
+}
+
+func (r *Runtime) Gateway() *gateway.V2Stub {
+	return r.gateway
+}
+
+func (r *Runtime) Serve(ctx context.Context, listener net.Listener) error {
+	if listener == nil {
+		return errors.New("listener is required")
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			r.Stop()
+		case <-done:
+		}
+	}()
+
+	err := r.grpcServer.Serve(listener)
+	if err == nil || errors.Is(err, grpc.ErrServerStopped) || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+
+	return err
+}
+
+func (r *Runtime) Stop() {
+	r.grpcServer.GracefulStop()
+}

--- a/internal/server/runtime_test.go
+++ b/internal/server/runtime_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+func TestRuntimeRegistersAllServices(t *testing.T) {
+	t.Parallel()
+
+	runtime := New(Options{})
+
+	got := runtime.GRPC().GetServiceInfo()
+	want := []string{
+		"rein.v1.AdapterService",
+		"rein.v1.ExecutionService",
+		"rein.v1.IssueService",
+		"rein.v1.ProjectService",
+		"rein.v1.WorkflowService",
+	}
+
+	for _, serviceName := range want {
+		if _, ok := got[serviceName]; !ok {
+			t.Fatalf("registered services missing %q", serviceName)
+		}
+	}
+
+	if gateway := runtime.Gateway(); gateway == nil || len(gateway.Routes()) == 0 || len(gateway.Streams()) == 0 {
+		t.Fatal("gateway stub was not initialized")
+	}
+}
+
+func TestRuntimeServeBufconnReturnsUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	runtime := New(Options{})
+	listener := bufconn.Listen(1024 * 1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runtime.Serve(ctx, listener)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient() error = %v", err)
+	}
+	defer conn.Close()
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+	defer rpcCancel()
+
+	client := reinv1.NewProjectServiceClient(conn)
+	_, err = client.GetProject(rpcCtx, &reinv1.GetProjectRequest{Id: "project-1"})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("GetProject() status = %v, want %v", status.Code(err), codes.Unimplemented)
+	}
+
+	cancel()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+}

--- a/internal/server/unix_auth_test.go
+++ b/internal/server/unix_auth_test.go
@@ -1,0 +1,70 @@
+//go:build linux || darwin
+
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+func TestListenUnixSocketWithPeerCredentialsServesCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	socketPath := testSocketPath(t)
+	listener, err := Listen(ListenerConfig{
+		Network:                "unix",
+		Address:                socketPath,
+		UnixSocketMode:         0o600,
+		RequirePeerCredentials: true,
+	})
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	runtime := New(Options{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runtime.Serve(ctx, listener)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient() error = %v", err)
+	}
+	defer conn.Close()
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer rpcCancel()
+
+	_, err = reinv1.NewWorkflowServiceClient(conn).ListWorkflows(rpcCtx, &reinv1.ListWorkflowsRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("ListWorkflows() status = %v, want %v", status.Code(err), codes.Unimplemented)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+}

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -1,0 +1,63 @@
+package service
+
+import reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+
+// Set contains the in-process gRPC service implementations registered by the
+// server runtime.
+type Set struct {
+	Adapter   reinv1.AdapterServiceServer
+	Execution reinv1.ExecutionServiceServer
+	Issue     reinv1.IssueServiceServer
+	Project   reinv1.ProjectServiceServer
+	Workflow  reinv1.WorkflowServiceServer
+}
+
+func NewSet() Set {
+	return Set{
+		Adapter:   AdapterServer{},
+		Execution: ExecutionServer{},
+		Issue:     IssueServer{},
+		Project:   ProjectServer{},
+		Workflow:  WorkflowServer{},
+	}
+}
+
+func (s Set) WithDefaults() Set {
+	if s.Adapter == nil {
+		s.Adapter = AdapterServer{}
+	}
+	if s.Execution == nil {
+		s.Execution = ExecutionServer{}
+	}
+	if s.Issue == nil {
+		s.Issue = IssueServer{}
+	}
+	if s.Project == nil {
+		s.Project = ProjectServer{}
+	}
+	if s.Workflow == nil {
+		s.Workflow = WorkflowServer{}
+	}
+
+	return s
+}
+
+type AdapterServer struct {
+	reinv1.UnimplementedAdapterServiceServer
+}
+
+type ExecutionServer struct {
+	reinv1.UnimplementedExecutionServiceServer
+}
+
+type IssueServer struct {
+	reinv1.UnimplementedIssueServiceServer
+}
+
+type ProjectServer struct {
+	reinv1.UnimplementedProjectServiceServer
+}
+
+type WorkflowServer struct {
+	reinv1.UnimplementedWorkflowServiceServer
+}


### PR DESCRIPTION
## Summary
- add the first rein gRPC runtime and in-process service registration layer
- add TCP/unix listener scaffolding with 0600 sockets and same-user peer-credential auth
- wire `cmd/rein` to boot the daemon skeleton and add runtime/listener tests

## Testing
- just ci
- just vet
- just test-race