### PR TITLE
Add SQLite-backed feature flag seam

### DIFF
--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -1,0 +1,89 @@
+package featureflags
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+var (
+	ErrAlreadyExists   = errors.New("featureflags: flag already exists")
+	ErrEmptyKey        = errors.New("featureflags: empty key")
+	ErrNilRepository   = errors.New("featureflags: nil repository")
+	ErrNotFound        = errors.New("featureflags: flag not found")
+	ErrVersionMismatch = errors.New("featureflags: lock version mismatch")
+)
+
+// Flag is the typed MVP feature-flag shape persisted by the repository.
+type Flag struct {
+	Key         string
+	Description string
+	Enabled     bool
+	LockVersion int64
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+func (f Flag) Normalize() (Flag, error) {
+	key := strings.TrimSpace(f.Key)
+	if key == "" {
+		return Flag{}, ErrEmptyKey
+	}
+
+	f.Key = key
+	f.Description = strings.TrimSpace(f.Description)
+	return f, nil
+}
+
+// Repository owns CRUD for persisted feature flags. A future Flipt-backed
+// implementation can satisfy the same contract without changing callers.
+type Repository interface {
+	Create(context.Context, Flag) (Flag, error)
+	Delete(context.Context, string, int64) error
+	Get(context.Context, string) (Flag, error)
+	List(context.Context) ([]Flag, error)
+	Update(context.Context, Flag) (Flag, error)
+}
+
+// EvaluationRequest leaves room for a future Flipt-backed evaluator to use
+// subject/context targeting while the SQLite MVP only resolves by Key.
+type EvaluationRequest struct {
+	Key        string
+	SubjectKey string
+	Attributes map[string]string
+}
+
+// Evaluator is the runtime seam for flag checks.
+type Evaluator interface {
+	EvaluateBoolean(context.Context, EvaluationRequest) (bool, error)
+}
+
+type repositoryEvaluator struct {
+	repo Repository
+}
+
+func NewRepositoryEvaluator(repo Repository) (Evaluator, error) {
+	if repo == nil {
+		return nil, ErrNilRepository
+	}
+
+	return repositoryEvaluator{repo: repo}, nil
+}
+
+func (e repositoryEvaluator) EvaluateBoolean(ctx context.Context, request EvaluationRequest) (bool, error) {
+	key := strings.TrimSpace(request.Key)
+	if key == "" {
+		return false, ErrEmptyKey
+	}
+
+	flag, err := e.repo.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return flag.Enabled, nil
+}

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -1,0 +1,110 @@
+package featureflags
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFlagNormalizeTrimsFields(t *testing.T) {
+	t.Parallel()
+
+	flag, err := (Flag{
+		Key:         " managed-flow ",
+		Description: " Gate managed flow steps ",
+	}).Normalize()
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+
+	if flag.Key != "managed-flow" {
+		t.Fatalf("Normalize() key = %q, want %q", flag.Key, "managed-flow")
+	}
+	if flag.Description != "Gate managed flow steps" {
+		t.Fatalf("Normalize() description = %q", flag.Description)
+	}
+}
+
+func TestFlagNormalizeRejectsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	if _, err := (Flag{Key: " \t "}).Normalize(); !errors.Is(err, ErrEmptyKey) {
+		t.Fatalf("Normalize() error = %v, want %v", err, ErrEmptyKey)
+	}
+}
+
+func TestNewRepositoryEvaluatorRejectsNilRepository(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewRepositoryEvaluator(nil); !errors.Is(err, ErrNilRepository) {
+		t.Fatalf("NewRepositoryEvaluator() error = %v, want %v", err, ErrNilRepository)
+	}
+}
+
+func TestRepositoryEvaluatorDefaultsMissingFlagsToDisabled(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := NewRepositoryEvaluator(stubRepository{getErr: ErrNotFound})
+	if err != nil {
+		t.Fatalf("NewRepositoryEvaluator() error = %v", err)
+	}
+
+	enabled, err := evaluator.EvaluateBoolean(context.Background(), EvaluationRequest{
+		Key:        "managed-flow",
+		SubjectKey: "user-123",
+		Attributes: map[string]string{"team": "core"},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateBoolean() error = %v", err)
+	}
+	if enabled {
+		t.Fatalf("EvaluateBoolean() = true, want false")
+	}
+}
+
+func TestRepositoryEvaluatorReturnsStoredBoolean(t *testing.T) {
+	t.Parallel()
+
+	evaluator, err := NewRepositoryEvaluator(stubRepository{
+		flag: Flag{Key: "managed-flow", Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("NewRepositoryEvaluator() error = %v", err)
+	}
+
+	enabled, err := evaluator.EvaluateBoolean(context.Background(), EvaluationRequest{Key: "managed-flow"})
+	if err != nil {
+		t.Fatalf("EvaluateBoolean() error = %v", err)
+	}
+	if !enabled {
+		t.Fatalf("EvaluateBoolean() = false, want true")
+	}
+}
+
+type stubRepository struct {
+	flag   Flag
+	getErr error
+}
+
+func (s stubRepository) Create(context.Context, Flag) (Flag, error) {
+	return Flag{}, errors.New("unexpected Create call")
+}
+
+func (s stubRepository) Delete(context.Context, string, int64) error {
+	return errors.New("unexpected Delete call")
+}
+
+func (s stubRepository) Get(context.Context, string) (Flag, error) {
+	if s.getErr != nil {
+		return Flag{}, s.getErr
+	}
+	return s.flag, nil
+}
+
+func (s stubRepository) List(context.Context) ([]Flag, error) {
+	return nil, errors.New("unexpected List call")
+}
+
+func (s stubRepository) Update(context.Context, Flag) (Flag, error) {
+	return Flag{}, errors.New("unexpected Update call")
+}

--- a/internal/storage/sqlite/featureflags.go
+++ b/internal/storage/sqlite/featureflags.go
@@ -1,0 +1,207 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/earchibald/rein/internal/featureflags"
+)
+
+type FeatureFlagRepository struct {
+	store *Store
+}
+
+func NewFeatureFlagRepository(store *Store) (*FeatureFlagRepository, error) {
+	if store == nil {
+		return nil, featureflags.ErrNilRepository
+	}
+
+	return &FeatureFlagRepository{store: store}, nil
+}
+
+func (r *FeatureFlagRepository) Create(ctx context.Context, flag featureflags.Flag) (featureflags.Flag, error) {
+	store, err := r.requireStore()
+	if err != nil {
+		return featureflags.Flag{}, err
+	}
+
+	normalized, err := flag.Normalize()
+	if err != nil {
+		return featureflags.Flag{}, err
+	}
+
+	payload, err := marshalFeatureFlag(normalized)
+	if err != nil {
+		return featureflags.Flag{}, fmt.Errorf("sqlite: marshal feature flag %q: %w", normalized.Key, err)
+	}
+
+	record, err := store.Create(ctx, FeatureFlagKind, normalized.Key, payload)
+	if err != nil {
+		return featureflags.Flag{}, mapFeatureFlagRepositoryError("create", normalized.Key, err)
+	}
+
+	return decodeFeatureFlagRecord(record)
+}
+
+func (r *FeatureFlagRepository) Delete(ctx context.Context, key string, expectedLockVersion int64) error {
+	store, err := r.requireStore()
+	if err != nil {
+		return err
+	}
+
+	normalizedKey := strings.TrimSpace(key)
+	if normalizedKey == "" {
+		return featureflags.ErrEmptyKey
+	}
+
+	if err := store.Delete(ctx, FeatureFlagKind, normalizedKey, expectedLockVersion); err != nil {
+		return mapFeatureFlagRepositoryError("delete", normalizedKey, err)
+	}
+
+	return nil
+}
+
+func (r *FeatureFlagRepository) Get(ctx context.Context, key string) (featureflags.Flag, error) {
+	store, err := r.requireStore()
+	if err != nil {
+		return featureflags.Flag{}, err
+	}
+
+	normalizedKey := strings.TrimSpace(key)
+	if normalizedKey == "" {
+		return featureflags.Flag{}, featureflags.ErrEmptyKey
+	}
+
+	record, err := store.Get(ctx, FeatureFlagKind, normalizedKey)
+	if err != nil {
+		return featureflags.Flag{}, mapFeatureFlagRepositoryError("get", normalizedKey, err)
+	}
+
+	return decodeFeatureFlagRecord(record)
+}
+
+func (r *FeatureFlagRepository) List(ctx context.Context) ([]featureflags.Flag, error) {
+	store, err := r.requireStore()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := store.DB().QueryContext(ctx, `SELECT id, lock_version, payload, created_at, updated_at FROM featureflags ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list feature flags: %w", err)
+	}
+	defer rows.Close()
+
+	flags := []featureflags.Flag{}
+	for rows.Next() {
+		var (
+			record       Record
+			createdAtRaw string
+			updatedAtRaw string
+		)
+
+		if err := rows.Scan(&record.ID, &record.LockVersion, &record.Payload, &createdAtRaw, &updatedAtRaw); err != nil {
+			return nil, fmt.Errorf("sqlite: scan feature flag row: %w", err)
+		}
+
+		record.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: parse feature flag created_at %q: %w", record.ID, err)
+		}
+		record.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: parse feature flag updated_at %q: %w", record.ID, err)
+		}
+
+		flag, err := decodeFeatureFlagRecord(record)
+		if err != nil {
+			return nil, err
+		}
+		flags = append(flags, flag)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate feature flags: %w", err)
+	}
+
+	return flags, nil
+}
+
+func (r *FeatureFlagRepository) Update(ctx context.Context, flag featureflags.Flag) (featureflags.Flag, error) {
+	store, err := r.requireStore()
+	if err != nil {
+		return featureflags.Flag{}, err
+	}
+
+	normalized, err := flag.Normalize()
+	if err != nil {
+		return featureflags.Flag{}, err
+	}
+
+	payload, err := marshalFeatureFlag(normalized)
+	if err != nil {
+		return featureflags.Flag{}, fmt.Errorf("sqlite: marshal feature flag %q: %w", normalized.Key, err)
+	}
+
+	record, err := store.Update(ctx, FeatureFlagKind, normalized.Key, normalized.LockVersion, payload)
+	if err != nil {
+		return featureflags.Flag{}, mapFeatureFlagRepositoryError("update", normalized.Key, err)
+	}
+
+	return decodeFeatureFlagRecord(record)
+}
+
+func (r *FeatureFlagRepository) requireStore() (*Store, error) {
+	if r == nil || r.store == nil {
+		return nil, featureflags.ErrNilRepository
+	}
+
+	return r.store, nil
+}
+
+type featureFlagPayload struct {
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled"`
+}
+
+func marshalFeatureFlag(flag featureflags.Flag) (json.RawMessage, error) {
+	return json.Marshal(featureFlagPayload{
+		Description: flag.Description,
+		Enabled:     flag.Enabled,
+	})
+}
+
+func decodeFeatureFlagRecord(record Record) (featureflags.Flag, error) {
+	var payload featureFlagPayload
+	if err := json.Unmarshal(record.Payload, &payload); err != nil {
+		return featureflags.Flag{}, fmt.Errorf("sqlite: decode feature flag %q: %w", record.ID, err)
+	}
+
+	return featureflags.Flag{
+		Key:         record.ID,
+		Description: payload.Description,
+		Enabled:     payload.Enabled,
+		LockVersion: record.LockVersion,
+		CreatedAt:   record.CreatedAt,
+		UpdatedAt:   record.UpdatedAt,
+	}, nil
+}
+
+func mapFeatureFlagRepositoryError(operation, key string, err error) error {
+	switch {
+	case errors.Is(err, ErrEmptyID):
+		return fmt.Errorf("sqlite: %s feature flag %q: %w", operation, key, featureflags.ErrEmptyKey)
+	case errors.Is(err, ErrLockVersionMismatch):
+		return fmt.Errorf("sqlite: %s feature flag %q: %w", operation, key, featureflags.ErrVersionMismatch)
+	case errors.Is(err, ErrNotFound):
+		return fmt.Errorf("sqlite: %s feature flag %q: %w", operation, key, featureflags.ErrNotFound)
+	case strings.Contains(err.Error(), "UNIQUE constraint failed: featureflags.id"):
+		return fmt.Errorf("sqlite: %s feature flag %q: %w", operation, key, featureflags.ErrAlreadyExists)
+	default:
+		return fmt.Errorf("sqlite: %s feature flag %q: %w", operation, key, err)
+	}
+}

--- a/internal/storage/sqlite/featureflags_test.go
+++ b/internal/storage/sqlite/featureflags_test.go
@@ -1,0 +1,143 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/earchibald/rein/internal/featureflags"
+)
+
+func TestNewFeatureFlagRepositoryRejectsNilStore(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewFeatureFlagRepository(nil); !errors.Is(err, featureflags.ErrNilRepository) {
+		t.Fatalf("NewFeatureFlagRepository() error = %v, want %v", err, featureflags.ErrNilRepository)
+	}
+}
+
+func TestFeatureFlagRepositoryCRUDAndEvaluation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := openFeatureFlagRepository(t)
+	evaluator, err := featureflags.NewRepositoryEvaluator(repo)
+	if err != nil {
+		t.Fatalf("NewRepositoryEvaluator() error = %v", err)
+	}
+
+	created, err := repo.Create(ctx, featureflags.Flag{
+		Key:         " managed-flow ",
+		Description: " Gate managed-flow steps ",
+		Enabled:     false,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Key != "managed-flow" {
+		t.Fatalf("Create() key = %q, want %q", created.Key, "managed-flow")
+	}
+	if created.Description != "Gate managed-flow steps" {
+		t.Fatalf("Create() description = %q", created.Description)
+	}
+	if created.LockVersion != 1 {
+		t.Fatalf("Create() lock version = %d, want 1", created.LockVersion)
+	}
+
+	got, err := repo.Get(ctx, "managed-flow")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != created {
+		t.Fatalf("Get() = %+v, want %+v", got, created)
+	}
+
+	if enabled, err := evaluator.EvaluateBoolean(ctx, featureflags.EvaluationRequest{
+		Key:        "managed-flow",
+		SubjectKey: "user-123",
+		Attributes: map[string]string{"team": "core"},
+	}); err != nil {
+		t.Fatalf("EvaluateBoolean() error = %v", err)
+	} else if enabled {
+		t.Fatalf("EvaluateBoolean() = true, want false")
+	}
+
+	if _, err := repo.Create(ctx, featureflags.Flag{Key: "managed-flow", Enabled: true}); !errors.Is(err, featureflags.ErrAlreadyExists) {
+		t.Fatalf("Create() duplicate error = %v, want %v", err, featureflags.ErrAlreadyExists)
+	}
+
+	second, err := repo.Create(ctx, featureflags.Flag{Key: "adapter-v2", Enabled: true})
+	if err != nil {
+		t.Fatalf("Create() second flag error = %v", err)
+	}
+
+	listed, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("List() len = %d, want 2", len(listed))
+	}
+	if listed[0].Key != "adapter-v2" || listed[1].Key != "managed-flow" {
+		t.Fatalf("List() keys = [%s, %s], want [adapter-v2, managed-flow]", listed[0].Key, listed[1].Key)
+	}
+	if listed[0] != second || listed[1] != created {
+		t.Fatalf("List() records = %+v", listed)
+	}
+
+	if _, err := repo.Update(ctx, featureflags.Flag{
+		Key:         "managed-flow",
+		Description: created.Description,
+		Enabled:     true,
+		LockVersion: 99,
+	}); !errors.Is(err, featureflags.ErrVersionMismatch) {
+		t.Fatalf("Update() stale lock error = %v, want %v", err, featureflags.ErrVersionMismatch)
+	}
+
+	updated, err := repo.Update(ctx, featureflags.Flag{
+		Key:         created.Key,
+		Description: created.Description,
+		Enabled:     true,
+		LockVersion: created.LockVersion,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated.LockVersion != 2 {
+		t.Fatalf("Update() lock version = %d, want 2", updated.LockVersion)
+	}
+
+	if enabled, err := evaluator.EvaluateBoolean(ctx, featureflags.EvaluationRequest{Key: "managed-flow"}); err != nil {
+		t.Fatalf("EvaluateBoolean() after update error = %v", err)
+	} else if !enabled {
+		t.Fatalf("EvaluateBoolean() after update = false, want true")
+	}
+
+	if err := repo.Delete(ctx, created.Key, created.LockVersion); !errors.Is(err, featureflags.ErrVersionMismatch) {
+		t.Fatalf("Delete() stale lock error = %v, want %v", err, featureflags.ErrVersionMismatch)
+	}
+
+	if err := repo.Delete(ctx, updated.Key, updated.LockVersion); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if _, err := repo.Get(ctx, updated.Key); !errors.Is(err, featureflags.ErrNotFound) {
+		t.Fatalf("Get() after delete error = %v, want %v", err, featureflags.ErrNotFound)
+	}
+	if enabled, err := evaluator.EvaluateBoolean(ctx, featureflags.EvaluationRequest{Key: updated.Key}); err != nil {
+		t.Fatalf("EvaluateBoolean() after delete error = %v", err)
+	} else if enabled {
+		t.Fatalf("EvaluateBoolean() after delete = true, want false")
+	}
+}
+
+func openFeatureFlagRepository(tb testing.TB) *FeatureFlagRepository {
+	tb.Helper()
+
+	repo, err := NewFeatureFlagRepository(openTestStore(tb, context.Background()))
+	if err != nil {
+		tb.Fatalf("NewFeatureFlagRepository() error = %v", err)
+	}
+
+	return repo
+}


### PR DESCRIPTION
## Summary
- add a typed feature-flag domain seam with repository + evaluator contracts
- add a SQLite-backed repository adapter over the existing featureflags table
- cover normalization, CRUD/versioning, and evaluator behavior with tests

Closes #14