### PR TITLE
RN-13: Add cost telemetry and budget enforcement

### DIFF
--- a/internal/cost/model.go
+++ b/internal/cost/model.go
@@ -1,0 +1,297 @@
+package cost
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Scope string
+
+const (
+	ScopeProject   Scope = "project"
+	ScopeIssue     Scope = "issue"
+	ScopeExecution Scope = "execution"
+)
+
+type Limits struct {
+	SoftLimitMicros int64
+	HardLimitMicros int64
+}
+
+func (l Limits) Validate() error {
+	if l.SoftLimitMicros < 0 {
+		return fmt.Errorf("cost: soft limit must be >= 0")
+	}
+	if l.HardLimitMicros < 0 {
+		return fmt.Errorf("cost: hard limit must be >= 0")
+	}
+	if l.HardLimitMicros > 0 && l.SoftLimitMicros > 0 && l.SoftLimitMicros > l.HardLimitMicros {
+		return fmt.Errorf("cost: soft limit %d exceeds hard limit %d", l.SoftLimitMicros, l.HardLimitMicros)
+	}
+	return nil
+}
+
+type Usage struct {
+	InputTokens      int64 `json:"input_tokens"`
+	OutputTokens     int64 `json:"output_tokens"`
+	CacheReadTokens  int64 `json:"cache_read_tokens"`
+	CacheWriteTokens int64 `json:"cache_write_tokens"`
+}
+
+func (u Usage) Validate() error {
+	if u.InputTokens < 0 || u.OutputTokens < 0 || u.CacheReadTokens < 0 || u.CacheWriteTokens < 0 {
+		return fmt.Errorf("cost: token counts must be >= 0")
+	}
+	return nil
+}
+
+func (u Usage) Add(other Usage) Usage {
+	return Usage{
+		InputTokens:      u.InputTokens + other.InputTokens,
+		OutputTokens:     u.OutputTokens + other.OutputTokens,
+		CacheReadTokens:  u.CacheReadTokens + other.CacheReadTokens,
+		CacheWriteTokens: u.CacheWriteTokens + other.CacheWriteTokens,
+	}
+}
+
+func (u Usage) TotalTokens() int64 {
+	return u.InputTokens + u.OutputTokens + u.CacheReadTokens + u.CacheWriteTokens
+}
+
+type ScopeRef struct {
+	Scope Scope
+	ID    string
+}
+
+type ScopePath struct {
+	ProjectID   string
+	IssueID     string
+	ExecutionID string
+}
+
+func (p ScopePath) Refs() []ScopeRef {
+	refs := make([]ScopeRef, 0, 3)
+	if id := strings.TrimSpace(p.ProjectID); id != "" {
+		refs = append(refs, ScopeRef{Scope: ScopeProject, ID: id})
+	}
+	if id := strings.TrimSpace(p.IssueID); id != "" {
+		refs = append(refs, ScopeRef{Scope: ScopeIssue, ID: id})
+	}
+	if id := strings.TrimSpace(p.ExecutionID); id != "" {
+		refs = append(refs, ScopeRef{Scope: ScopeExecution, ID: id})
+	}
+	return refs
+}
+
+type Event struct {
+	ID                 string            `json:"id"`
+	Sequence           int64             `json:"sequence,omitempty"`
+	Name               string            `json:"name"`
+	Time               time.Time         `json:"time"`
+	ProjectID          string            `json:"project_id"`
+	IssueID            string            `json:"issue_id,omitempty"`
+	ExecutionID        string            `json:"execution_id,omitempty"`
+	WorkflowID         string            `json:"workflow_id,omitempty"`
+	AdapterID          string            `json:"adapter_id,omitempty"`
+	Currency           string            `json:"currency"`
+	CostMicros         int64             `json:"cost_micros"`
+	Usage              Usage             `json:"usage"`
+	ResourceAttributes map[string]string `json:"resource_attributes,omitempty"`
+	Attributes         map[string]string `json:"attributes,omitempty"`
+}
+
+func (e Event) Normalize(now time.Time) (Event, error) {
+	e.ID = strings.TrimSpace(e.ID)
+	e.Name = strings.TrimSpace(e.Name)
+	e.ProjectID = strings.TrimSpace(e.ProjectID)
+	e.IssueID = strings.TrimSpace(e.IssueID)
+	e.ExecutionID = strings.TrimSpace(e.ExecutionID)
+	e.WorkflowID = strings.TrimSpace(e.WorkflowID)
+	e.AdapterID = strings.TrimSpace(e.AdapterID)
+	e.Currency = strings.ToUpper(strings.TrimSpace(e.Currency))
+
+	if e.ID == "" {
+		return Event{}, fmt.Errorf("cost: event id is required")
+	}
+	if e.Name == "" {
+		return Event{}, fmt.Errorf("cost: event name is required")
+	}
+	if e.ProjectID == "" {
+		return Event{}, fmt.Errorf("cost: project id is required")
+	}
+	if e.ExecutionID != "" && e.IssueID == "" {
+		return Event{}, fmt.Errorf("cost: execution-scoped event requires issue id")
+	}
+	if e.Currency == "" {
+		return Event{}, fmt.Errorf("cost: currency is required")
+	}
+	if e.CostMicros < 0 {
+		return Event{}, fmt.Errorf("cost: cost micros must be >= 0")
+	}
+	if err := e.Usage.Validate(); err != nil {
+		return Event{}, err
+	}
+	if e.Time.IsZero() {
+		e.Time = now.UTC()
+	} else {
+		e.Time = e.Time.UTC()
+	}
+
+	e.ResourceAttributes = cloneStringMap(e.ResourceAttributes)
+	e.Attributes = cloneStringMap(e.Attributes)
+	e.ResourceAttributes["service.name"] = "rein"
+	e.ResourceAttributes["rein.project.id"] = e.ProjectID
+	if e.IssueID != "" {
+		e.ResourceAttributes["rein.issue.id"] = e.IssueID
+	}
+	if e.ExecutionID != "" {
+		e.ResourceAttributes["rein.execution.id"] = e.ExecutionID
+	}
+	if e.WorkflowID != "" {
+		e.ResourceAttributes["rein.workflow.id"] = e.WorkflowID
+	}
+	if e.AdapterID != "" {
+		e.ResourceAttributes["rein.adapter.id"] = e.AdapterID
+	}
+
+	return e, nil
+}
+
+type Snapshot struct {
+	Scope            Scope     `json:"scope"`
+	ScopeID          string    `json:"scope_id"`
+	Currency         string    `json:"currency"`
+	SoftLimitMicros  int64     `json:"soft_limit_micros"`
+	HardLimitMicros  int64     `json:"hard_limit_micros"`
+	SpentMicros      int64     `json:"spent_micros"`
+	Usage            Usage     `json:"usage"`
+	EventCount       int64     `json:"event_count"`
+	LastEventID      string    `json:"last_event_id,omitempty"`
+	LastEventTime    time.Time `json:"last_event_time,omitempty"`
+	SoftLimitHitTime time.Time `json:"soft_limit_hit_time,omitempty"`
+	HardLimitHitTime time.Time `json:"hard_limit_hit_time,omitempty"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+func (s Snapshot) Validate() error {
+	if !s.Scope.Valid() {
+		return fmt.Errorf("cost: invalid scope %q", s.Scope)
+	}
+	if strings.TrimSpace(s.ScopeID) == "" {
+		return fmt.Errorf("cost: scope id is required")
+	}
+	if s.Currency != "" && strings.TrimSpace(s.Currency) == "" {
+		return fmt.Errorf("cost: currency is required when provided")
+	}
+	if err := (Limits{SoftLimitMicros: s.SoftLimitMicros, HardLimitMicros: s.HardLimitMicros}).Validate(); err != nil {
+		return err
+	}
+	if s.SpentMicros < 0 || s.EventCount < 0 {
+		return fmt.Errorf("cost: snapshot counters must be >= 0")
+	}
+	return s.Usage.Validate()
+}
+
+func (s Scope) Valid() bool {
+	switch s {
+	case ScopeProject, ScopeIssue, ScopeExecution:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s Snapshot) SetLimits(limits Limits, at time.Time) (Snapshot, error) {
+	if !s.Scope.Valid() {
+		return Snapshot{}, fmt.Errorf("cost: invalid scope %q", s.Scope)
+	}
+	if strings.TrimSpace(s.ScopeID) == "" {
+		return Snapshot{}, fmt.Errorf("cost: scope id is required")
+	}
+	if err := limits.Validate(); err != nil {
+		return Snapshot{}, err
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	} else {
+		at = at.UTC()
+	}
+	if s.Currency == "" {
+		s.Currency = "USD"
+	}
+	s.UpdatedAt = at
+	s.SoftLimitMicros = limits.SoftLimitMicros
+	s.HardLimitMicros = limits.HardLimitMicros
+	if s.SoftLimited() {
+		if s.SoftLimitHitTime.IsZero() {
+			s.SoftLimitHitTime = at
+		}
+	} else {
+		s.SoftLimitHitTime = time.Time{}
+	}
+	if s.HardLimited() {
+		if s.HardLimitHitTime.IsZero() {
+			s.HardLimitHitTime = at
+		}
+	} else {
+		s.HardLimitHitTime = time.Time{}
+	}
+	return s, nil
+}
+
+func (s Snapshot) Observe(event Event) (Snapshot, error) {
+	if !s.Scope.Valid() {
+		return Snapshot{}, fmt.Errorf("cost: invalid scope %q", s.Scope)
+	}
+	if strings.TrimSpace(s.ScopeID) == "" {
+		return Snapshot{}, fmt.Errorf("cost: scope id is required")
+	}
+	if err := s.Validate(); err != nil {
+		return Snapshot{}, err
+	}
+	if s.Currency == "" {
+		s.Currency = event.Currency
+	}
+	if s.Currency != event.Currency {
+		return Snapshot{}, fmt.Errorf("cost: currency mismatch for %s %q: have %s, got %s", s.Scope, s.ScopeID, s.Currency, event.Currency)
+	}
+	s.SpentMicros += event.CostMicros
+	s.Usage = s.Usage.Add(event.Usage)
+	s.EventCount++
+	s.LastEventID = event.ID
+	s.LastEventTime = event.Time
+	s.UpdatedAt = event.Time
+	if s.SoftLimited() && s.SoftLimitHitTime.IsZero() {
+		s.SoftLimitHitTime = event.Time
+	}
+	if s.HardLimited() && s.HardLimitHitTime.IsZero() {
+		s.HardLimitHitTime = event.Time
+	}
+	return s, nil
+}
+
+func (s Snapshot) SoftLimited() bool {
+	return s.SoftLimitMicros > 0 && s.SpentMicros >= s.SoftLimitMicros
+}
+
+func (s Snapshot) HardLimited() bool {
+	return s.HardLimitMicros > 0 && s.SpentMicros >= s.HardLimitMicros
+}
+
+type Admission struct {
+	Allowed   bool
+	Warnings  []Snapshot
+	BlockedBy Snapshot
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/cost/recorder.go
+++ b/internal/cost/recorder.go
@@ -1,0 +1,159 @@
+package cost
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Store interface {
+	AppendCostEvent(context.Context, Event) (Event, error)
+	GetBudgetSnapshot(context.Context, Scope, string) (Snapshot, bool, error)
+	UpsertBudgetSnapshot(context.Context, Snapshot) (Snapshot, error)
+}
+
+type Publisher interface {
+	Publish(Event)
+}
+
+type Recorder struct {
+	store     Store
+	publisher Publisher
+	now       func() time.Time
+}
+
+type Option func(*Recorder)
+
+func WithPublisher(publisher Publisher) Option {
+	return func(r *Recorder) {
+		r.publisher = publisher
+	}
+}
+
+func WithNow(now func() time.Time) Option {
+	return func(r *Recorder) {
+		r.now = now
+	}
+}
+
+func NewRecorder(store Store, options ...Option) *Recorder {
+	recorder := &Recorder{
+		store: store,
+		now:   func() time.Time { return time.Now().UTC() },
+	}
+	for _, option := range options {
+		option(recorder)
+	}
+	return recorder
+}
+
+type RecordResult struct {
+	Event     Event
+	Snapshots []Snapshot
+}
+
+func (r *Recorder) ConfigureBudget(ctx context.Context, scope Scope, scopeID, currency string, limits Limits) (Snapshot, error) {
+	if r == nil || r.store == nil {
+		return Snapshot{}, fmt.Errorf("cost: recorder store is required")
+	}
+	if err := limits.Validate(); err != nil {
+		return Snapshot{}, err
+	}
+	scopeID = stringsTrim(scopeID)
+	currency = stringsUpperTrim(currency)
+	if !scope.Valid() {
+		return Snapshot{}, fmt.Errorf("cost: invalid scope %q", scope)
+	}
+	if scopeID == "" {
+		return Snapshot{}, fmt.Errorf("cost: scope id is required")
+	}
+	if currency == "" {
+		currency = "USD"
+	}
+	current, found, err := r.store.GetBudgetSnapshot(ctx, scope, scopeID)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if !found {
+		current = Snapshot{Scope: scope, ScopeID: scopeID, Currency: currency}
+	}
+	if current.Currency == "" {
+		current.Currency = currency
+	}
+	updated, err := current.SetLimits(limits, r.now())
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return r.store.UpsertBudgetSnapshot(ctx, updated)
+}
+
+func (r *Recorder) CheckLaunch(ctx context.Context, path ScopePath) (Admission, error) {
+	if r == nil || r.store == nil {
+		return Admission{}, fmt.Errorf("cost: recorder store is required")
+	}
+	admission := Admission{Allowed: true}
+	for _, ref := range path.Refs() {
+		snapshot, found, err := r.store.GetBudgetSnapshot(ctx, ref.Scope, ref.ID)
+		if err != nil {
+			return Admission{}, err
+		}
+		if !found {
+			continue
+		}
+		if snapshot.HardLimited() {
+			admission.Allowed = false
+			admission.BlockedBy = snapshot
+			return admission, nil
+		}
+		if snapshot.SoftLimited() {
+			admission.Warnings = append(admission.Warnings, snapshot)
+		}
+	}
+	return admission, nil
+}
+
+func (r *Recorder) Record(ctx context.Context, event Event) (RecordResult, error) {
+	if r == nil || r.store == nil {
+		return RecordResult{}, fmt.Errorf("cost: recorder store is required")
+	}
+	normalized, err := event.Normalize(r.now())
+	if err != nil {
+		return RecordResult{}, err
+	}
+	storedEvent, err := r.store.AppendCostEvent(ctx, normalized)
+	if err != nil {
+		return RecordResult{}, err
+	}
+	result := RecordResult{Event: storedEvent}
+	for _, ref := range (ScopePath{ProjectID: storedEvent.ProjectID, IssueID: storedEvent.IssueID, ExecutionID: storedEvent.ExecutionID}).Refs() {
+		snapshot, found, err := r.store.GetBudgetSnapshot(ctx, ref.Scope, ref.ID)
+		if err != nil {
+			return RecordResult{}, err
+		}
+		if !found {
+			snapshot = Snapshot{Scope: ref.Scope, ScopeID: ref.ID, Currency: storedEvent.Currency}
+		}
+		updated, err := snapshot.Observe(storedEvent)
+		if err != nil {
+			return RecordResult{}, err
+		}
+		updated, err = r.store.UpsertBudgetSnapshot(ctx, updated)
+		if err != nil {
+			return RecordResult{}, err
+		}
+		result.Snapshots = append(result.Snapshots, updated)
+	}
+	if r.publisher != nil {
+		r.publisher.Publish(storedEvent)
+	}
+	return result, nil
+}
+
+func stringsTrim(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func stringsUpperTrim(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}

--- a/internal/cost/recorder_test.go
+++ b/internal/cost/recorder_test.go
@@ -1,0 +1,153 @@
+package cost
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type memoryStore struct {
+	mu        sync.Mutex
+	events    []Event
+	snapshots map[string]Snapshot
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{snapshots: map[string]Snapshot{}}
+}
+
+func (s *memoryStore) AppendCostEvent(_ context.Context, event Event) (Event, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	event.Sequence = int64(len(s.events) + 1)
+	s.events = append(s.events, event)
+	return event, nil
+}
+
+func (s *memoryStore) GetBudgetSnapshot(_ context.Context, scope Scope, scopeID string) (Snapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, ok := s.snapshots[fmt.Sprintf("%s/%s", scope, scopeID)]
+	return snapshot, ok, nil
+}
+
+func (s *memoryStore) UpsertBudgetSnapshot(_ context.Context, snapshot Snapshot) (Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshots[fmt.Sprintf("%s/%s", snapshot.Scope, snapshot.ScopeID)] = snapshot
+	return snapshot, nil
+}
+
+func TestRecorderPublishesEventAndUpdatesSnapshots(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 2, 15, 4, 5, 0, time.UTC)
+	store := newMemoryStore()
+	stream := NewStream()
+	recorder := NewRecorder(store, WithPublisher(stream), WithNow(func() time.Time { return now }))
+	streamCh, unsubscribe := stream.Subscribe(1)
+	defer unsubscribe()
+
+	ctx := context.Background()
+	for _, scope := range []Scope{ScopeProject, ScopeIssue, ScopeExecution} {
+		scopeID := map[Scope]string{
+			ScopeProject:   "project-rein",
+			ScopeIssue:     "RN-13",
+			ScopeExecution: "exec-rn-13-001",
+		}[scope]
+		if _, err := recorder.ConfigureBudget(ctx, scope, scopeID, "USD", Limits{SoftLimitMicros: 1000, HardLimitMicros: 5000}); err != nil {
+			t.Fatalf("ConfigureBudget(%s) error = %v", scope, err)
+		}
+	}
+
+	result, err := recorder.Record(ctx, Event{
+		ID:          "evt-1",
+		Name:        "adapter.turn.completed",
+		ProjectID:   "project-rein",
+		IssueID:     "RN-13",
+		ExecutionID: "exec-rn-13-001",
+		WorkflowID:  "managed-issue-pr-review-merge",
+		AdapterID:   "coding-copilot-fake",
+		Currency:    "usd",
+		CostMicros:  1200,
+		Usage: Usage{
+			InputTokens:  200,
+			OutputTokens: 80,
+		},
+		Attributes: map[string]string{"workflow_step_id": "open-pr"},
+	})
+	if err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+	if len(result.Snapshots) != 3 {
+		t.Fatalf("Record() snapshots = %d, want 3", len(result.Snapshots))
+	}
+	if result.Event.Sequence != 1 {
+		t.Fatalf("Record() sequence = %d, want 1", result.Event.Sequence)
+	}
+
+	streamed := <-streamCh
+	if streamed.ID != result.Event.ID {
+		t.Fatalf("streamed event id = %q, want %q", streamed.ID, result.Event.ID)
+	}
+	if streamed.ResourceAttributes["rein.execution.id"] != "exec-rn-13-001" {
+		t.Fatalf("streamed resource attrs = %+v", streamed.ResourceAttributes)
+	}
+
+	executionSnapshot, found, err := store.GetBudgetSnapshot(ctx, ScopeExecution, "exec-rn-13-001")
+	if err != nil {
+		t.Fatalf("GetBudgetSnapshot() error = %v", err)
+	}
+	if !found {
+		t.Fatal("GetBudgetSnapshot() found = false, want true")
+	}
+	if !executionSnapshot.SoftLimited() || executionSnapshot.HardLimited() {
+		t.Fatalf("execution snapshot limits = %+v", executionSnapshot)
+	}
+	if executionSnapshot.SpentMicros != 1200 || executionSnapshot.Usage.TotalTokens() != 280 {
+		t.Fatalf("execution snapshot = %+v", executionSnapshot)
+	}
+}
+
+func TestRecorderCheckLaunchBlocksOnlyAfterHardHit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 2, 16, 0, 0, 0, time.UTC)
+	store := newMemoryStore()
+	recorder := NewRecorder(store, WithNow(func() time.Time { return now }))
+	ctx := context.Background()
+
+	if _, err := recorder.ConfigureBudget(ctx, ScopeExecution, "exec-rn-13-001", "USD", Limits{HardLimitMicros: 1000}); err != nil {
+		t.Fatalf("ConfigureBudget() error = %v", err)
+	}
+
+	before, err := recorder.CheckLaunch(ctx, ScopePath{ProjectID: "project-rein", IssueID: "RN-13", ExecutionID: "exec-rn-13-001"})
+	if err != nil {
+		t.Fatalf("CheckLaunch() before error = %v", err)
+	}
+	if !before.Allowed {
+		t.Fatalf("CheckLaunch() before = %+v, want allowed", before)
+	}
+
+	if _, err := recorder.Record(ctx, Event{
+		ID:          "evt-1",
+		Name:        "adapter.turn.completed",
+		ProjectID:   "project-rein",
+		IssueID:     "RN-13",
+		ExecutionID: "exec-rn-13-001",
+		Currency:    "USD",
+		CostMicros:  1200,
+	}); err != nil {
+		t.Fatalf("Record() error = %v", err)
+	}
+
+	after, err := recorder.CheckLaunch(ctx, ScopePath{ProjectID: "project-rein", IssueID: "RN-13", ExecutionID: "exec-rn-13-001"})
+	if err != nil {
+		t.Fatalf("CheckLaunch() after error = %v", err)
+	}
+	if after.Allowed || after.BlockedBy.Scope != ScopeExecution {
+		t.Fatalf("CheckLaunch() after = %+v, want execution hard block", after)
+	}
+}

--- a/internal/cost/stream.go
+++ b/internal/cost/stream.go
@@ -1,0 +1,48 @@
+package cost
+
+import "sync"
+
+type Stream struct {
+	mu          sync.Mutex
+	nextID      int
+	subscribers map[int]chan Event
+}
+
+func NewStream() *Stream {
+	return &Stream{subscribers: map[int]chan Event{}}
+}
+
+func (s *Stream) Publish(event Event) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ch := range s.subscribers {
+		ch <- event
+	}
+}
+
+func (s *Stream) Subscribe(buffer int) (events <-chan Event, unsubscribe func()) {
+	if buffer < 0 {
+		buffer = 0
+	}
+	ch := make(chan Event, buffer)
+	if s == nil {
+		close(ch)
+		return ch, func() {}
+	}
+	s.mu.Lock()
+	id := s.nextID
+	s.nextID++
+	s.subscribers[id] = ch
+	s.mu.Unlock()
+	return ch, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if current, ok := s.subscribers[id]; ok {
+			delete(s.subscribers, id)
+			close(current)
+		}
+	}
+}

--- a/internal/server/managed_flow_harness_test.go
+++ b/internal/server/managed_flow_harness_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/earchibald/rein/adaptertest"
 	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/cost"
 	"github.com/earchibald/rein/internal/service"
 	"github.com/earchibald/rein/internal/storage/sqlite"
 )
@@ -33,6 +34,8 @@ func TestManagedFlowHarnessIssueToMergeFlow(t *testing.T) {
 	harness := newManagedFlowHarness(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	costEventsCh, unsubscribe := harness.subscribeCostEvents(4)
+	defer unsubscribe()
 
 	workflow := managedFlowWorkflow()
 	if err := harness.seedWorkflow(ctx, workflow); err != nil {
@@ -182,10 +185,145 @@ func TestManagedFlowHarnessIssueToMergeFlow(t *testing.T) {
 			t.Fatalf("GetIssue() labels[%q] = %q, want %q", key, got, want)
 		}
 	}
+
+	streamedCostEvents := collectCostEvents(t, ctx, costEventsCh, 4)
+	if got := []string{
+		streamedCostEvents[0].AdapterID,
+		streamedCostEvents[1].AdapterID,
+		streamedCostEvents[2].AdapterID,
+		streamedCostEvents[3].AdapterID,
+	}; !slices.Equal(got, []string{fakeTrackerAdapterID, fakeCodingAdapterID, fakeReviewAdapterID, fakeTrackerAdapterID}) {
+		t.Fatalf("streamed adapter ids = %v", got)
+	}
+
+	storedCostEvents, err := harness.listCostEvents(ctx, execution.GetId())
+	if err != nil {
+		t.Fatalf("listCostEvents() error = %v", err)
+	}
+	if len(storedCostEvents) != 4 {
+		t.Fatalf("listCostEvents() count = %d, want 4", len(storedCostEvents))
+	}
+
+	executionBudget, found, err := harness.budgetSnapshot(ctx, cost.ScopeExecution, execution.GetId())
+	if err != nil {
+		t.Fatalf("budgetSnapshot() error = %v", err)
+	}
+	if !found {
+		t.Fatal("budgetSnapshot() found = false, want true")
+	}
+	if executionBudget.EventCount != 4 || executionBudget.SpentMicros != 5600 {
+		t.Fatalf("execution budget snapshot = %+v, want 4 events and 5600 micros", executionBudget)
+	}
+}
+
+func TestManagedFlowHarnessBudgetHardLimitBlocksNewLaunches(t *testing.T) {
+	t.Parallel()
+
+	harness := newManagedFlowHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	costEventsCh, unsubscribe := harness.subscribeCostEvents(1)
+	defer unsubscribe()
+
+	workflow := managedFlowWorkflow()
+	if err := harness.seedWorkflow(ctx, workflow); err != nil {
+		t.Fatalf("seedWorkflow() error = %v", err)
+	}
+
+	projectResp, err := harness.projectClient.CreateProject(ctx, &reinv1.CreateProjectRequest{
+		Project: &reinv1.Project{
+			Id:          "project-rein",
+			Slug:        "rein",
+			DisplayName: "rein",
+			Summary:     "Managed flow harness",
+			Status:      reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+
+	issueResp, err := harness.issueClient.CreateIssue(ctx, &reinv1.CreateIssueRequest{
+		Issue: &reinv1.Issue{
+			Id:         "RN-13",
+			ProjectId:  projectResp.GetProject().GetId(),
+			Title:      "Cost telemetry budgets",
+			Summary:    "Exercise launch blocking after a hard budget hit",
+			Status:     reinv1.IssueStatus_ISSUE_STATUS_OPEN,
+			Priority:   reinv1.IssuePriority_ISSUE_PRIORITY_HIGH,
+			WorkflowId: workflow.GetId(),
+			Assignee:   "copilot",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	if _, err := harness.configureBudget(ctx, cost.ScopeExecution, "exec-rn-9-001", cost.Limits{HardLimitMicros: 1000}); err != nil {
+		t.Fatalf("configureBudget() error = %v", err)
+	}
+
+	_, err = harness.executionClient.StartExecution(ctx, &reinv1.StartExecutionRequest{
+		IssueId:     issueResp.GetIssue().GetId(),
+		WorkflowId:  workflow.GetId(),
+		RequestedBy: "copilot",
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("StartExecution() status = %v, want %v", status.Code(err), codes.ResourceExhausted)
+	}
+
+	streamedCostEvents := collectCostEvents(t, ctx, costEventsCh, 1)
+	if len(streamedCostEvents) != 1 || streamedCostEvents[0].AdapterID != fakeTrackerAdapterID {
+		t.Fatalf("streamedCostEvents = %+v", streamedCostEvents)
+	}
+
+	executionResp, err := harness.executionClient.GetExecution(ctx, &reinv1.GetExecutionRequest{Id: "exec-rn-9-001"})
+	if err != nil {
+		t.Fatalf("GetExecution() error = %v", err)
+	}
+	execution := executionResp.GetExecution()
+	if execution.GetStatus() != reinv1.ExecutionStatus_EXECUTION_STATUS_FAILED {
+		t.Fatalf("GetExecution() status = %s, want %s", execution.GetStatus(), reinv1.ExecutionStatus_EXECUTION_STATUS_FAILED)
+	}
+	if execution.GetMetadata()["result"] != "budget_hard_limit" {
+		t.Fatalf("GetExecution() result = %q, want %q", execution.GetMetadata()["result"], "budget_hard_limit")
+	}
+	if execution.GetMetadata()["branch"] == "" || execution.GetMetadata()["worktree"] == "" {
+		t.Fatalf("GetExecution() missing first-step metadata: %+v", execution.GetMetadata())
+	}
+	if execution.GetMetadata()["pr_url"] != "" {
+		t.Fatalf("GetExecution() pr_url = %q, want empty", execution.GetMetadata()["pr_url"])
+	}
+
+	issueState, err := harness.issueClient.GetIssue(ctx, &reinv1.GetIssueRequest{Id: issueResp.GetIssue().GetId()})
+	if err != nil {
+		t.Fatalf("GetIssue() error = %v", err)
+	}
+	if issueState.GetIssue().GetStatus() != reinv1.IssueStatus_ISSUE_STATUS_IN_PROGRESS {
+		t.Fatalf("GetIssue() status = %s, want %s", issueState.GetIssue().GetStatus(), reinv1.IssueStatus_ISSUE_STATUS_IN_PROGRESS)
+	}
+
+	storedCostEvents, err := harness.listCostEvents(ctx, execution.GetId())
+	if err != nil {
+		t.Fatalf("listCostEvents() error = %v", err)
+	}
+	if len(storedCostEvents) != 1 {
+		t.Fatalf("listCostEvents() count = %d, want 1", len(storedCostEvents))
+	}
+
+	executionBudget, found, err := harness.budgetSnapshot(ctx, cost.ScopeExecution, execution.GetId())
+	if err != nil {
+		t.Fatalf("budgetSnapshot() error = %v", err)
+	}
+	if !found || !executionBudget.HardLimited() || executionBudget.EventCount != 1 || executionBudget.SpentMicros != 1200 {
+		t.Fatalf("execution budget snapshot = %+v, want hard-limited first-step spend", executionBudget)
+	}
 }
 
 type managedFlowHarness struct {
 	adapterClient   reinv1.AdapterServiceClient
+	costRecorder    *cost.Recorder
+	costStream      *cost.Stream
 	executionClient reinv1.ExecutionServiceClient
 	issueClient     reinv1.IssueServiceClient
 	projectClient   reinv1.ProjectServiceClient
@@ -207,12 +345,15 @@ func newManagedFlowHarness(tb testing.TB) *managedFlowHarness {
 	})
 
 	adapters := newManagedFlowAdapterCatalog(tb)
+	costStream := cost.NewStream()
+	costRecorder := cost.NewRecorder(store, cost.WithPublisher(costStream))
 	bufconn := newBufconnHarness(tb, Options{
 		Services: service.Set{
 			Adapter: &managedFlowAdapterService{catalog: adapters},
 			Execution: &managedFlowExecutionService{
-				adapters: adapters,
-				store:    store,
+				adapters:     adapters,
+				costRecorder: costRecorder,
+				store:        store,
 			},
 			Issue:    &managedFlowIssueService{store: store},
 			Project:  &managedFlowProjectService{store: store},
@@ -222,6 +363,8 @@ func newManagedFlowHarness(tb testing.TB) *managedFlowHarness {
 
 	return &managedFlowHarness{
 		adapterClient:   reinv1.NewAdapterServiceClient(bufconn.conn),
+		costRecorder:    costRecorder,
+		costStream:      costStream,
 		executionClient: reinv1.NewExecutionServiceClient(bufconn.conn),
 		issueClient:     reinv1.NewIssueServiceClient(bufconn.conn),
 		projectClient:   reinv1.NewProjectServiceClient(bufconn.conn),
@@ -233,6 +376,22 @@ func newManagedFlowHarness(tb testing.TB) *managedFlowHarness {
 func (h *managedFlowHarness) seedWorkflow(ctx context.Context, workflow *reinv1.Workflow) error {
 	_, err := createStoredProto(ctx, h.store, sqlite.WorkflowKind, workflow.GetId(), workflow)
 	return err
+}
+
+func (h *managedFlowHarness) subscribeCostEvents(buffer int) (events <-chan cost.Event, unsubscribe func()) {
+	return h.costStream.Subscribe(buffer)
+}
+
+func (h *managedFlowHarness) configureBudget(ctx context.Context, scope cost.Scope, scopeID string, limits cost.Limits) (cost.Snapshot, error) {
+	return h.costRecorder.ConfigureBudget(ctx, scope, scopeID, "USD", limits)
+}
+
+func (h *managedFlowHarness) listCostEvents(ctx context.Context, executionID string) ([]cost.Event, error) {
+	return h.store.ListCostEvents(ctx, sqlite.CostEventFilter{ExecutionID: executionID})
+}
+
+func (h *managedFlowHarness) budgetSnapshot(ctx context.Context, scope cost.Scope, scopeID string) (cost.Snapshot, bool, error) {
+	return h.store.GetBudgetSnapshot(ctx, scope, scopeID)
 }
 
 type managedFlowAdapterService struct {
@@ -387,8 +546,9 @@ func (s *managedFlowIssueService) GetIssue(ctx context.Context, req *reinv1.GetI
 
 type managedFlowExecutionService struct {
 	reinv1.UnimplementedExecutionServiceServer
-	adapters *managedFlowAdapterCatalog
-	store    *sqlite.Store
+	adapters     *managedFlowAdapterCatalog
+	costRecorder *cost.Recorder
+	store        *sqlite.Store
 }
 
 func (s *managedFlowExecutionService) StartExecution(ctx context.Context, req *reinv1.StartExecutionRequest) (*reinv1.StartExecutionResponse, error) {
@@ -455,12 +615,38 @@ func (s *managedFlowExecutionService) StartExecution(ctx context.Context, req *r
 	}
 
 	state := &managedFlowState{
-		execution: execution,
-		issue:     issue,
-		workflow:  workflow,
+		costRecorder: s.costRecorder,
+		execution:    execution,
+		issue:        issue,
+		workflow:     workflow,
 	}
 
 	for _, step := range workflow.GetSteps() {
+		if s.costRecorder != nil {
+			admission, err := s.costRecorder.CheckLaunch(ctx, cost.ScopePath{
+				ProjectID:   issue.GetProjectId(),
+				IssueID:     issue.GetId(),
+				ExecutionID: execution.GetId(),
+			})
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "check budgets for execution %q: %v", execution.GetId(), err)
+			}
+			if !admission.Allowed {
+				execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_FAILED
+				execution.FinishedTime = timestamppb.Now()
+				execution.Metadata["budget_block_scope"] = string(admission.BlockedBy.Scope)
+				execution.Metadata["budget_block_scope_id"] = admission.BlockedBy.ScopeID
+				execution.Metadata["result"] = "budget_hard_limit"
+				if _, updateErr := updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution); updateErr != nil {
+					return nil, status.Errorf(codes.Internal, "store budget-blocked execution %q: %v", execution.GetId(), updateErr)
+				}
+				return nil, status.Errorf(codes.ResourceExhausted, "budget hard limit reached for %s %q", admission.BlockedBy.Scope, admission.BlockedBy.ScopeID)
+			}
+			if len(admission.Warnings) > 0 {
+				execution.Metadata["budget_soft_warning_scope"] = string(admission.Warnings[0].Scope)
+			}
+		}
+
 		err := s.adapters.Run(ctx, state, step)
 		if err == nil {
 			continue
@@ -511,9 +697,10 @@ func (s *managedFlowExecutionService) GetExecution(ctx context.Context, req *rei
 }
 
 type managedFlowState struct {
-	execution *reinv1.Execution
-	issue     *reinv1.Issue
-	workflow  *reinv1.Workflow
+	costRecorder *cost.Recorder
+	execution    *reinv1.Execution
+	issue        *reinv1.Issue
+	workflow     *reinv1.Workflow
 }
 
 type managedFlowAdapterCatalog struct {
@@ -652,7 +839,7 @@ func (a *managedFlowTrackerAdapter) Descriptor() *reinv1.Adapter {
 	return proto.Clone(a.descriptor).(*reinv1.Adapter)
 }
 
-func (a *managedFlowTrackerAdapter) Run(_ context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
+func (a *managedFlowTrackerAdapter) Run(ctx context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
 	switch step.GetInputs()["operation"] {
 	case "prepare":
 		slug := slugify(state.issue.GetTitle())
@@ -663,7 +850,7 @@ func (a *managedFlowTrackerAdapter) Run(_ context.Context, state *managedFlowSta
 		state.execution.Metadata["worktree"] = worktree
 		state.issue.Labels["branch"] = branch
 		state.issue.Labels["worktree"] = worktree
-		return nil
+		return state.recordCost(ctx, step, 1200, cost.Usage{InputTokens: 120, OutputTokens: 40}, map[string]string{"operation": "prepare"})
 	case "merge":
 		if state.execution.Metadata["review_state"] != "APPROVED" {
 			return errors.New("review approval missing before merge")
@@ -679,7 +866,7 @@ func (a *managedFlowTrackerAdapter) Run(_ context.Context, state *managedFlowSta
 		state.execution.Metadata["merge_commit"] = mergeCommit
 		state.execution.Metadata["integration_branch"] = baseBranch
 		state.issue.Labels["merge_commit"] = mergeCommit
-		return nil
+		return state.recordCost(ctx, step, 1100, cost.Usage{InputTokens: 60, OutputTokens: 25}, map[string]string{"operation": "merge"})
 	default:
 		return fmt.Errorf("unsupported tracker operation %q", step.GetInputs()["operation"])
 	}
@@ -693,7 +880,7 @@ func (a *managedFlowCodingAdapter) Descriptor() *reinv1.Adapter {
 	return proto.Clone(a.descriptor).(*reinv1.Adapter)
 }
 
-func (a *managedFlowCodingAdapter) Run(_ context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
+func (a *managedFlowCodingAdapter) Run(ctx context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
 	if len(step.GetDependsOn()) == 0 || state.execution.Metadata["branch"] == "" || state.execution.Metadata["worktree"] == "" {
 		return errors.New("branch and worktree must exist before opening a pull request")
 	}
@@ -701,7 +888,7 @@ func (a *managedFlowCodingAdapter) Run(_ context.Context, state *managedFlowStat
 	state.execution.Metadata["pr_url"] = "https://tracker.fake/repos/rein/pull/101"
 	state.execution.Metadata["pr_state"] = "OPEN"
 	state.issue.Labels["pr_url"] = state.execution.Metadata["pr_url"]
-	return nil
+	return state.recordCost(ctx, step, 2400, cost.Usage{InputTokens: 400, OutputTokens: 180}, nil)
 }
 
 type managedFlowReviewAdapter struct {
@@ -712,7 +899,7 @@ func (a *managedFlowReviewAdapter) Descriptor() *reinv1.Adapter {
 	return proto.Clone(a.descriptor).(*reinv1.Adapter)
 }
 
-func (a *managedFlowReviewAdapter) Run(_ context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
+func (a *managedFlowReviewAdapter) Run(ctx context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
 	if len(step.GetDependsOn()) == 0 || state.execution.Metadata["pr_url"] == "" {
 		return errors.New("pull request must exist before review")
 	}
@@ -720,7 +907,7 @@ func (a *managedFlowReviewAdapter) Run(_ context.Context, state *managedFlowStat
 	state.execution.Metadata["review_state"] = "APPROVED"
 	state.execution.Metadata["reviewed_by"] = a.descriptor.GetId()
 	state.issue.Labels["review_state"] = "APPROVED"
-	return nil
+	return state.recordCost(ctx, step, 900, cost.Usage{InputTokens: 80, OutputTokens: 30}, nil)
 }
 
 func managedFlowWorkflow() *reinv1.Workflow {
@@ -883,6 +1070,46 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func (s *managedFlowState) recordCost(ctx context.Context, step *reinv1.WorkflowStep, costMicros int64, usage cost.Usage, attributes map[string]string) error {
+	if s.costRecorder == nil {
+		return nil
+	}
+	attributes = cloneStringMap(attributes)
+	if attributes == nil {
+		attributes = map[string]string{}
+	}
+	attributes["workflow_step_id"] = step.GetId()
+	attributes["workflow_step_name"] = step.GetName()
+	_, err := s.costRecorder.Record(ctx, cost.Event{
+		ID:          fmt.Sprintf("%s-%s", s.execution.GetId(), step.GetId()),
+		Name:        "adapter.turn.completed",
+		ProjectID:   s.issue.GetProjectId(),
+		IssueID:     s.issue.GetId(),
+		ExecutionID: s.execution.GetId(),
+		WorkflowID:  s.workflow.GetId(),
+		AdapterID:   step.GetAdapterId(),
+		Currency:    "USD",
+		CostMicros:  costMicros,
+		Usage:       usage,
+		Attributes:  attributes,
+	})
+	return err
+}
+
+func collectCostEvents(tb testing.TB, ctx context.Context, events <-chan cost.Event, want int) []cost.Event {
+	tb.Helper()
+	collected := make([]cost.Event, 0, want)
+	for len(collected) < want {
+		select {
+		case event := <-events:
+			collected = append(collected, event)
+		case <-ctx.Done():
+			tb.Fatalf("collectCostEvents() timed out after %d/%d events: %v", len(collected), want, ctx.Err())
+		}
+	}
+	return collected
 }
 
 func adapterIDs(adapters []*reinv1.Adapter) []string {

--- a/internal/storage/sqlite/cost_telemetry.go
+++ b/internal/storage/sqlite/cost_telemetry.go
@@ -1,0 +1,270 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/earchibald/rein/internal/cost"
+)
+
+type CostEventFilter struct {
+	ProjectID   string
+	IssueID     string
+	ExecutionID string
+}
+
+func (s *Store) AppendCostEvent(ctx context.Context, event cost.Event) (cost.Event, error) {
+	normalized, err := event.Normalize(time.Now().UTC())
+	if err != nil {
+		return cost.Event{}, err
+	}
+
+	resourceAttributes, err := json.Marshal(normalized.ResourceAttributes)
+	if err != nil {
+		return cost.Event{}, fmt.Errorf("sqlite: marshal cost event resource attributes %q: %w", normalized.ID, err)
+	}
+	attributes, err := json.Marshal(normalized.Attributes)
+	if err != nil {
+		return cost.Event{}, fmt.Errorf("sqlite: marshal cost event attributes %q: %w", normalized.ID, err)
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return cost.Event{}, fmt.Errorf("sqlite: marshal cost event payload %q: %w", normalized.ID, err)
+	}
+
+	result, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO costeventlog (
+event_id, event_name, event_time, project_id, issue_id, execution_id, workflow_id, adapter_id,
+currency, cost_micros, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+resource_attributes, attributes, payload, created_at
+) VALUES (?, ?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		normalized.ID,
+		normalized.Name,
+		normalized.Time.Format(time.RFC3339Nano),
+		normalized.ProjectID,
+		normalized.IssueID,
+		normalized.ExecutionID,
+		normalized.WorkflowID,
+		normalized.AdapterID,
+		normalized.Currency,
+		normalized.CostMicros,
+		normalized.Usage.InputTokens,
+		normalized.Usage.OutputTokens,
+		normalized.Usage.CacheReadTokens,
+		normalized.Usage.CacheWriteTokens,
+		string(resourceAttributes),
+		string(attributes),
+		string(payload),
+		normalized.Time.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return cost.Event{}, fmt.Errorf("sqlite: append cost event %q: %w", normalized.ID, err)
+	}
+
+	sequence, err := result.LastInsertId()
+	if err != nil {
+		return cost.Event{}, fmt.Errorf("sqlite: inspect cost event insert %q: %w", normalized.ID, err)
+	}
+	normalized.Sequence = sequence
+	return normalized, nil
+}
+
+func (s *Store) ListCostEvents(ctx context.Context, filter CostEventFilter) ([]cost.Event, error) {
+	clauses := []string{"1 = 1"}
+	args := make([]any, 0, 3)
+	if value := strings.TrimSpace(filter.ProjectID); value != "" {
+		clauses = append(clauses, "project_id = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(filter.IssueID); value != "" {
+		clauses = append(clauses, "issue_id = ?")
+		args = append(args, value)
+	}
+	if value := strings.TrimSpace(filter.ExecutionID); value != "" {
+		clauses = append(clauses, "execution_id = ?")
+		args = append(args, value)
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx,
+		fmt.Sprintf(`SELECT sequence, payload FROM costeventlog WHERE %s ORDER BY sequence`, strings.Join(clauses, " AND ")),
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list cost events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []cost.Event
+	for rows.Next() {
+		var (
+			sequence int64
+			payload  []byte
+		)
+		if err := rows.Scan(&sequence, &payload); err != nil {
+			return nil, fmt.Errorf("sqlite: scan cost event row: %w", err)
+		}
+		var event cost.Event
+		if err := json.Unmarshal(payload, &event); err != nil {
+			return nil, fmt.Errorf("sqlite: decode cost event payload: %w", err)
+		}
+		event.Sequence = sequence
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate cost events: %w", err)
+	}
+	return events, nil
+}
+
+func (s *Store) GetBudgetSnapshot(ctx context.Context, scope cost.Scope, scopeID string) (cost.Snapshot, bool, error) {
+	if !scope.Valid() {
+		return cost.Snapshot{}, false, fmt.Errorf("sqlite: invalid budget scope %q", scope)
+	}
+	scopeID = strings.TrimSpace(scopeID)
+	if scopeID == "" {
+		return cost.Snapshot{}, false, fmt.Errorf("sqlite: budget scope id is required")
+	}
+
+	var (
+		snapshot       cost.Snapshot
+		lastEventTime  string
+		softLimitHitAt string
+		hardLimitHitAt string
+		updatedAt      string
+	)
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT scope, scope_id, currency, soft_limit_micros, hard_limit_micros, spent_micros,
+input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, event_count,
+last_event_id, last_event_time, soft_limit_hit_time, hard_limit_hit_time, updated_at
+ FROM budgetstates WHERE scope = ? AND scope_id = ?`,
+		string(scope),
+		scopeID,
+	).Scan(
+		&snapshot.Scope,
+		&snapshot.ScopeID,
+		&snapshot.Currency,
+		&snapshot.SoftLimitMicros,
+		&snapshot.HardLimitMicros,
+		&snapshot.SpentMicros,
+		&snapshot.Usage.InputTokens,
+		&snapshot.Usage.OutputTokens,
+		&snapshot.Usage.CacheReadTokens,
+		&snapshot.Usage.CacheWriteTokens,
+		&snapshot.EventCount,
+		&snapshot.LastEventID,
+		&lastEventTime,
+		&softLimitHitAt,
+		&hardLimitHitAt,
+		&updatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return cost.Snapshot{}, false, nil
+	}
+	if err != nil {
+		return cost.Snapshot{}, false, fmt.Errorf("sqlite: get budget snapshot %s %q: %w", scope, scopeID, err)
+	}
+
+	if err := parseOptionalBudgetTimes(&snapshot, lastEventTime, softLimitHitAt, hardLimitHitAt, updatedAt); err != nil {
+		return cost.Snapshot{}, false, err
+	}
+	return snapshot, true, nil
+}
+
+func (s *Store) UpsertBudgetSnapshot(ctx context.Context, snapshot cost.Snapshot) (cost.Snapshot, error) {
+	if err := snapshot.Validate(); err != nil {
+		return cost.Snapshot{}, err
+	}
+	if snapshot.Currency == "" {
+		snapshot.Currency = "USD"
+	}
+	if snapshot.UpdatedAt.IsZero() {
+		snapshot.UpdatedAt = time.Now().UTC()
+	} else {
+		snapshot.UpdatedAt = snapshot.UpdatedAt.UTC()
+	}
+
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO budgetstates (
+scope, scope_id, currency, soft_limit_micros, hard_limit_micros, spent_micros,
+input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, event_count,
+last_event_id, last_event_time, soft_limit_hit_time, hard_limit_hit_time, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(scope, scope_id) DO UPDATE SET
+currency = excluded.currency,
+soft_limit_micros = excluded.soft_limit_micros,
+hard_limit_micros = excluded.hard_limit_micros,
+spent_micros = excluded.spent_micros,
+input_tokens = excluded.input_tokens,
+output_tokens = excluded.output_tokens,
+cache_read_tokens = excluded.cache_read_tokens,
+cache_write_tokens = excluded.cache_write_tokens,
+event_count = excluded.event_count,
+last_event_id = excluded.last_event_id,
+last_event_time = excluded.last_event_time,
+soft_limit_hit_time = excluded.soft_limit_hit_time,
+hard_limit_hit_time = excluded.hard_limit_hit_time,
+updated_at = excluded.updated_at`,
+		string(snapshot.Scope),
+		snapshot.ScopeID,
+		snapshot.Currency,
+		snapshot.SoftLimitMicros,
+		snapshot.HardLimitMicros,
+		snapshot.SpentMicros,
+		snapshot.Usage.InputTokens,
+		snapshot.Usage.OutputTokens,
+		snapshot.Usage.CacheReadTokens,
+		snapshot.Usage.CacheWriteTokens,
+		snapshot.EventCount,
+		snapshot.LastEventID,
+		formatOptionalTime(snapshot.LastEventTime),
+		formatOptionalTime(snapshot.SoftLimitHitTime),
+		formatOptionalTime(snapshot.HardLimitHitTime),
+		snapshot.UpdatedAt.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return cost.Snapshot{}, fmt.Errorf("sqlite: upsert budget snapshot %s %q: %w", snapshot.Scope, snapshot.ScopeID, err)
+	}
+	return snapshot, nil
+}
+
+func parseOptionalBudgetTimes(snapshot *cost.Snapshot, lastEventTime, softLimitHitAt, hardLimitHitAt, updatedAt string) error {
+	var err error
+	if lastEventTime != "" {
+		snapshot.LastEventTime, err = time.Parse(time.RFC3339Nano, lastEventTime)
+		if err != nil {
+			return fmt.Errorf("sqlite: parse budget last_event_time: %w", err)
+		}
+	}
+	if softLimitHitAt != "" {
+		snapshot.SoftLimitHitTime, err = time.Parse(time.RFC3339Nano, softLimitHitAt)
+		if err != nil {
+			return fmt.Errorf("sqlite: parse budget soft_limit_hit_time: %w", err)
+		}
+	}
+	if hardLimitHitAt != "" {
+		snapshot.HardLimitHitTime, err = time.Parse(time.RFC3339Nano, hardLimitHitAt)
+		if err != nil {
+			return fmt.Errorf("sqlite: parse budget hard_limit_hit_time: %w", err)
+		}
+	}
+	snapshot.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt)
+	if err != nil {
+		return fmt.Errorf("sqlite: parse budget updated_at: %w", err)
+	}
+	return nil
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/storage/sqlite/cost_telemetry_test.go
+++ b/internal/storage/sqlite/cost_telemetry_test.go
@@ -1,0 +1,117 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/earchibald/rein/internal/cost"
+)
+
+func TestStoreCostTelemetryRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestStore(t, ctx)
+
+	first, err := store.AppendCostEvent(ctx, cost.Event{
+		ID:          "evt-1",
+		Name:        "adapter.turn.completed",
+		Time:        time.Date(2026, time.May, 2, 18, 0, 0, 0, time.UTC),
+		ProjectID:   "project-rein",
+		IssueID:     "RN-13",
+		ExecutionID: "exec-rn-13-001",
+		AdapterID:   "coding-copilot-fake",
+		Currency:    "USD",
+		CostMicros:  1200,
+		Usage: cost.Usage{
+			InputTokens:  200,
+			OutputTokens: 80,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendCostEvent() first error = %v", err)
+	}
+	second, err := store.AppendCostEvent(ctx, cost.Event{
+		ID:          "evt-2",
+		Name:        "adapter.turn.completed",
+		Time:        time.Date(2026, time.May, 2, 18, 1, 0, 0, time.UTC),
+		ProjectID:   "project-rein",
+		IssueID:     "RN-13",
+		ExecutionID: "exec-rn-13-001",
+		AdapterID:   "review-bot-fake",
+		Currency:    "USD",
+		CostMicros:  900,
+	})
+	if err != nil {
+		t.Fatalf("AppendCostEvent() second error = %v", err)
+	}
+
+	events, err := store.ListCostEvents(ctx, CostEventFilter{ExecutionID: "exec-rn-13-001"})
+	if err != nil {
+		t.Fatalf("ListCostEvents() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ListCostEvents() count = %d, want 2", len(events))
+	}
+	if events[0].ID != first.ID || events[0].Sequence != 1 {
+		t.Fatalf("ListCostEvents()[0] = %+v", events[0])
+	}
+	if events[1].ID != second.ID || events[1].Sequence != 2 {
+		t.Fatalf("ListCostEvents()[1] = %+v", events[1])
+	}
+}
+
+func TestStoreBudgetSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestStore(t, ctx)
+	updatedAt := time.Date(2026, time.May, 2, 19, 0, 0, 0, time.UTC)
+
+	created, err := store.UpsertBudgetSnapshot(ctx, cost.Snapshot{
+		Scope:            cost.ScopeExecution,
+		ScopeID:          "exec-rn-13-001",
+		Currency:         "USD",
+		SoftLimitMicros:  1000,
+		HardLimitMicros:  5000,
+		SpentMicros:      1200,
+		Usage:            cost.Usage{InputTokens: 200, OutputTokens: 80},
+		EventCount:       1,
+		LastEventID:      "evt-1",
+		LastEventTime:    updatedAt,
+		SoftLimitHitTime: updatedAt,
+		UpdatedAt:        updatedAt,
+	})
+	if err != nil {
+		t.Fatalf("UpsertBudgetSnapshot() create error = %v", err)
+	}
+
+	got, found, err := store.GetBudgetSnapshot(ctx, cost.ScopeExecution, "exec-rn-13-001")
+	if err != nil {
+		t.Fatalf("GetBudgetSnapshot() error = %v", err)
+	}
+	if !found {
+		t.Fatal("GetBudgetSnapshot() found = false, want true")
+	}
+	if got.SpentMicros != created.SpentMicros || got.LastEventID != created.LastEventID {
+		t.Fatalf("GetBudgetSnapshot() = %+v, want %+v", got, created)
+	}
+
+	got.SpentMicros = 5200
+	got.EventCount = 2
+	got.LastEventID = "evt-2"
+	got.HardLimitHitTime = updatedAt.Add(time.Minute)
+	got.UpdatedAt = updatedAt.Add(time.Minute)
+	if _, err := store.UpsertBudgetSnapshot(ctx, got); err != nil {
+		t.Fatalf("UpsertBudgetSnapshot() update error = %v", err)
+	}
+
+	updated, found, err := store.GetBudgetSnapshot(ctx, cost.ScopeExecution, "exec-rn-13-001")
+	if err != nil {
+		t.Fatalf("GetBudgetSnapshot() after update error = %v", err)
+	}
+	if !found || !updated.HardLimited() || updated.EventCount != 2 {
+		t.Fatalf("updated snapshot = %+v", updated)
+	}
+}

--- a/internal/storage/sqlite/migrate_test.go
+++ b/internal/storage/sqlite/migrate_test.go
@@ -37,6 +37,8 @@ func TestMigrateUpAndDown(t *testing.T) {
 		"tasksteps",
 		"sideeffects",
 		"costevents",
+		"costeventlog",
+		"budgetstates",
 		"settings",
 		"featureflags",
 	} {
@@ -64,6 +66,8 @@ func TestMigrateUpAndDown(t *testing.T) {
 		"tasksteps",
 		"sideeffects",
 		"costevents",
+		"costeventlog",
+		"budgetstates",
 		"settings",
 		"featureflags",
 	} {
@@ -79,7 +83,7 @@ func TestMigrateDownStepsRejectsInvalidStepCount(t *testing.T) {
 	}
 }
 
-func TestMigrateDownStepsDropsSchema(t *testing.T) {
+func TestMigrateDownStepsDropsLatestMigration(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -94,7 +98,9 @@ func TestMigrateDownStepsDropsSchema(t *testing.T) {
 		t.Fatalf("MigrateDownSteps() error = %v", err)
 	}
 
-	assertTableExists(t, store.DB(), "projects", false)
+	assertTableExists(t, store.DB(), "projects", true)
+	assertTableExists(t, store.DB(), "costeventlog", false)
+	assertTableExists(t, store.DB(), "budgetstates", false)
 
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)

--- a/internal/storage/sqlite/migrations/000002_cost_telemetry.down.sql
+++ b/internal/storage/sqlite/migrations/000002_cost_telemetry.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS budgetstates;
+DROP TABLE IF EXISTS costeventlog;

--- a/internal/storage/sqlite/migrations/000002_cost_telemetry.up.sql
+++ b/internal/storage/sqlite/migrations/000002_cost_telemetry.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS costeventlog (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    event_name TEXT NOT NULL,
+    event_time TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    issue_id TEXT,
+    execution_id TEXT,
+    workflow_id TEXT,
+    adapter_id TEXT,
+    currency TEXT NOT NULL,
+    cost_micros INTEGER NOT NULL CHECK (cost_micros >= 0),
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_read_tokens >= 0),
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_write_tokens >= 0),
+    resource_attributes TEXT NOT NULL CHECK (json_valid(resource_attributes)),
+    attributes TEXT NOT NULL CHECK (json_valid(attributes)),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_costeventlog_project_time ON costeventlog(project_id, event_time, sequence);
+CREATE INDEX IF NOT EXISTS idx_costeventlog_issue_time ON costeventlog(issue_id, event_time, sequence);
+CREATE INDEX IF NOT EXISTS idx_costeventlog_execution_time ON costeventlog(execution_id, event_time, sequence);
+
+CREATE TABLE IF NOT EXISTS budgetstates (
+    scope TEXT NOT NULL CHECK (scope IN ('project', 'issue', 'execution')),
+    scope_id TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    soft_limit_micros INTEGER NOT NULL DEFAULT 0 CHECK (soft_limit_micros >= 0),
+    hard_limit_micros INTEGER NOT NULL DEFAULT 0 CHECK (hard_limit_micros >= 0),
+    spent_micros INTEGER NOT NULL DEFAULT 0 CHECK (spent_micros >= 0),
+    input_tokens INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_read_tokens >= 0),
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0 CHECK (cache_write_tokens >= 0),
+    event_count INTEGER NOT NULL DEFAULT 0 CHECK (event_count >= 0),
+    last_event_id TEXT NOT NULL DEFAULT '',
+    last_event_time TEXT NOT NULL DEFAULT '',
+    soft_limit_hit_time TEXT NOT NULL DEFAULT '',
+    hard_limit_hit_time TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (scope, scope_id),
+    CHECK (hard_limit_micros = 0 OR soft_limit_micros = 0 OR soft_limit_micros <= hard_limit_micros)
+);
+
+CREATE INDEX IF NOT EXISTS idx_budgetstates_updated_at ON budgetstates(updated_at);
+CREATE INDEX IF NOT EXISTS idx_budgetstates_hard_limit_hit_time ON budgetstates(hard_limit_hit_time);


### PR DESCRIPTION
## Summary
- add OTLP-aligned cost telemetry event/budget models and in-process fan-out
- persist append-only cost events plus projected project/issue/execution budget state in SQLite
- exercise successful telemetry capture and hard-budget launch blocking in the managed-flow harness

Closes #13