### PR TITLE
Add gotestsum-based test harness helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test -race ./...
+        run: just test-race
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@
 # Run `just` or `just --list` to see available recipes.
 
 buf := "go run github.com/bufbuild/buf/cmd/buf@v1.59.0"
+gotestsum := "go run gotest.tools/gotestsum@v1.10.0"
 
 default:
     @just --list
@@ -18,11 +19,16 @@ build:
 
 # Run tests
 test:
-    go test ./...
+    {{gotestsum}} --format pkgname -- ./...
 
 # Run tests with race detector
 test-race:
-    go test -race ./...
+    {{gotestsum}} --format pkgname -- -race ./...
+
+# Run tests with coverage output
+test-cover:
+    {{gotestsum}} --format pkgname -- -coverprofile=coverage.out -covermode=atomic ./...
+    go tool cover -func=coverage.out
 
 # Run golangci-lint
 lint:
@@ -45,10 +51,11 @@ tidy:
 clean:
     rm -rf bin/
 
-# Run build + lint + test (CI equivalent)
-ci: build lint test
+# Run build + vet + lint + race-tested suite (CI equivalent)
+ci: build vet lint test-race
 
 # Install development tools
 install-tools:
+    go install gotest.tools/gotestsum@v1.10.0
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     go install golang.org/x/tools/cmd/goimports@latest

--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 ## Development
 
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.
+- `just test` is the standard test entrypoint and runs the suite via `gotestsum`.
+- `just test-race` keeps the same runner while enabling the Go race detector.
+- `just test-cover` writes `coverage.out` and prints `go tool cover -func` output for local review.
+
+## Test harness
+
+- `internal/server` keeps a reusable bufconn-backed in-process gRPC harness alongside its runtime tests.
+- `internal/storage/sqlite` exposes migrated in-memory SQLite helpers so tests stay hermetic and fast.
+- Coverage thresholds are tracked per harness-heavy package: keep `internal/server` at or above 75% statement coverage and `internal/storage/sqlite` at or above 70%, and treat any drop in those packages as a regression to fix before merge.

--- a/internal/server/bufconn_harness_test.go
+++ b/internal/server/bufconn_harness_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const defaultBufconnListenerSize = 1024 * 1024
+
+type bufconnHarness struct {
+	conn     *grpc.ClientConn
+	cancel   context.CancelFunc
+	errCh    chan error
+	runtime  *Runtime
+	listener *bufconn.Listener
+	tb       testing.TB
+}
+
+func newBufconnHarness(tb testing.TB, options Options, dialOptions ...grpc.DialOption) *bufconnHarness {
+	tb.Helper()
+
+	runtime := New(options)
+	listener := bufconn.Listen(defaultBufconnListenerSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- runtime.Serve(ctx, listener)
+	}()
+
+	optionsForDial := []grpc.DialOption{
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	optionsForDial = append(optionsForDial, dialOptions...)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet", optionsForDial...)
+	if err != nil {
+		cancel()
+		runtime.Stop()
+		_ = listener.Close()
+		tb.Fatalf("grpc.NewClient() error = %v", err)
+	}
+
+	harness := &bufconnHarness{
+		conn:     conn,
+		cancel:   cancel,
+		errCh:    errCh,
+		runtime:  runtime,
+		listener: listener,
+		tb:       tb,
+	}
+	tb.Cleanup(harness.Close)
+
+	return harness
+}
+
+func (h *bufconnHarness) Close() {
+	if h.conn != nil {
+		_ = h.conn.Close()
+	}
+	if h.cancel != nil {
+		h.cancel()
+	}
+	if h.runtime != nil {
+		h.runtime.Stop()
+	}
+	if h.errCh != nil {
+		if err := <-h.errCh; err != nil && h.tb != nil {
+			h.tb.Errorf("Runtime.Serve() error = %v", err)
+		}
+		h.errCh = nil
+	}
+	if h.listener != nil {
+		_ = h.listener.Close()
+	}
+}

--- a/internal/server/listener_test.go
+++ b/internal/server/listener_test.go
@@ -69,6 +69,37 @@ func TestValidatePeerCredentialsRejectsDifferentUID(t *testing.T) {
 	}
 }
 
+func TestListenTCPAllocatesLoopbackPort(t *testing.T) {
+	t.Parallel()
+
+	listener, err := Listen(ListenerConfig{
+		Network: "tcp",
+		Address: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	if listener.Addr().String() == "" {
+		t.Fatal("Listen() returned empty tcp address")
+	}
+}
+
+func TestListenRejectsUnsupportedNetwork(t *testing.T) {
+	t.Parallel()
+
+	_, err := Listen(ListenerConfig{
+		Network: "udp",
+		Address: "127.0.0.1:0",
+	})
+	if err == nil {
+		t.Fatal("Listen() error = nil, want non-nil")
+	}
+}
+
 func testSocketPath(t *testing.T) string {
 	t.Helper()
 

--- a/internal/server/runtime_test.go
+++ b/internal/server/runtime_test.go
@@ -2,15 +2,11 @@ package server
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/test/bufconn"
 
 	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
 )
@@ -43,41 +39,22 @@ func TestRuntimeRegistersAllServices(t *testing.T) {
 func TestRuntimeServeBufconnReturnsUnimplemented(t *testing.T) {
 	t.Parallel()
 
-	runtime := New(Options{})
-	listener := bufconn.Listen(1024 * 1024)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- runtime.Serve(ctx, listener)
-	}()
-
-	conn, err := grpc.NewClient(
-		"passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return listener.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient() error = %v", err)
-	}
-	defer conn.Close()
+	harness := newBufconnHarness(t, Options{})
 
 	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
 	defer rpcCancel()
 
-	client := reinv1.NewProjectServiceClient(conn)
-	_, err = client.GetProject(rpcCtx, &reinv1.GetProjectRequest{Id: "project-1"})
+	client := reinv1.NewProjectServiceClient(harness.conn)
+	_, err := client.GetProject(rpcCtx, &reinv1.GetProjectRequest{Id: "project-1"})
 	if status.Code(err) != codes.Unimplemented {
 		t.Fatalf("GetProject() status = %v, want %v", status.Code(err), codes.Unimplemented)
 	}
+}
 
-	cancel()
+func TestRuntimeServeRejectsNilListener(t *testing.T) {
+	t.Parallel()
 
-	if err := <-errCh; err != nil {
-		t.Fatalf("Serve() error = %v", err)
+	if err := New(Options{}).Serve(context.Background(), nil); err == nil {
+		t.Fatal("Serve() error = nil, want non-nil")
 	}
 }

--- a/internal/storage/sqlite/migrate.go
+++ b/internal/storage/sqlite/migrate.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"embed"
 	"errors"
 	"fmt"
@@ -61,28 +62,44 @@ func runMigrations(ctx context.Context, cfg Config, apply func(*migrate.Migrate)
 		}
 	}()
 
-	sourceDriver, err := iofs.New(migrationsFS, "migrations")
+	migrator, err := newMigrator(normalized, db)
 	if err != nil {
-		return fmt.Errorf("sqlite: init migration source: %w", err)
-	}
-
-	dbDriver, err := migratesqlite.WithInstance(db, &migratesqlite.Config{
-		MigrationsTable: normalized.MigrationsTable,
-		DatabaseName:    normalized.Path,
-	})
-	if err != nil {
-		return fmt.Errorf("sqlite: init migration database driver: %w", err)
-	}
-
-	migrator, err := migrate.NewWithInstance("iofs", sourceDriver, driverName, dbDriver)
-	if err != nil {
-		return fmt.Errorf("sqlite: init migrator: %w", err)
+		return err
 	}
 	defer func() {
 		sourceErr, closeErr := migrator.Close()
 		err = errors.Join(err, sourceErr, closeErr)
 	}()
 
+	return applyMigrator(migrator, apply)
+}
+
+func newMigrator(cfg Config, db *sql.DB) (*migrate.Migrate, error) {
+	sourceDriver, err := iofs.New(migrationsFS, "migrations")
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: init migration source: %w", err)
+	}
+
+	dbDriver, err := migratesqlite.WithInstance(db, &migratesqlite.Config{
+		MigrationsTable: cfg.MigrationsTable,
+		DatabaseName:    cfg.Path,
+	})
+	if err != nil {
+		_ = sourceDriver.Close()
+		return nil, fmt.Errorf("sqlite: init migration database driver: %w", err)
+	}
+
+	migrator, err := migrate.NewWithInstance("iofs", sourceDriver, driverName, dbDriver)
+	if err != nil {
+		_ = sourceDriver.Close()
+		_ = dbDriver.Close()
+		return nil, fmt.Errorf("sqlite: init migrator: %w", err)
+	}
+
+	return migrator, nil
+}
+
+func applyMigrator(migrator *migrate.Migrate, apply func(*migrate.Migrate) error) error {
 	if err := apply(migrator); err != nil {
 		return fmt.Errorf("sqlite: apply migrations: %w", err)
 	}

--- a/internal/storage/sqlite/migrate_test.go
+++ b/internal/storage/sqlite/migrate_test.go
@@ -79,6 +79,28 @@ func TestMigrateDownStepsRejectsInvalidStepCount(t *testing.T) {
 	}
 }
 
+func TestMigrateDownStepsDropsSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := InMemoryConfig(t.Name())
+
+	store, err := OpenAndMigrate(ctx, cfg)
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+
+	if err := MigrateDownSteps(ctx, cfg, 1); err != nil {
+		t.Fatalf("MigrateDownSteps() error = %v", err)
+	}
+
+	assertTableExists(t, store.DB(), "projects", false)
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
 func assertTableExists(t *testing.T, db *sql.DB, table string, want bool) {
 	t.Helper()
 

--- a/internal/storage/sqlite/store.go
+++ b/internal/storage/sqlite/store.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
+	"github.com/golang-migrate/migrate/v4"
 	_ "modernc.org/sqlite"
 )
 
@@ -90,11 +93,64 @@ func Open(ctx context.Context, cfg Config) (*Store, error) {
 }
 
 func OpenAndMigrate(ctx context.Context, cfg Config) (*Store, error) {
-	if err := MigrateUp(ctx, cfg); err != nil {
+	normalized, err := cfg.normalize()
+	if err != nil {
 		return nil, err
 	}
 
-	return Open(ctx, cfg)
+	migrationDB, err := openDB(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	migrator, err := newMigrator(normalized, migrationDB)
+	if err != nil {
+		_ = migrationDB.Close()
+		return nil, err
+	}
+
+	if err := applyMigrator(migrator, func(m *migrate.Migrate) error {
+		if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			return err
+		}
+		return nil
+	}); err != nil {
+		sourceErr, closeErr := migrator.Close()
+		err = errors.Join(err, sourceErr, closeErr)
+		return nil, err
+	}
+
+	db, err := openDB(ctx, normalized)
+	if err != nil {
+		sourceErr, closeErr := migrator.Close()
+		err = errors.Join(err, sourceErr, closeErr)
+		return nil, err
+	}
+
+	sourceErr, closeErr := migrator.Close()
+	if sourceErr != nil || closeErr != nil {
+		_ = db.Close()
+		return nil, errors.Join(sourceErr, closeErr)
+	}
+
+	return &Store{
+		db:     db,
+		config: normalized,
+	}, nil
+}
+
+func InMemoryConfig(name string) Config {
+	if name == "" {
+		name = "rein"
+	}
+
+	return Config{
+		Path: fmt.Sprintf("file:%s?mode=memory&cache=shared", url.PathEscape(name)),
+	}
+}
+
+func OpenInMemoryAndMigrate(ctx context.Context, name string) (*Store, error) {
+	return OpenAndMigrate(ctx, InMemoryConfig(name))
 }
 
 func (s *Store) Close() error {
@@ -301,7 +357,7 @@ func openDB(ctx context.Context, cfg Config) (*sql.DB, error) {
 		return nil, fmt.Errorf("sqlite: ping %q: %w", cfg.Path, err)
 	}
 
-	if err := applyPragmas(ctx, db, cfg.BusyTimeout); err != nil {
+	if err := applyPragmas(ctx, db, cfg); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -309,11 +365,16 @@ func openDB(ctx context.Context, cfg Config) (*sql.DB, error) {
 	return db, nil
 }
 
-func applyPragmas(ctx context.Context, db *sql.DB, busyTimeout time.Duration) error {
+func applyPragmas(ctx context.Context, db *sql.DB, cfg Config) error {
+	journalMode := "WAL"
+	if isInMemoryPath(cfg.Path) {
+		journalMode = "MEMORY"
+	}
+
 	statements := []string{
 		"PRAGMA foreign_keys = ON",
-		fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeout.Milliseconds()),
-		"PRAGMA journal_mode = WAL",
+		fmt.Sprintf("PRAGMA busy_timeout = %d", cfg.BusyTimeout.Milliseconds()),
+		fmt.Sprintf("PRAGMA journal_mode = %s", journalMode),
 		"PRAGMA synchronous = NORMAL",
 	}
 
@@ -324,6 +385,10 @@ func applyPragmas(ctx context.Context, db *sql.DB, busyTimeout time.Duration) er
 	}
 
 	return nil
+}
+
+func isInMemoryPath(path string) bool {
+	return path == ":memory:" || strings.Contains(path, "mode=memory")
 }
 
 func (c Config) normalize() (Config, error) {

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -12,17 +12,7 @@ func TestStoreCreateGetUpdateDelete(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	store, err := OpenAndMigrate(ctx, Config{
-		Path: filepath.Join(t.TempDir(), "rein.db"),
-	})
-	if err != nil {
-		t.Fatalf("OpenAndMigrate() error = %v", err)
-	}
-	defer func() {
-		if closeErr := store.Close(); closeErr != nil {
-			t.Fatalf("Close() error = %v", closeErr)
-		}
-	}()
+	store := openTestStore(t, ctx)
 
 	created, err := store.Create(ctx, ProjectKind, "project-1", json.RawMessage(`{"name":"rein"}`))
 	if err != nil {
@@ -78,11 +68,19 @@ func TestStoreRejectsInvalidPayload(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	store, err := OpenAndMigrate(ctx, Config{
-		Path: filepath.Join(t.TempDir(), "rein.db"),
-	})
+	store := openTestStore(t, ctx)
+
+	if _, err := store.Create(ctx, WorkflowKind, "workflow-1", json.RawMessage(`{`)); !errors.Is(err, ErrInvalidPayload) {
+		t.Fatalf("Create() invalid payload error = %v, want %v", err, ErrInvalidPayload)
+	}
+}
+
+func TestOpenInMemoryAndMigrate(t *testing.T) {
+	t.Parallel()
+
+	store, err := OpenInMemoryAndMigrate(context.Background(), t.Name())
 	if err != nil {
-		t.Fatalf("OpenAndMigrate() error = %v", err)
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
 	}
 	defer func() {
 		if closeErr := store.Close(); closeErr != nil {
@@ -90,8 +88,43 @@ func TestStoreRejectsInvalidPayload(t *testing.T) {
 		}
 	}()
 
-	if _, err := store.Create(ctx, WorkflowKind, "workflow-1", json.RawMessage(`{`)); !errors.Is(err, ErrInvalidPayload) {
-		t.Fatalf("Create() invalid payload error = %v, want %v", err, ErrInvalidPayload)
+	assertTableExists(t, store.DB(), "projects", true)
+}
+
+func TestInMemoryConfigUsesSharedCacheURI(t *testing.T) {
+	t.Parallel()
+
+	cfg := InMemoryConfig("rein test")
+	if !strings.Contains(cfg.Path, "mode=memory") || !strings.Contains(cfg.Path, "cache=shared") {
+		t.Fatalf("InMemoryConfig() path = %q", cfg.Path)
+	}
+	if !isInMemoryPath(cfg.Path) {
+		t.Fatalf("isInMemoryPath(%q) = false, want true", cfg.Path)
+	}
+}
+
+func TestOpenRejectsMissingPath(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Open(context.Background(), Config{}); !errors.Is(err, ErrMissingPath) {
+		t.Fatalf("Open() error = %v, want %v", err, ErrMissingPath)
+	}
+}
+
+func TestTableForUnknownKind(t *testing.T) {
+	t.Parallel()
+
+	if _, err := tableFor(EntityKind("nope")); !errors.Is(err, ErrUnknownKind) {
+		t.Fatalf("tableFor() error = %v, want %v", err, ErrUnknownKind)
+	}
+}
+
+func TestStoreGetRejectsEmptyID(t *testing.T) {
+	t.Parallel()
+
+	_, err := openTestStore(t, context.Background()).Get(context.Background(), ProjectKind, "")
+	if !errors.Is(err, ErrEmptyID) {
+		t.Fatalf("Get() error = %v, want %v", err, ErrEmptyID)
 	}
 }
 

--- a/internal/storage/sqlite/test_harness_test.go
+++ b/internal/storage/sqlite/test_harness_test.go
@@ -1,0 +1,27 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+var nextStoreID uint64
+
+func openTestStore(tb testing.TB, ctx context.Context) *Store {
+	tb.Helper()
+
+	store, err := OpenAndMigrate(ctx, InMemoryConfig(fmt.Sprintf("%s-%d", tb.Name(), atomic.AddUint64(&nextStoreID, 1))))
+	if err != nil {
+		tb.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+
+	tb.Cleanup(func() {
+		if closeErr := store.Close(); closeErr != nil {
+			tb.Errorf("Close() error = %v", closeErr)
+		}
+	})
+
+	return store
+}


### PR DESCRIPTION
## Summary
- standardize `just test`/`just test-race` on gotestsum and route CI through the Justfile
- add reusable bufconn-backed gRPC runtime test helpers and broader listener/runtime coverage
- support migrated shared-cache in-memory SQLite stores for tests and document coverage thresholds

Closes #7

## Validation
- just test
- go build ./...
- go vet ./...
- golangci-lint run ./...
- just test-race
- just test-cover