### PR TITLE
RN-8: Add gRPC contract tests and conformance harness

### DIFF
--- a/adaptertest/adaptertest.go
+++ b/adaptertest/adaptertest.go
@@ -1,0 +1,143 @@
+// Package adaptertest provides reusable conformance checks for adapter plugins.
+package adaptertest
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+// Spec describes a single adapter implementation to validate.
+//
+// Contract should be provided as either:
+//   - a typed nil pointer to the required interface, e.g. (*MyContract)(nil), or
+//   - a reflect.Type whose Kind is Interface.
+type Spec struct {
+	Category             reinv1.AdapterCategory
+	Descriptor           *reinv1.Adapter
+	Implementation       any
+	Contract             any
+	RequiredCapabilities []string
+	Validate             func(testing.TB, *reinv1.Adapter, any)
+}
+
+func Run(t testing.TB, spec Spec) {
+	t.Helper()
+
+	if err := validate(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	if spec.Validate != nil {
+		spec.Validate(t, spec.Descriptor, spec.Implementation)
+	}
+}
+
+func RunCodingAgent(t testing.TB, spec Spec) {
+	t.Helper()
+	spec.Category = reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT
+	Run(t, spec)
+}
+
+func RunReviewAgent(t testing.TB, spec Spec) {
+	t.Helper()
+	spec.Category = reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT
+	Run(t, spec)
+}
+
+func RunTracker(t testing.TB, spec Spec) {
+	t.Helper()
+	spec.Category = reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER
+	Run(t, spec)
+}
+
+func RunNotification(t testing.TB, spec Spec) {
+	t.Helper()
+	spec.Category = reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION
+	Run(t, spec)
+}
+
+func RunMultiplexer(t testing.TB, spec Spec) {
+	t.Helper()
+	spec.Category = reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER
+	Run(t, spec)
+}
+
+func validate(spec Spec) error {
+	if spec.Category == reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED {
+		return fmt.Errorf("category is required")
+	}
+	if spec.Descriptor == nil {
+		return fmt.Errorf("descriptor is required")
+	}
+	if strings.TrimSpace(spec.Descriptor.GetId()) == "" {
+		return fmt.Errorf("descriptor.id is required")
+	}
+	if strings.TrimSpace(spec.Descriptor.GetName()) == "" {
+		return fmt.Errorf("descriptor.name is required")
+	}
+	if strings.TrimSpace(spec.Descriptor.GetVersion()) == "" {
+		return fmt.Errorf("descriptor.version is required")
+	}
+	if spec.Descriptor.GetCategory() != spec.Category {
+		return fmt.Errorf("descriptor category = %s, want %s", spec.Descriptor.GetCategory(), spec.Category)
+	}
+	if spec.Implementation == nil {
+		return fmt.Errorf("implementation is required")
+	}
+
+	contractType, err := normalizeContractType(spec.Contract)
+	if err != nil {
+		return err
+	}
+
+	implementationType := reflect.TypeOf(spec.Implementation)
+	if !implementationType.Implements(contractType) {
+		if implementationType.Kind() != reflect.Pointer && reflect.PointerTo(implementationType).Implements(contractType) {
+			return fmt.Errorf("implementation %T does not implement %s; pass a pointer value instead", spec.Implementation, contractType)
+		}
+		return fmt.Errorf("implementation %T does not implement %s", spec.Implementation, contractType)
+	}
+
+	if missing := missingCapabilities(spec.Descriptor.GetCapabilities(), spec.RequiredCapabilities); len(missing) > 0 {
+		return fmt.Errorf("descriptor.capabilities missing %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func normalizeContractType(contract any) (reflect.Type, error) {
+	if contract == nil {
+		return nil, fmt.Errorf("contract is required")
+	}
+
+	if contractType, ok := contract.(reflect.Type); ok {
+		if contractType.Kind() != reflect.Interface {
+			return nil, fmt.Errorf("contract type must be an interface, got %s", contractType)
+		}
+		return contractType, nil
+	}
+
+	contractType := reflect.TypeOf(contract)
+	if contractType.Kind() == reflect.Pointer && contractType.Elem().Kind() == reflect.Interface {
+		return contractType.Elem(), nil
+	}
+
+	return nil, fmt.Errorf("contract must be a typed nil pointer to an interface or a reflect.Type, got %T", contract)
+}
+
+func missingCapabilities(capabilities map[string]string, required []string) []string {
+	missing := make([]string, 0, len(required))
+	for _, capability := range required {
+		if _, ok := capabilities[capability]; !ok {
+			missing = append(missing, capability)
+		}
+	}
+
+	slices.Sort(missing)
+	return slices.Compact(missing)
+}

--- a/adaptertest/adaptertest_test.go
+++ b/adaptertest/adaptertest_test.go
@@ -1,0 +1,179 @@
+package adaptertest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+type codingAgentContract interface {
+	Run(context.Context, string) error
+}
+
+type reviewAgentContract interface {
+	Review(context.Context, string) error
+}
+
+type codingAgent struct{}
+
+func (*codingAgent) Run(context.Context, string) error {
+	return nil
+}
+
+type reviewAgent struct{}
+
+func (*reviewAgent) Review(context.Context, string) error {
+	return nil
+}
+
+func TestRunCodingAgent(t *testing.T) {
+	t.Parallel()
+
+	validated := false
+	RunCodingAgent(t, Spec{
+		Descriptor: &reinv1.Adapter{
+			Id:       "copilot",
+			Name:     "Copilot",
+			Version:  "1.0.0",
+			Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+			Capabilities: map[string]string{
+				"apply_patch": "true",
+			},
+		},
+		Implementation:       &codingAgent{},
+		Contract:             (*codingAgentContract)(nil),
+		RequiredCapabilities: []string{"apply_patch"},
+		Validate: func(tb testing.TB, descriptor *reinv1.Adapter, implementation any) {
+			tb.Helper()
+			validated = true
+			if descriptor.GetId() != "copilot" {
+				tb.Fatalf("descriptor id = %q, want %q", descriptor.GetId(), "copilot")
+			}
+			if _, ok := implementation.(*codingAgent); !ok {
+				tb.Fatalf("implementation type = %T, want *codingAgent", implementation)
+			}
+		},
+	})
+
+	if !validated {
+		t.Fatal("Validate callback was not invoked")
+	}
+}
+
+func TestValidateAcceptsReflectTypeContracts(t *testing.T) {
+	t.Parallel()
+
+	err := validate(Spec{
+		Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT,
+		Descriptor: &reinv1.Adapter{
+			Id:       "review-bot",
+			Name:     "Review Bot",
+			Version:  "1.0.0",
+			Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT,
+		},
+		Implementation: &reviewAgent{},
+		Contract:       reflect.TypeOf((*reviewAgentContract)(nil)).Elem(),
+	})
+	if err != nil {
+		t.Fatalf("validate() error = %v", err)
+	}
+}
+
+func TestValidateErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec Spec
+		want string
+	}{
+		{
+			name: "category mismatch",
+			spec: Spec{
+				Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Descriptor: &reinv1.Adapter{
+					Id:       "tracker",
+					Name:     "Tracker",
+					Version:  "1.0.0",
+					Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER,
+				},
+				Implementation: &codingAgent{},
+				Contract:       (*codingAgentContract)(nil),
+			},
+			want: "descriptor category = ADAPTER_CATEGORY_TRACKER, want ADAPTER_CATEGORY_CODING_AGENT",
+		},
+		{
+			name: "missing capability",
+			spec: Spec{
+				Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Descriptor: &reinv1.Adapter{
+					Id:       "copilot",
+					Name:     "Copilot",
+					Version:  "1.0.0",
+					Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				},
+				Implementation:       &codingAgent{},
+				Contract:             (*codingAgentContract)(nil),
+				RequiredCapabilities: []string{"apply_patch"},
+			},
+			want: "descriptor.capabilities missing apply_patch",
+		},
+		{
+			name: "implementation mismatch",
+			spec: Spec{
+				Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Descriptor: &reinv1.Adapter{
+					Id:       "copilot",
+					Name:     "Copilot",
+					Version:  "1.0.0",
+					Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				},
+				Implementation: &reviewAgent{},
+				Contract:       (*codingAgentContract)(nil),
+			},
+			want: "implementation *adaptertest.reviewAgent does not implement adaptertest.codingAgentContract",
+		},
+		{
+			name: "invalid contract",
+			spec: Spec{
+				Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Descriptor: &reinv1.Adapter{
+					Id:       "copilot",
+					Name:     "Copilot",
+					Version:  "1.0.0",
+					Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				},
+				Implementation: &codingAgent{},
+				Contract:       codingAgent{},
+			},
+			want: "contract must be a typed nil pointer to an interface or a reflect.Type, got adaptertest.codingAgent",
+		},
+		{
+			name: "missing descriptor metadata",
+			spec: Spec{
+				Category:       reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Descriptor:     &reinv1.Adapter{Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT},
+				Implementation: &codingAgent{},
+				Contract:       (*codingAgentContract)(nil),
+			},
+			want: "descriptor.id is required",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validate(tt.spec)
+			if err == nil {
+				t.Fatal("validate() error = nil, want non-nil")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("validate() error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/grpc_contract_test.go
+++ b/internal/server/grpc_contract_test.go
@@ -1,0 +1,345 @@
+package server
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+type grpcContract struct {
+	service    string
+	method     string
+	fullMethod string
+	input      protoreflect.FullName
+	output     protoreflect.FullName
+	newRequest func() proto.Message
+}
+
+func TestRuntimeGRPCServiceContracts(t *testing.T) {
+	t.Parallel()
+
+	runtime := New(Options{})
+	serviceInfo := runtime.GRPC().GetServiceInfo()
+
+	wantByService := map[string][]string{}
+	for _, contract := range allGRPCContracts() {
+		wantByService[contract.service] = append(wantByService[contract.service], contract.method)
+
+		methodDescriptor := findMethodDescriptor(t, contract.fullMethod)
+		if got := string(methodDescriptor.Input().FullName()); got != string(contract.input) {
+			t.Fatalf("%s input = %s, want %s", contract.fullMethod, methodDescriptor.Input().FullName(), contract.input)
+		}
+		if got := string(methodDescriptor.Output().FullName()); got != string(contract.output) {
+			t.Fatalf("%s output = %s, want %s", contract.fullMethod, methodDescriptor.Output().FullName(), contract.output)
+		}
+		if methodDescriptor.IsStreamingClient() || methodDescriptor.IsStreamingServer() {
+			t.Fatalf("%s unexpectedly declared as streaming", contract.fullMethod)
+		}
+	}
+
+	if len(serviceInfo) != len(wantByService) {
+		t.Fatalf("registered service count = %d, want %d", len(serviceInfo), len(wantByService))
+	}
+
+	for serviceName, wantMethods := range wantByService {
+		info, ok := serviceInfo[serviceName]
+		if !ok {
+			t.Fatalf("registered services missing %q", serviceName)
+		}
+
+		gotMethods := make([]string, 0, len(info.Methods))
+		for _, method := range info.Methods {
+			if method.IsClientStream || method.IsServerStream {
+				t.Fatalf("%s/%s unexpectedly registered as streaming", serviceName, method.Name)
+			}
+			gotMethods = append(gotMethods, method.Name)
+		}
+
+		slices.Sort(gotMethods)
+		slices.Sort(wantMethods)
+		if !slices.Equal(gotMethods, wantMethods) {
+			t.Fatalf("%s methods = %v, want %v", serviceName, gotMethods, wantMethods)
+		}
+	}
+}
+
+func TestRuntimeUnaryRPCErrorContracts(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		observed = map[string]reflect.Type{}
+	)
+
+	runtime := New(Options{
+		GRPCOptions: []grpc.ServerOption{
+			grpc.UnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+				mu.Lock()
+				observed[info.FullMethod] = reflect.TypeOf(req)
+				mu.Unlock()
+				return handler(ctx, req)
+			}),
+		},
+	})
+
+	listener := bufconn.Listen(1024 * 1024)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runtime.Serve(ctx, listener)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient() error = %v", err)
+	}
+	defer conn.Close()
+
+	for _, contract := range allGRPCContracts() {
+		contract := contract
+		t.Run(strings.TrimPrefix(strings.ReplaceAll(contract.fullMethod, "/", "_"), "_"), func(t *testing.T) {
+			rpcCtx, rpcCancel := context.WithTimeout(context.Background(), time.Second)
+			defer rpcCancel()
+
+			reply := emptyReply(t, contract.output)
+			err := conn.Invoke(rpcCtx, contract.fullMethod, contract.newRequest(), reply)
+			if err == nil {
+				t.Fatal("Invoke() error = nil, want non-nil")
+			}
+
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("status.FromError(%v) = !ok", err)
+			}
+			if st.Code() != codes.Unimplemented {
+				t.Fatalf("%s code = %v, want %v", contract.fullMethod, st.Code(), codes.Unimplemented)
+			}
+			wantMessage := "method " + contract.method + " not implemented"
+			if st.Message() != wantMessage {
+				t.Fatalf("%s message = %q, want %q", contract.fullMethod, st.Message(), wantMessage)
+			}
+
+			mu.Lock()
+			gotRequestType := observed[contract.fullMethod]
+			mu.Unlock()
+			if gotRequestType != reflect.TypeOf(contract.newRequest()) {
+				t.Fatalf("%s request type = %v, want %v", contract.fullMethod, gotRequestType, reflect.TypeOf(contract.newRequest()))
+			}
+		})
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+}
+
+func findMethodDescriptor(t testing.TB, fullMethod string) protoreflect.MethodDescriptor {
+	t.Helper()
+
+	parts := strings.Split(strings.TrimPrefix(fullMethod, "/"), "/")
+	if len(parts) != 2 {
+		t.Fatalf("full method %q must be /service/method", fullMethod)
+	}
+
+	serviceDescriptor, err := protoregistry.GlobalFiles.FindDescriptorByName(protoreflect.FullName(parts[0]))
+	if err != nil {
+		t.Fatalf("FindDescriptorByName(%q) error = %v", parts[0], err)
+	}
+
+	service, ok := serviceDescriptor.(protoreflect.ServiceDescriptor)
+	if !ok {
+		t.Fatalf("descriptor %q is %T, want service descriptor", parts[0], serviceDescriptor)
+	}
+
+	method := service.Methods().ByName(protoreflect.Name(parts[1]))
+	if method == nil {
+		t.Fatalf("service %q missing method %q", parts[0], parts[1])
+	}
+
+	return method
+}
+
+func emptyReply(t testing.TB, fullName protoreflect.FullName) proto.Message {
+	t.Helper()
+
+	descriptor, err := protoregistry.GlobalTypes.FindMessageByName(fullName)
+	if err != nil {
+		t.Fatalf("FindMessageByName(%q) error = %v", fullName, err)
+	}
+
+	return descriptor.New().Interface()
+}
+
+func allGRPCContracts() []grpcContract {
+	return []grpcContract{
+		{
+			service:    "rein.v1.AdapterService",
+			method:     "ListAdapters",
+			fullMethod: reinv1.AdapterService_ListAdapters_FullMethodName,
+			input:      "rein.v1.ListAdaptersRequest",
+			output:     "rein.v1.ListAdaptersResponse",
+			newRequest: func() proto.Message { return &reinv1.ListAdaptersRequest{} },
+		},
+		{
+			service:    "rein.v1.AdapterService",
+			method:     "GetAdapter",
+			fullMethod: reinv1.AdapterService_GetAdapter_FullMethodName,
+			input:      "rein.v1.GetAdapterRequest",
+			output:     "rein.v1.GetAdapterResponse",
+			newRequest: func() proto.Message { return &reinv1.GetAdapterRequest{} },
+		},
+		{
+			service:    "rein.v1.AdapterService",
+			method:     "ValidateAdapter",
+			fullMethod: reinv1.AdapterService_ValidateAdapter_FullMethodName,
+			input:      "rein.v1.ValidateAdapterRequest",
+			output:     "rein.v1.ValidateAdapterResponse",
+			newRequest: func() proto.Message { return &reinv1.ValidateAdapterRequest{} },
+		},
+		{
+			service:    "rein.v1.ExecutionService",
+			method:     "ListExecutions",
+			fullMethod: reinv1.ExecutionService_ListExecutions_FullMethodName,
+			input:      "rein.v1.ListExecutionsRequest",
+			output:     "rein.v1.ListExecutionsResponse",
+			newRequest: func() proto.Message { return &reinv1.ListExecutionsRequest{} },
+		},
+		{
+			service:    "rein.v1.ExecutionService",
+			method:     "GetExecution",
+			fullMethod: reinv1.ExecutionService_GetExecution_FullMethodName,
+			input:      "rein.v1.GetExecutionRequest",
+			output:     "rein.v1.GetExecutionResponse",
+			newRequest: func() proto.Message { return &reinv1.GetExecutionRequest{} },
+		},
+		{
+			service:    "rein.v1.ExecutionService",
+			method:     "StartExecution",
+			fullMethod: reinv1.ExecutionService_StartExecution_FullMethodName,
+			input:      "rein.v1.StartExecutionRequest",
+			output:     "rein.v1.StartExecutionResponse",
+			newRequest: func() proto.Message { return &reinv1.StartExecutionRequest{} },
+		},
+		{
+			service:    "rein.v1.ExecutionService",
+			method:     "CancelExecution",
+			fullMethod: reinv1.ExecutionService_CancelExecution_FullMethodName,
+			input:      "rein.v1.CancelExecutionRequest",
+			output:     "rein.v1.CancelExecutionResponse",
+			newRequest: func() proto.Message { return &reinv1.CancelExecutionRequest{} },
+		},
+		{
+			service:    "rein.v1.IssueService",
+			method:     "ListIssues",
+			fullMethod: reinv1.IssueService_ListIssues_FullMethodName,
+			input:      "rein.v1.ListIssuesRequest",
+			output:     "rein.v1.ListIssuesResponse",
+			newRequest: func() proto.Message { return &reinv1.ListIssuesRequest{} },
+		},
+		{
+			service:    "rein.v1.IssueService",
+			method:     "GetIssue",
+			fullMethod: reinv1.IssueService_GetIssue_FullMethodName,
+			input:      "rein.v1.GetIssueRequest",
+			output:     "rein.v1.GetIssueResponse",
+			newRequest: func() proto.Message { return &reinv1.GetIssueRequest{} },
+		},
+		{
+			service:    "rein.v1.IssueService",
+			method:     "CreateIssue",
+			fullMethod: reinv1.IssueService_CreateIssue_FullMethodName,
+			input:      "rein.v1.CreateIssueRequest",
+			output:     "rein.v1.CreateIssueResponse",
+			newRequest: func() proto.Message { return &reinv1.CreateIssueRequest{} },
+		},
+		{
+			service:    "rein.v1.IssueService",
+			method:     "UpdateIssue",
+			fullMethod: reinv1.IssueService_UpdateIssue_FullMethodName,
+			input:      "rein.v1.UpdateIssueRequest",
+			output:     "rein.v1.UpdateIssueResponse",
+			newRequest: func() proto.Message { return &reinv1.UpdateIssueRequest{} },
+		},
+		{
+			service:    "rein.v1.ProjectService",
+			method:     "ListProjects",
+			fullMethod: reinv1.ProjectService_ListProjects_FullMethodName,
+			input:      "rein.v1.ListProjectsRequest",
+			output:     "rein.v1.ListProjectsResponse",
+			newRequest: func() proto.Message { return &reinv1.ListProjectsRequest{} },
+		},
+		{
+			service:    "rein.v1.ProjectService",
+			method:     "GetProject",
+			fullMethod: reinv1.ProjectService_GetProject_FullMethodName,
+			input:      "rein.v1.GetProjectRequest",
+			output:     "rein.v1.GetProjectResponse",
+			newRequest: func() proto.Message { return &reinv1.GetProjectRequest{} },
+		},
+		{
+			service:    "rein.v1.ProjectService",
+			method:     "CreateProject",
+			fullMethod: reinv1.ProjectService_CreateProject_FullMethodName,
+			input:      "rein.v1.CreateProjectRequest",
+			output:     "rein.v1.CreateProjectResponse",
+			newRequest: func() proto.Message { return &reinv1.CreateProjectRequest{} },
+		},
+		{
+			service:    "rein.v1.ProjectService",
+			method:     "UpdateProject",
+			fullMethod: reinv1.ProjectService_UpdateProject_FullMethodName,
+			input:      "rein.v1.UpdateProjectRequest",
+			output:     "rein.v1.UpdateProjectResponse",
+			newRequest: func() proto.Message { return &reinv1.UpdateProjectRequest{} },
+		},
+		{
+			service:    "rein.v1.WorkflowService",
+			method:     "ListWorkflows",
+			fullMethod: reinv1.WorkflowService_ListWorkflows_FullMethodName,
+			input:      "rein.v1.ListWorkflowsRequest",
+			output:     "rein.v1.ListWorkflowsResponse",
+			newRequest: func() proto.Message { return &reinv1.ListWorkflowsRequest{} },
+		},
+		{
+			service:    "rein.v1.WorkflowService",
+			method:     "GetWorkflow",
+			fullMethod: reinv1.WorkflowService_GetWorkflow_FullMethodName,
+			input:      "rein.v1.GetWorkflowRequest",
+			output:     "rein.v1.GetWorkflowResponse",
+			newRequest: func() proto.Message { return &reinv1.GetWorkflowRequest{} },
+		},
+		{
+			service:    "rein.v1.WorkflowService",
+			method:     "ValidateWorkflow",
+			fullMethod: reinv1.WorkflowService_ValidateWorkflow_FullMethodName,
+			input:      "rein.v1.ValidateWorkflowRequest",
+			output:     "rein.v1.ValidateWorkflowResponse",
+			newRequest: func() proto.Message { return &reinv1.ValidateWorkflowRequest{} },
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add per-RPC gRPC contract tests that lock the current proto/service wire surface and unimplemented error semantics
- add a reusable adaptertest package for adapter descriptor/category/interface conformance checks against the current taxonomy
- run the local CI-equivalent validation suite (proto, build, vet, race tests, golangci-lint)

Closes #8