### PR TITLE
RN-11: Add adapter registry and loader

### DIFF
--- a/cmd/rein/main.go
+++ b/cmd/rein/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/earchibald/rein/internal/adapter"
 	"github.com/earchibald/rein/internal/server"
 	"github.com/earchibald/rein/internal/service"
 )
@@ -43,9 +44,13 @@ func run() int {
 		}
 	}()
 
-	runtime := server.New(server.Options{
-		Services: service.NewSet(),
-	})
+	services, err := service.NewSetFromRoot(".", adapter.DiscoveryOptions{})
+	if err != nil {
+		logger.Error("failed to load adapter registry", "error", err)
+		return 1
+	}
+
+	runtime := server.New(server.Options{Services: services})
 
 	logger.Info("rein gRPC server starting", "network", *network, "address", listener.Addr().String())
 	logger.Info(

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -1,0 +1,630 @@
+package adapter
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+const CurrentDaemonAPIVersion = "rein.v1"
+
+var shaPattern = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
+
+type Category string
+
+const (
+	CategoryCodingAgent Category = "codingAgent"
+	CategoryMux         Category = "mux"
+	CategoryTracker     Category = "tracker"
+	CategoryMessaging   Category = "messaging"
+	CategoryProjection  Category = "projection"
+)
+
+type Taxonomy struct {
+	Marketplace Category
+	Proto       reinv1.AdapterCategory
+	Alias       string
+}
+
+type DiscoveryOptions struct {
+	DaemonAPIVersion   string
+	AllowUnsignedIndex bool
+	TrustedKeys        map[string]ed25519.PublicKey
+}
+
+type Registry struct {
+	marketplaceName string
+	entries         map[string]Entry
+}
+
+type Entry struct {
+	ID                  string
+	MarketplaceCategory Category
+	Taxonomy            Taxonomy
+	Source              Source
+	Descriptor          *reinv1.Adapter
+	Requires            []string
+	Tail                bool
+}
+
+type SourceKind string
+
+const (
+	SourceLocal     SourceKind = "local"
+	SourceGitHub    SourceKind = "github"
+	SourceURL       SourceKind = "url"
+	SourceGitSubdir SourceKind = "git-subdir"
+	SourceNPM       SourceKind = "npm"
+)
+
+type Source struct {
+	Kind     SourceKind
+	Path     string
+	Repo     string
+	URL      string
+	Ref      string
+	SHA      string
+	Package  string
+	Version  string
+	Registry string
+}
+
+type marketplaceDocument struct {
+	Name      string              `json:"name"`
+	Plugins   []marketplacePlugin `json:"plugins"`
+	Signature *indexSignature     `json:"signature,omitempty"`
+}
+
+type marketplacePlugin struct {
+	Name             string            `json:"name"`
+	Source           json.RawMessage   `json:"source"`
+	Description      string            `json:"description,omitempty"`
+	Version          string            `json:"version,omitempty"`
+	Category         string            `json:"category,omitempty"`
+	Strict           *bool             `json:"strict,omitempty"`
+	DaemonAPIVersion string            `json:"daemonApiVersion,omitempty"`
+	Capabilities     map[string]string `json:"capabilities,omitempty"`
+	Tail             *bool             `json:"tail,omitempty"`
+	Requires         []string          `json:"requires,omitempty"`
+}
+
+type pluginManifest struct {
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	Version          string            `json:"version,omitempty"`
+	Category         string            `json:"category,omitempty"`
+	DaemonAPIVersion string            `json:"daemonApiVersion,omitempty"`
+	Capabilities     map[string]string `json:"capabilities,omitempty"`
+	Tail             *bool             `json:"tail,omitempty"`
+	Requires         []string          `json:"requires,omitempty"`
+}
+
+type indexSignature struct {
+	Algorithm string `json:"algorithm"`
+	KeyID     string `json:"keyId"`
+	Value     string `json:"value"`
+}
+
+type pluginRecord struct {
+	ID                  string
+	Description         string
+	Version             string
+	Category            string
+	DaemonAPIVersion    string
+	Capabilities        map[string]string
+	Tail                *bool
+	Requires            []string
+	MarketplaceCategory Category
+	Source              Source
+}
+
+func Load(root string, options DiscoveryOptions) (*Registry, error) {
+	options = options.withDefaults()
+
+	marketplacePath := filepath.Join(root, ".claude-plugin", "marketplace.json")
+	raw, err := os.ReadFile(marketplacePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Registry{entries: map[string]Entry{}}, nil
+		}
+		return nil, fmt.Errorf("read marketplace index: %w", err)
+	}
+
+	if err := verifyIndexSignature(raw, options); err != nil {
+		return nil, err
+	}
+
+	var document marketplaceDocument
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return nil, fmt.Errorf("decode marketplace index: %w", err)
+	}
+
+	registry := &Registry{
+		marketplaceName: document.Name,
+		entries:         make(map[string]Entry, len(document.Plugins)),
+	}
+
+	for _, plugin := range document.Plugins {
+		entry, err := loadPlugin(root, plugin, options)
+		if err != nil {
+			return nil, fmt.Errorf("load plugin %q: %w", plugin.Name, err)
+		}
+		if _, exists := registry.entries[entry.ID]; exists {
+			return nil, fmt.Errorf("load plugin %q: duplicate adapter id", plugin.Name)
+		}
+		registry.entries[entry.ID] = entry
+	}
+
+	return registry, nil
+}
+
+func NormalizeCategory(value string) (Taxonomy, error) {
+	normalized := strings.NewReplacer("-", "", "_", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(value)))
+	switch normalized {
+	case "codingagent":
+		return Taxonomy{Marketplace: CategoryCodingAgent, Proto: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT, Alias: aliasFor(value, string(CategoryCodingAgent))}, nil
+	case "mux", "multiplexer":
+		return Taxonomy{Marketplace: CategoryMux, Proto: reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER, Alias: aliasFor(value, string(CategoryMux))}, nil
+	case "tracker":
+		return Taxonomy{Marketplace: CategoryTracker, Proto: reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER}, nil
+	case "messaging", "notification":
+		return Taxonomy{Marketplace: CategoryMessaging, Proto: reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION, Alias: aliasFor(value, string(CategoryMessaging))}, nil
+	case "projection", "reviewagent":
+		return Taxonomy{Marketplace: CategoryProjection, Proto: reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT, Alias: aliasFor(value, string(CategoryProjection))}, nil
+	default:
+		return Taxonomy{}, fmt.Errorf("unsupported category %q", value)
+	}
+}
+
+func (r *Registry) List(category reinv1.AdapterCategory, enabledOnly bool) []*reinv1.Adapter {
+	if r == nil {
+		return nil
+	}
+
+	ids := make([]string, 0, len(r.entries))
+	for id := range r.entries {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	adapters := make([]*reinv1.Adapter, 0, len(ids))
+	for _, id := range ids {
+		entry := r.entries[id]
+		if category != reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED && entry.Descriptor.GetCategory() != category {
+			continue
+		}
+		if enabledOnly && !entry.Descriptor.GetEnabled() {
+			continue
+		}
+		adapters = append(adapters, proto.Clone(entry.Descriptor).(*reinv1.Adapter))
+	}
+
+	return adapters
+}
+
+func (r *Registry) Get(id string) (*reinv1.Adapter, bool) {
+	if r == nil {
+		return nil, false
+	}
+
+	entry, ok := r.entries[id]
+	if !ok {
+		return nil, false
+	}
+
+	return proto.Clone(entry.Descriptor).(*reinv1.Adapter), true
+}
+
+func (r *Registry) Entry(id string) (Entry, bool) {
+	if r == nil {
+		return Entry{}, false
+	}
+
+	entry, ok := r.entries[id]
+	if !ok {
+		return Entry{}, false
+	}
+
+	entry.Descriptor = proto.Clone(entry.Descriptor).(*reinv1.Adapter)
+	entry.Requires = append([]string(nil), entry.Requires...)
+	return entry, true
+}
+
+func ValidateDescriptor(adapter *reinv1.Adapter) []*reinv1.ValidationMessage {
+	if adapter == nil {
+		return []*reinv1.ValidationMessage{validationError("adapter", "adapter is required")}
+	}
+
+	var messages []*reinv1.ValidationMessage
+	if strings.TrimSpace(adapter.GetId()) == "" {
+		messages = append(messages, validationError("adapter.id", "adapter id is required"))
+	}
+	if strings.TrimSpace(adapter.GetName()) == "" {
+		messages = append(messages, validationError("adapter.name", "adapter name is required"))
+	}
+	if strings.TrimSpace(adapter.GetVersion()) == "" {
+		messages = append(messages, validationError("adapter.version", "adapter version is required"))
+	}
+
+	switch adapter.GetCategory() {
+	case reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+		reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT,
+		reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER,
+		reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION,
+		reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER:
+	default:
+		messages = append(messages, validationError("adapter.category", fmt.Sprintf("unsupported adapter category %s", adapter.GetCategory())))
+	}
+
+	if tail, ok := adapter.GetCapabilities()["tail"]; ok {
+		if _, err := strconv.ParseBool(tail); err != nil {
+			messages = append(messages, validationError("adapter.capabilities.tail", "tail must be a boolean string"))
+		}
+	}
+
+	if requires, ok := adapter.GetCapabilities()["requires"]; ok && strings.TrimSpace(requires) != "" {
+		var required []string
+		if err := json.Unmarshal([]byte(requires), &required); err != nil {
+			messages = append(messages, validationError("adapter.capabilities.requires", "requires must be a JSON array of strings"))
+		} else {
+			for _, capability := range required {
+				if strings.TrimSpace(capability) == "" {
+					messages = append(messages, validationError("adapter.capabilities.requires", "requires entries must be non-empty strings"))
+					break
+				}
+			}
+		}
+	}
+
+	return messages
+}
+
+func (o DiscoveryOptions) withDefaults() DiscoveryOptions {
+	if strings.TrimSpace(o.DaemonAPIVersion) == "" {
+		o.DaemonAPIVersion = CurrentDaemonAPIVersion
+	}
+	if o.TrustedKeys == nil {
+		o.TrustedKeys = map[string]ed25519.PublicKey{}
+	}
+	return o
+}
+
+func loadPlugin(root string, plugin marketplacePlugin, options DiscoveryOptions) (Entry, error) {
+	if strings.TrimSpace(plugin.Name) == "" {
+		return Entry{}, errors.New("name is required")
+	}
+
+	source, err := parseSource(plugin.Source)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	record := pluginRecord{
+		ID:               plugin.Name,
+		Description:      plugin.Description,
+		Version:          plugin.Version,
+		Category:         plugin.Category,
+		DaemonAPIVersion: plugin.DaemonAPIVersion,
+		Capabilities:     cloneCapabilities(plugin.Capabilities),
+		Tail:             cloneBool(plugin.Tail),
+		Requires:         append([]string(nil), plugin.Requires...),
+		Source:           source,
+	}
+
+	strict := true
+	if plugin.Strict != nil {
+		strict = *plugin.Strict
+	}
+
+	if source.Kind == SourceLocal {
+		manifest, err := loadPluginManifest(root, plugin.Name, source.Path)
+		if err != nil {
+			return Entry{}, err
+		}
+		if manifest != nil {
+			if manifest.Name != "" && manifest.Name != plugin.Name {
+				return Entry{}, fmt.Errorf("plugin manifest name %q does not match marketplace entry", manifest.Name)
+			}
+			manifestRecord := pluginRecord{
+				ID:               plugin.Name,
+				Description:      manifest.Description,
+				Version:          manifest.Version,
+				Category:         manifest.Category,
+				DaemonAPIVersion: manifest.DaemonAPIVersion,
+				Capabilities:     cloneCapabilities(manifest.Capabilities),
+				Tail:             cloneBool(manifest.Tail),
+				Requires:         append([]string(nil), manifest.Requires...),
+				Source:           source,
+			}
+			if strict {
+				record = overlayRecord(record, manifestRecord)
+			} else {
+				record = overlayRecord(manifestRecord, record)
+			}
+		}
+	}
+
+	if strings.TrimSpace(record.Version) == "" {
+		return Entry{}, errors.New("version is required")
+	}
+	if strings.TrimSpace(record.Category) == "" {
+		return Entry{}, errors.New("category is required")
+	}
+	if strings.TrimSpace(record.DaemonAPIVersion) == "" {
+		return Entry{}, errors.New("daemonApiVersion is required")
+	}
+	if record.DaemonAPIVersion != options.DaemonAPIVersion {
+		return Entry{}, fmt.Errorf("daemonApiVersion %q does not match daemon %q", record.DaemonAPIVersion, options.DaemonAPIVersion)
+	}
+
+	taxonomy, err := NormalizeCategory(record.Category)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	capabilities := cloneCapabilities(record.Capabilities)
+	if capabilities == nil {
+		capabilities = map[string]string{}
+	}
+	if len(record.Requires) > 0 {
+		encoded, err := json.Marshal(record.Requires)
+		if err != nil {
+			return Entry{}, fmt.Errorf("encode requires capability: %w", err)
+		}
+		capabilities["requires"] = string(encoded)
+	}
+	if record.Tail != nil {
+		capabilities["tail"] = strconv.FormatBool(*record.Tail)
+	}
+
+	descriptor := &reinv1.Adapter{
+		Id:           record.ID,
+		Name:         record.ID,
+		Category:     taxonomy.Proto,
+		Description:  record.Description,
+		Version:      record.Version,
+		Enabled:      true,
+		Capabilities: capabilities,
+	}
+
+	return Entry{
+		ID:                  record.ID,
+		MarketplaceCategory: taxonomy.Marketplace,
+		Taxonomy:            taxonomy,
+		Source:              source,
+		Descriptor:          descriptor,
+		Requires:            append([]string(nil), record.Requires...),
+		Tail:                record.Tail != nil && *record.Tail,
+	}, nil
+}
+
+func loadPluginManifest(root, pluginName, sourcePath string) (*pluginManifest, error) {
+	pluginRoot := filepath.Join(root, filepath.Clean(sourcePath))
+	manifestPath := filepath.Join(pluginRoot, ".claude-plugin", "plugin.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read plugin manifest for %q: %w", pluginName, err)
+	}
+
+	var manifest pluginManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, fmt.Errorf("decode plugin manifest for %q: %w", pluginName, err)
+	}
+
+	return &manifest, nil
+}
+
+func parseSource(raw json.RawMessage) (Source, error) {
+	var localPath string
+	if err := json.Unmarshal(raw, &localPath); err == nil {
+		if err := validateLocalPath(localPath); err != nil {
+			return Source{}, err
+		}
+		return Source{Kind: SourceLocal, Path: localPath}, nil
+	}
+
+	var source struct {
+		Source   string `json:"source"`
+		Repo     string `json:"repo"`
+		URL      string `json:"url"`
+		Path     string `json:"path"`
+		Ref      string `json:"ref"`
+		SHA      string `json:"sha"`
+		Package  string `json:"package"`
+		Version  string `json:"version"`
+		Registry string `json:"registry"`
+	}
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return Source{}, fmt.Errorf("decode source: %w", err)
+	}
+
+	if source.SHA != "" && !shaPattern.MatchString(source.SHA) {
+		return Source{}, fmt.Errorf("invalid source sha %q", source.SHA)
+	}
+
+	switch source.Source {
+	case "github":
+		return Source{Kind: SourceGitHub, Repo: source.Repo, Ref: source.Ref, SHA: source.SHA}, nil
+	case "url":
+		return Source{Kind: SourceURL, URL: source.URL, Ref: source.Ref, SHA: source.SHA}, nil
+	case "git-subdir":
+		if err := validateGitSubdirPath(source.Path); err != nil {
+			return Source{}, err
+		}
+		return Source{Kind: SourceGitSubdir, URL: source.URL, Path: source.Path, Ref: source.Ref, SHA: source.SHA}, nil
+	case "npm":
+		return Source{Kind: SourceNPM, Package: source.Package, Version: source.Version, Registry: source.Registry}, nil
+	default:
+		return Source{}, fmt.Errorf("unsupported source kind %q", source.Source)
+	}
+}
+
+func verifyIndexSignature(raw []byte, options DiscoveryOptions) error {
+	var envelope map[string]any
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode marketplace signature envelope: %w", err)
+	}
+
+	value, ok := envelope["signature"]
+	if !ok {
+		if options.AllowUnsignedIndex {
+			return nil
+		}
+		return errors.New("marketplace index signature is required")
+	}
+
+	signatureMap, ok := value.(map[string]any)
+	if !ok {
+		return errors.New("marketplace index signature must be an object")
+	}
+
+	algorithm, _ := signatureMap["algorithm"].(string)
+	if algorithm != "ed25519" {
+		return fmt.Errorf("unsupported marketplace signature algorithm %q", algorithm)
+	}
+
+	keyID, _ := signatureMap["keyId"].(string)
+	if strings.TrimSpace(keyID) == "" {
+		return errors.New("marketplace index signature keyId is required")
+	}
+
+	signatureValue, _ := signatureMap["value"].(string)
+	if strings.TrimSpace(signatureValue) == "" {
+		return errors.New("marketplace index signature value is required")
+	}
+
+	publicKey, ok := options.TrustedKeys[keyID]
+	if !ok {
+		return fmt.Errorf("trusted key %q is not configured", keyID)
+	}
+
+	delete(envelope, "signature")
+	canonical, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("canonicalize marketplace index: %w", err)
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(signatureValue)
+	if err != nil {
+		return fmt.Errorf("decode marketplace signature: %w", err)
+	}
+
+	if !ed25519.Verify(publicKey, canonical, signature) {
+		return errors.New("marketplace index signature verification failed")
+	}
+
+	return nil
+}
+
+func validationError(field, message string) *reinv1.ValidationMessage {
+	return &reinv1.ValidationMessage{
+		Severity: reinv1.ValidationMessage_SEVERITY_ERROR,
+		Field:    field,
+		Message:  message,
+	}
+}
+
+func overlayRecord(base, override pluginRecord) pluginRecord {
+	if strings.TrimSpace(override.Description) != "" {
+		base.Description = override.Description
+	}
+	if strings.TrimSpace(override.Version) != "" {
+		base.Version = override.Version
+	}
+	if strings.TrimSpace(override.Category) != "" {
+		base.Category = override.Category
+	}
+	if strings.TrimSpace(override.DaemonAPIVersion) != "" {
+		base.DaemonAPIVersion = override.DaemonAPIVersion
+	}
+	if len(override.Capabilities) > 0 {
+		if base.Capabilities == nil {
+			base.Capabilities = map[string]string{}
+		}
+		for key, value := range override.Capabilities {
+			base.Capabilities[key] = value
+		}
+	}
+	if override.Tail != nil {
+		base.Tail = cloneBool(override.Tail)
+	}
+	if len(override.Requires) > 0 {
+		base.Requires = append([]string(nil), override.Requires...)
+	}
+	return base
+}
+
+func cloneCapabilities(capabilities map[string]string) map[string]string {
+	if len(capabilities) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(capabilities))
+	for key, value := range capabilities {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneBool(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}
+
+func validateLocalPath(path string) error {
+	if !strings.HasPrefix(path, "./") {
+		return fmt.Errorf("relative source path %q must start with ./", path)
+	}
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("relative source path %q must not be absolute", path)
+	}
+
+	clean := filepath.Clean(path)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("relative source path %q must stay within the marketplace root", path)
+	}
+
+	return nil
+}
+
+func validateGitSubdirPath(path string) error {
+	if path == "" {
+		return errors.New("git-subdir source path is required")
+	}
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("git-subdir path %q must not be absolute", path)
+	}
+
+	clean := filepath.Clean(path)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("git-subdir path %q must stay within the repository root", path)
+	}
+
+	return nil
+}
+
+func aliasFor(got, canonical string) string {
+	if strings.EqualFold(strings.TrimSpace(got), canonical) {
+		return ""
+	}
+	return got
+}

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -1,0 +1,346 @@
+package adapter
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+)
+
+func TestLoadSignedMarketplace(t *testing.T) {
+	t.Parallel()
+
+	root := writeMarketplaceFixture(t, fixtureOptions{Signed: true})
+	registry, err := Load(root, DiscoveryOptions{TrustedKeys: trustedKeys()})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got, want := adapterIDs(registry.List(reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED, false)), []string{"coding-local", "messaging-local", "mux-local", "projection-local", "tracker-remote"}; !slices.Equal(got, want) {
+		t.Fatalf("List() ids = %v, want %v", got, want)
+	}
+
+	coding, ok := registry.Entry("coding-local")
+	if !ok {
+		t.Fatal("Entry(coding-local) = !ok")
+	}
+	if got := coding.Descriptor.GetVersion(); got != "1.2.3" {
+		t.Fatalf("coding version = %q, want %q", got, "1.2.3")
+	}
+	if got := coding.Descriptor.GetCapabilities()["local.manifest"]; got != "true" {
+		t.Fatalf("coding capabilities[local.manifest] = %q, want %q", got, "true")
+	}
+
+	messaging, ok := registry.Entry("messaging-local")
+	if !ok {
+		t.Fatal("Entry(messaging-local) = !ok")
+	}
+	if got := messaging.Descriptor.GetCategory(); got != reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION {
+		t.Fatalf("messaging category = %s, want %s", got, reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION)
+	}
+
+	projection, ok := registry.Entry("projection-local")
+	if !ok {
+		t.Fatal("Entry(projection-local) = !ok")
+	}
+	if projection.MarketplaceCategory != CategoryProjection {
+		t.Fatalf("projection marketplace category = %q, want %q", projection.MarketplaceCategory, CategoryProjection)
+	}
+	if got := projection.Descriptor.GetCategory(); got != reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT {
+		t.Fatalf("projection proto category = %s, want %s", got, reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT)
+	}
+	if !projection.Tail {
+		t.Fatal("projection tail = false, want true")
+	}
+	if got := projection.Descriptor.GetCapabilities()["requires"]; got != `["messaging.post"]` {
+		t.Fatalf("projection requires capability = %q, want %q", got, `["messaging.post"]`)
+	}
+
+	tracker, ok := registry.Entry("tracker-remote")
+	if !ok {
+		t.Fatal("Entry(tracker-remote) = !ok")
+	}
+	if tracker.Source.Kind != SourceGitHub {
+		t.Fatalf("tracker source kind = %q, want %q", tracker.Source.Kind, SourceGitHub)
+	}
+}
+
+func TestLoadRejectsUnsignedMarketplaceByDefault(t *testing.T) {
+	t.Parallel()
+
+	root := writeMarketplaceFixture(t, fixtureOptions{})
+	_, err := Load(root, DiscoveryOptions{TrustedKeys: trustedKeys()})
+	if err == nil || err.Error() != "marketplace index signature is required" {
+		t.Fatalf("Load() error = %v, want %q", err, "marketplace index signature is required")
+	}
+}
+
+func TestLoadAllowsUnsignedMarketplaceWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	root := writeMarketplaceFixture(t, fixtureOptions{})
+	registry, err := Load(root, DiscoveryOptions{
+		AllowUnsignedIndex: true,
+		TrustedKeys:        trustedKeys(),
+	})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := len(registry.List(reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED, false)), 5; got != want {
+		t.Fatalf("len(List()) = %d, want %d", got, want)
+	}
+}
+
+func TestLoadRejectsDaemonAPIVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	root := writeMarketplaceFixture(t, fixtureOptions{Signed: true, MismatchDaemonVersion: true})
+	_, err := Load(root, DiscoveryOptions{TrustedKeys: trustedKeys()})
+	want := `load plugin "projection-local": daemonApiVersion "rein.v2" does not match daemon "rein.v1"`
+	if err == nil || err.Error() != want {
+		t.Fatalf("Load() error = %v, want %q", err, want)
+	}
+}
+
+func TestNormalizeCategoryAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  Taxonomy
+	}{
+		{
+			input: "coding_agent",
+			want: Taxonomy{
+				Marketplace: CategoryCodingAgent,
+				Proto:       reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+				Alias:       "coding_agent",
+			},
+		},
+		{
+			input: "multiplexer",
+			want: Taxonomy{
+				Marketplace: CategoryMux,
+				Proto:       reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER,
+				Alias:       "multiplexer",
+			},
+		},
+		{
+			input: "notification",
+			want: Taxonomy{
+				Marketplace: CategoryMessaging,
+				Proto:       reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION,
+				Alias:       "notification",
+			},
+		},
+		{
+			input: "review_agent",
+			want: Taxonomy{
+				Marketplace: CategoryProjection,
+				Proto:       reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT,
+				Alias:       "review_agent",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NormalizeCategory(tt.input)
+			if err != nil {
+				t.Fatalf("NormalizeCategory() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeCategory() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func adapterIDs(adapters []*reinv1.Adapter) []string {
+	ids := make([]string, 0, len(adapters))
+	for _, adapter := range adapters {
+		ids = append(ids, adapter.GetId())
+	}
+	return ids
+}
+
+type fixtureOptions struct {
+	Signed                bool
+	MismatchDaemonVersion bool
+}
+
+func writeMarketplaceFixture(t *testing.T, options fixtureOptions) string {
+	t.Helper()
+
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, ".claude-plugin"))
+
+	writePluginManifest(t, root, "coding-local", map[string]any{
+		"name":             "coding-local",
+		"version":          "1.2.3",
+		"description":      "Local coding adapter manifest",
+		"category":         "codingAgent",
+		"daemonApiVersion": CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"patch.apply":    "true",
+			"local.manifest": "true",
+		},
+	})
+	writePluginManifest(t, root, "mux-local", map[string]any{
+		"name":             "mux-local",
+		"version":          "0.4.0",
+		"description":      "Local mux adapter manifest",
+		"category":         "mux",
+		"daemonApiVersion": CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"session.attach": "true",
+		},
+	})
+	writePluginManifest(t, root, "messaging-local", map[string]any{
+		"name":             "messaging-local",
+		"version":          "0.6.0",
+		"description":      "Local messaging adapter manifest",
+		"category":         "messaging",
+		"daemonApiVersion": CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"messaging.post": "true",
+		},
+	})
+	writePluginManifest(t, root, "projection-local", map[string]any{
+		"name":             "projection-local",
+		"version":          "0.9.0",
+		"description":      "Local projection adapter manifest",
+		"category":         "projection",
+		"daemonApiVersion": daemonVersion(options.MismatchDaemonVersion),
+		"tail":             true,
+		"requires":         []string{"messaging.post"},
+		"capabilities": map[string]string{
+			"projection.sync": "true",
+		},
+	})
+
+	document := map[string]any{
+		"name": "rein-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             "coding-local",
+				"source":           "./plugins/coding-local",
+				"version":          "0.1.0",
+				"description":      "Marketplace fallback coding metadata",
+				"category":         "codingAgent",
+				"daemonApiVersion": CurrentDaemonAPIVersion,
+				"capabilities": map[string]string{
+					"patch.apply": "true",
+				},
+			},
+			map[string]any{
+				"name":             "mux-local",
+				"source":           "./plugins/mux-local",
+				"version":          "0.4.0",
+				"description":      "Marketplace mux metadata",
+				"category":         "mux",
+				"daemonApiVersion": CurrentDaemonAPIVersion,
+			},
+			map[string]any{
+				"name":             "tracker-remote",
+				"source":           map[string]any{"source": "github", "repo": "example/tracker", "sha": "0123456789abcdef0123456789abcdef01234567"},
+				"version":          "1.0.0",
+				"description":      "Remote tracker metadata",
+				"category":         "tracker",
+				"daemonApiVersion": CurrentDaemonAPIVersion,
+				"capabilities": map[string]string{
+					"issue.sync": "true",
+				},
+			},
+			map[string]any{
+				"name":             "messaging-local",
+				"source":           "./plugins/messaging-local",
+				"version":          "0.6.0",
+				"description":      "Marketplace messaging metadata",
+				"category":         "messaging",
+				"daemonApiVersion": CurrentDaemonAPIVersion,
+			},
+			map[string]any{
+				"name":             "projection-local",
+				"source":           "./plugins/projection-local",
+				"version":          "0.9.0",
+				"description":      "Marketplace projection metadata",
+				"category":         "projection",
+				"daemonApiVersion": daemonVersion(options.MismatchDaemonVersion),
+				"tail":             true,
+				"requires":         []string{"messaging.post"},
+			},
+		},
+	}
+
+	if options.Signed {
+		canonical, err := json.Marshal(document)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		signature := ed25519.Sign(privateKey(), canonical)
+		document["signature"] = map[string]any{
+			"algorithm": "ed25519",
+			"keyId":     "test-key",
+			"value":     base64.StdEncoding.EncodeToString(signature),
+		}
+	}
+
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+
+	return root
+}
+
+func writePluginManifest(t *testing.T, root, name string, manifest map[string]any) {
+	t.Helper()
+
+	manifestDir := filepath.Join(root, "plugins", name, ".claude-plugin")
+	mustMkdirAll(t, manifestDir)
+
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(plugin.json) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json) error = %v", err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+}
+
+func daemonVersion(mismatch bool) string {
+	if mismatch {
+		return "rein.v2"
+	}
+	return CurrentDaemonAPIVersion
+}
+
+func trustedKeys() map[string]ed25519.PublicKey {
+	return map[string]ed25519.PublicKey{
+		"test-key": privateKey().Public().(ed25519.PublicKey),
+	}
+}
+
+func privateKey() ed25519.PrivateKey {
+	seed := []byte("rein-rn11-marketplace-signing-se")
+	return ed25519.NewKeyFromSeed(seed)
+}

--- a/internal/server/grpc_contract_test.go
+++ b/internal/server/grpc_contract_test.go
@@ -127,20 +127,26 @@ func TestRuntimeUnaryRPCErrorContracts(t *testing.T) {
 
 			reply := emptyReply(t, contract.output)
 			err := conn.Invoke(rpcCtx, contract.fullMethod, contract.newRequest(), reply)
-			if err == nil {
-				t.Fatal("Invoke() error = nil, want non-nil")
-			}
+			expectation := unaryExpectation(contract)
+			if expectation.code == codes.OK {
+				if err != nil {
+					t.Fatalf("%s error = %v, want nil", contract.fullMethod, err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("Invoke() error = nil, want non-nil")
+				}
 
-			st, ok := status.FromError(err)
-			if !ok {
-				t.Fatalf("status.FromError(%v) = !ok", err)
-			}
-			if st.Code() != codes.Unimplemented {
-				t.Fatalf("%s code = %v, want %v", contract.fullMethod, st.Code(), codes.Unimplemented)
-			}
-			wantMessage := "method " + contract.method + " not implemented"
-			if st.Message() != wantMessage {
-				t.Fatalf("%s message = %q, want %q", contract.fullMethod, st.Message(), wantMessage)
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("status.FromError(%v) = !ok", err)
+				}
+				if st.Code() != expectation.code {
+					t.Fatalf("%s code = %v, want %v", contract.fullMethod, st.Code(), expectation.code)
+				}
+				if st.Message() != expectation.message {
+					t.Fatalf("%s message = %q, want %q", contract.fullMethod, st.Message(), expectation.message)
+				}
 			}
 
 			mu.Lock()
@@ -155,6 +161,27 @@ func TestRuntimeUnaryRPCErrorContracts(t *testing.T) {
 	cancel()
 	if err := <-errCh; err != nil {
 		t.Fatalf("Serve() error = %v", err)
+	}
+}
+
+type unaryRPCExpectation struct {
+	code    codes.Code
+	message string
+}
+
+func unaryExpectation(contract grpcContract) unaryRPCExpectation {
+	switch contract.fullMethod {
+	case reinv1.AdapterService_ListAdapters_FullMethodName:
+		return unaryRPCExpectation{code: codes.OK}
+	case reinv1.AdapterService_GetAdapter_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.AdapterService_ValidateAdapter_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "adapter is required"}
+	default:
+		return unaryRPCExpectation{
+			code:    codes.Unimplemented,
+			message: "method " + contract.method + " not implemented",
+		}
 	}
 }
 

--- a/internal/service/adapter_server.go
+++ b/internal/service/adapter_server.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+)
+
+type AdapterServer struct {
+	reinv1.UnimplementedAdapterServiceServer
+	registry *adapter.Registry
+	loadErr  error
+}
+
+func NewAdapterServerFromRoot(root string, options adapter.DiscoveryOptions) (*AdapterServer, error) {
+	registry, err := adapter.Load(root, options)
+	server := &AdapterServer{
+		registry: registry,
+		loadErr:  err,
+	}
+	return server, err
+}
+
+func (s *AdapterServer) ListAdapters(_ context.Context, req *reinv1.ListAdaptersRequest) (*reinv1.ListAdaptersResponse, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+
+	return &reinv1.ListAdaptersResponse{
+		Adapters: s.registry.List(req.GetCategory(), req.GetEnabledOnly()),
+	}, nil
+}
+
+func (s *AdapterServer) GetAdapter(_ context.Context, req *reinv1.GetAdapterRequest) (*reinv1.GetAdapterResponse, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+
+	descriptor, ok := s.registry.Get(req.GetId())
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "adapter %q not found", req.GetId())
+	}
+
+	return &reinv1.GetAdapterResponse{Adapter: descriptor}, nil
+}
+
+func (s *AdapterServer) ValidateAdapter(_ context.Context, req *reinv1.ValidateAdapterRequest) (*reinv1.ValidateAdapterResponse, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	if req.GetAdapter() == nil {
+		return nil, status.Error(codes.InvalidArgument, "adapter is required")
+	}
+
+	messages := adapter.ValidateDescriptor(req.GetAdapter())
+	return &reinv1.ValidateAdapterResponse{
+		Valid:    len(messages) == 0,
+		Messages: messages,
+	}, nil
+}
+
+func (s *AdapterServer) ready() error {
+	if s == nil {
+		return status.Error(codes.FailedPrecondition, "adapter registry is not configured")
+	}
+	if s.loadErr != nil {
+		return status.Errorf(codes.FailedPrecondition, "adapter registry unavailable: %v", s.loadErr)
+	}
+	return nil
+}

--- a/internal/service/adapter_server_test.go
+++ b/internal/service/adapter_server_test.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+)
+
+func TestAdapterServerListGetValidate(t *testing.T) {
+	t.Parallel()
+
+	root := writeServiceFixture(t, false)
+	server, err := NewAdapterServerFromRoot(root, adapter.DiscoveryOptions{TrustedKeys: serviceTrustedKeys()})
+	if err != nil {
+		t.Fatalf("NewAdapterServerFromRoot() error = %v", err)
+	}
+
+	listResp, err := server.ListAdapters(context.Background(), &reinv1.ListAdaptersRequest{
+		Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION,
+	})
+	if err != nil {
+		t.Fatalf("ListAdapters() error = %v", err)
+	}
+	if got, want := serviceAdapterIDs(listResp.GetAdapters()), []string{"messaging-local"}; !slices.Equal(got, want) {
+		t.Fatalf("ListAdapters() ids = %v, want %v", got, want)
+	}
+
+	getResp, err := server.GetAdapter(context.Background(), &reinv1.GetAdapterRequest{Id: "projection-local"})
+	if err != nil {
+		t.Fatalf("GetAdapter() error = %v", err)
+	}
+	if got := getResp.GetAdapter().GetCategory(); got != reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT {
+		t.Fatalf("GetAdapter() category = %s, want %s", got, reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT)
+	}
+
+	validateResp, err := server.ValidateAdapter(context.Background(), &reinv1.ValidateAdapterRequest{
+		Adapter: &reinv1.Adapter{
+			Id:       "broken",
+			Name:     "broken",
+			Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION,
+			Version:  "1.0.0",
+			Capabilities: map[string]string{
+				"tail": "definitely",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateAdapter() error = %v", err)
+	}
+	if validateResp.GetValid() {
+		t.Fatal("ValidateAdapter() valid = true, want false")
+	}
+	if got, want := validateResp.GetMessages()[0].GetField(), "adapter.capabilities.tail"; got != want {
+		t.Fatalf("ValidateAdapter() first field = %q, want %q", got, want)
+	}
+}
+
+func TestAdapterServerPropagatesRegistryLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	root := writeServiceFixture(t, true)
+	server, err := NewAdapterServerFromRoot(root, adapter.DiscoveryOptions{TrustedKeys: serviceTrustedKeys()})
+	if err == nil {
+		t.Fatal("NewAdapterServerFromRoot() error = nil, want non-nil")
+	}
+
+	_, rpcErr := server.ListAdapters(context.Background(), &reinv1.ListAdaptersRequest{})
+	if status.Code(rpcErr) != codes.FailedPrecondition {
+		t.Fatalf("ListAdapters() status = %v, want %v", status.Code(rpcErr), codes.FailedPrecondition)
+	}
+}
+
+func serviceAdapterIDs(adapters []*reinv1.Adapter) []string {
+	ids := make([]string, 0, len(adapters))
+	for _, adapter := range adapters {
+		ids = append(ids, adapter.GetId())
+	}
+	return ids
+}
+
+func writeServiceFixture(t *testing.T, mismatch bool) string {
+	t.Helper()
+
+	root := t.TempDir()
+	mustServiceMkdirAll(t, filepath.Join(root, ".claude-plugin"))
+
+	writeServiceManifest(t, root, "messaging-local", map[string]any{
+		"name":             "messaging-local",
+		"version":          "0.6.0",
+		"description":      "Messaging plugin",
+		"category":         "messaging",
+		"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+	})
+	writeServiceManifest(t, root, "projection-local", map[string]any{
+		"name":             "projection-local",
+		"version":          "0.9.0",
+		"description":      "Projection plugin",
+		"category":         "projection",
+		"daemonApiVersion": serviceDaemonVersion(mismatch),
+		"tail":             true,
+		"requires":         []string{"messaging.post"},
+	})
+
+	document := map[string]any{
+		"name": "rein-service-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             "messaging-local",
+				"source":           "./plugins/messaging-local",
+				"version":          "0.6.0",
+				"category":         "messaging",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+			},
+			map[string]any{
+				"name":             "projection-local",
+				"source":           "./plugins/projection-local",
+				"version":          "0.9.0",
+				"category":         "projection",
+				"daemonApiVersion": serviceDaemonVersion(mismatch),
+				"tail":             true,
+				"requires":         []string{"messaging.post"},
+			},
+		},
+	}
+
+	canonical, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	document["signature"] = map[string]any{
+		"algorithm": "ed25519",
+		"keyId":     "test-key",
+		"value":     base64.StdEncoding.EncodeToString(ed25519.Sign(servicePrivateKey(), canonical)),
+	}
+
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+
+	return root
+}
+
+func writeServiceManifest(t *testing.T, root, name string, manifest map[string]any) {
+	t.Helper()
+
+	manifestDir := filepath.Join(root, "plugins", name, ".claude-plugin")
+	mustServiceMkdirAll(t, manifestDir)
+
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(plugin.json) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json) error = %v", err)
+	}
+}
+
+func mustServiceMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+}
+
+func serviceDaemonVersion(mismatch bool) string {
+	if mismatch {
+		return "rein.v2"
+	}
+	return adapter.CurrentDaemonAPIVersion
+}
+
+func serviceTrustedKeys() map[string]ed25519.PublicKey {
+	return map[string]ed25519.PublicKey{
+		"test-key": servicePrivateKey().Public().(ed25519.PublicKey),
+	}
+}
+
+func servicePrivateKey() ed25519.PrivateKey {
+	seed := []byte("rein-rn11-marketplace-signing-se")
+	return ed25519.NewKeyFromSeed(seed)
+}

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -1,6 +1,9 @@
 package service
 
-import reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+import (
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+)
 
 // Set contains the in-process gRPC service implementations registered by the
 // server runtime.
@@ -13,8 +16,9 @@ type Set struct {
 }
 
 func NewSet() Set {
+	adapterServer, _ := NewAdapterServerFromRoot(".", adapter.DiscoveryOptions{})
 	return Set{
-		Adapter:   AdapterServer{},
+		Adapter:   adapterServer,
 		Execution: ExecutionServer{},
 		Issue:     IssueServer{},
 		Project:   ProjectServer{},
@@ -22,9 +26,21 @@ func NewSet() Set {
 	}
 }
 
+func NewSetFromRoot(root string, options adapter.DiscoveryOptions) (Set, error) {
+	adapterServer, err := NewAdapterServerFromRoot(root, options)
+	return Set{
+		Adapter:   adapterServer,
+		Execution: ExecutionServer{},
+		Issue:     IssueServer{},
+		Project:   ProjectServer{},
+		Workflow:  WorkflowServer{},
+	}, err
+}
+
 func (s Set) WithDefaults() Set {
 	if s.Adapter == nil {
-		s.Adapter = AdapterServer{}
+		adapterServer, _ := NewAdapterServerFromRoot(".", adapter.DiscoveryOptions{})
+		s.Adapter = adapterServer
 	}
 	if s.Execution == nil {
 		s.Execution = ExecutionServer{}
@@ -40,10 +56,6 @@ func (s Set) WithDefaults() Set {
 	}
 
 	return s
-}
-
-type AdapterServer struct {
-	reinv1.UnimplementedAdapterServiceServer
 }
 
 type ExecutionServer struct {


### PR DESCRIPTION
## Summary
- add a signed marketplace adapter registry/loader with daemon API compatibility checks
- reconcile the five marketplace category labels onto the current generated adapter taxonomy
- wire the default AdapterService/startup path to the registry and cover it with loader/service tests

## Testing
- go test ./...
- just ci