### PR TITLE
RN-10: Add workflow engine state machine

### DIFF
--- a/internal/server/workflow_engine_runtime_test.go
+++ b/internal/server/workflow_engine_runtime_test.go
@@ -1,0 +1,273 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/service"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+	workflowpkg "github.com/earchibald/rein/internal/workflow"
+)
+
+const (
+	runtimeTrackerAdapterID = "tracker-github-fake"
+	runtimeCodingAdapterID  = "coding-copilot-fake"
+	runtimeReviewAdapterID  = "review-bot-fake"
+)
+
+func TestManagedServicesWorkflowEngineFlow(t *testing.T) {
+	t.Parallel()
+
+	store, err := sqlite.OpenInMemoryAndMigrate(context.Background(), t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	catalog := newRuntimeCatalog()
+	harness := newBufconnHarness(t, Options{Services: service.NewManagedSet(store, catalog)})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	workflowEntity := runtimeWorkflowDefinition()
+	if err := seedWorkflow(ctx, store, workflowEntity); err != nil {
+		t.Fatalf("seedWorkflow() error = %v", err)
+	}
+
+	adapterClient := reinv1.NewAdapterServiceClient(harness.conn)
+	workflowClient := reinv1.NewWorkflowServiceClient(harness.conn)
+	projectClient := reinv1.NewProjectServiceClient(harness.conn)
+	issueClient := reinv1.NewIssueServiceClient(harness.conn)
+	executionClient := reinv1.NewExecutionServiceClient(harness.conn)
+
+	adaptersResp, err := adapterClient.ListAdapters(ctx, &reinv1.ListAdaptersRequest{})
+	if err != nil {
+		t.Fatalf("ListAdapters() error = %v", err)
+	}
+	if got := runtimeAdapterIDs(adaptersResp.Adapters); !slices.Equal(got, []string{runtimeCodingAdapterID, runtimeReviewAdapterID, runtimeTrackerAdapterID}) {
+		t.Fatalf("ListAdapters() ids = %v", got)
+	}
+
+	validateResp, err := workflowClient.ValidateWorkflow(ctx, &reinv1.ValidateWorkflowRequest{Workflow: workflowEntity})
+	if err != nil {
+		t.Fatalf("ValidateWorkflow() error = %v", err)
+	}
+	if !validateResp.GetValid() || len(validateResp.GetMessages()) != 0 {
+		t.Fatalf("ValidateWorkflow() = %+v, want valid", validateResp)
+	}
+
+	projectResp, err := projectClient.CreateProject(ctx, &reinv1.CreateProjectRequest{Project: &reinv1.Project{
+		Id:          "project-rein",
+		Slug:        "rein",
+		DisplayName: "rein",
+		Summary:     "Workflow engine runtime test",
+		Status:      reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE,
+	}})
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+
+	issueResp, err := issueClient.CreateIssue(ctx, &reinv1.CreateIssueRequest{Issue: &reinv1.Issue{
+		Id:         "RN-10",
+		ProjectId:  projectResp.GetProject().GetId(),
+		Title:      "Workflow engine runtime test",
+		Summary:    "Exercise trunk and laterals against managed services",
+		Status:     reinv1.IssueStatus_ISSUE_STATUS_OPEN,
+		Priority:   reinv1.IssuePriority_ISSUE_PRIORITY_HIGH,
+		WorkflowId: workflowEntity.GetId(),
+		Assignee:   "copilot",
+	}})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	startResp, err := executionClient.StartExecution(ctx, &reinv1.StartExecutionRequest{
+		IssueId:     issueResp.GetIssue().GetId(),
+		WorkflowId:  workflowEntity.GetId(),
+		RequestedBy: "copilot",
+		Inputs:      map[string]string{"base_branch": "main"},
+	})
+	if err != nil {
+		t.Fatalf("StartExecution() error = %v", err)
+	}
+
+	execution := startResp.GetExecution()
+	if got := execution.GetStatus(); got != reinv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED {
+		t.Fatalf("StartExecution() status = %s, want %s", got, reinv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED)
+	}
+	if execution.GetMetadata()["result"] != "merged" {
+		t.Fatalf("StartExecution() result = %q, want merged", execution.GetMetadata()["result"])
+	}
+
+	getIssueResp, err := issueClient.GetIssue(ctx, &reinv1.GetIssueRequest{Id: issueResp.GetIssue().GetId()})
+	if err != nil {
+		t.Fatalf("GetIssue() error = %v", err)
+	}
+	if got := getIssueResp.GetIssue().GetStatus(); got != reinv1.IssueStatus_ISSUE_STATUS_RESOLVED {
+		t.Fatalf("GetIssue() status = %s, want resolved", got)
+	}
+	if getIssueResp.GetIssue().GetLabels()["integration_status"] != "merged" {
+		t.Fatalf("GetIssue() integration_status = %q, want merged", getIssueResp.GetIssue().GetLabels()["integration_status"])
+	}
+
+	engine := workflowpkg.New(store)
+	effects, err := engine.ListSideEffects(ctx, execution.GetId())
+	if err != nil {
+		t.Fatalf("ListSideEffects() error = %v", err)
+	}
+	if len(effects) != 4 {
+		t.Fatalf("ListSideEffects() len = %d, want 4", len(effects))
+	}
+	if got := effects[1].Lane; got != "review-cycle" {
+		t.Fatalf("review side effect lane = %q, want review-cycle", got)
+	}
+}
+
+type runtimeCatalog struct {
+	adapters map[string]*runtimeAdapter
+}
+
+func newRuntimeCatalog() *runtimeCatalog {
+	return &runtimeCatalog{adapters: map[string]*runtimeAdapter{
+		runtimeTrackerAdapterID: {
+			descriptor: &reinv1.Adapter{Id: runtimeTrackerAdapterID, Name: "Tracker Fake", Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER, Enabled: true},
+		},
+		runtimeCodingAdapterID: {
+			descriptor: &reinv1.Adapter{Id: runtimeCodingAdapterID, Name: "Coding Fake", Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT, Enabled: true},
+		},
+		runtimeReviewAdapterID: {
+			descriptor: &reinv1.Adapter{Id: runtimeReviewAdapterID, Name: "Review Fake", Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT, Enabled: true},
+		},
+	}}
+}
+
+func (c *runtimeCatalog) List() []*reinv1.Adapter {
+	ids := make([]string, 0, len(c.adapters))
+	for id := range c.adapters {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	adapters := make([]*reinv1.Adapter, 0, len(ids))
+	for _, id := range ids {
+		adapters = append(adapters, c.adapters[id].Descriptor())
+	}
+	return adapters
+}
+
+func (c *runtimeCatalog) Lookup(id string) (service.ManagedAdapter, bool) {
+	adapter, ok := c.adapters[id]
+	return adapter, ok
+}
+
+type runtimeAdapter struct {
+	descriptor *reinv1.Adapter
+}
+
+func (a *runtimeAdapter) Descriptor() *reinv1.Adapter {
+	return proto.Clone(a.descriptor).(*reinv1.Adapter)
+}
+
+func (a *runtimeAdapter) Run(_ context.Context, state *workflowpkg.RuntimeState, phase workflowpkg.Phase, direction workflowpkg.Direction, effect *workflowpkg.SideEffect) error {
+	if state.Execution.Metadata == nil {
+		state.Execution.Metadata = map[string]string{}
+	}
+	if state.Issue.Labels == nil {
+		state.Issue.Labels = map[string]string{}
+	}
+
+	switch direction {
+	case workflowpkg.DirectionForward:
+		switch effect.Operation {
+		case "prepare":
+			state.Execution.Metadata["issue_url"] = fmt.Sprintf("https://tracker.fake/issues/%s", state.Issue.GetId())
+			state.Execution.Metadata["branch"] = "issues/rn-10-workflow-engine-runtime-test"
+			state.Execution.Metadata["worktree"] = "/worktrees/rn-10-workflow-engine-runtime-test"
+			state.Issue.Labels["branch"] = state.Execution.Metadata["branch"]
+			state.Issue.Labels["worktree"] = state.Execution.Metadata["worktree"]
+			effect.Outputs = map[string]string{"branch": state.Execution.Metadata["branch"]}
+		case "open-pr":
+			if state.Execution.Metadata["branch"] == "" {
+				return errors.New("branch missing before PR")
+			}
+			state.Execution.Metadata["pr_url"] = "https://tracker.fake/repos/rein/pull/110"
+			state.Execution.Metadata["pr_state"] = "OPEN"
+			state.Issue.Labels["pr_url"] = state.Execution.Metadata["pr_url"]
+		case "approve-pr":
+			if state.Execution.Metadata["pr_url"] == "" {
+				return errors.New("pr missing before review")
+			}
+			state.Execution.Metadata["review_state"] = "APPROVED"
+			state.Execution.Metadata["reviewed_by"] = runtimeReviewAdapterID
+			state.Issue.Labels["review_state"] = "APPROVED"
+		case "merge":
+			if state.Execution.Metadata["review_state"] != "APPROVED" {
+				return errors.New("review missing before merge")
+			}
+			state.Execution.Metadata["merge_commit"] = "merge-rn-10-001"
+			state.Execution.Metadata["integration_branch"] = state.Execution.Metadata["base_branch"]
+			state.Execution.Metadata["result"] = "merged"
+			state.Issue.Labels["merge_commit"] = state.Execution.Metadata["merge_commit"]
+		}
+	case workflowpkg.DirectionBackward:
+		switch effect.Operation {
+		case "cleanup-branch":
+			state.Execution.Metadata["branch_cleanup"] = "true"
+		case "close-pr":
+			state.Execution.Metadata["pr_state"] = "CLOSED"
+		case "dismiss-review":
+			state.Execution.Metadata["review_state"] = "DISMISSED"
+		case "reopen-merge":
+			state.Execution.Metadata["result"] = "reopened"
+		}
+	}
+	return nil
+}
+
+func runtimeWorkflowDefinition() *reinv1.Workflow {
+	created := timestamppb.New(time.Date(2026, time.May, 2, 12, 0, 0, 0, time.UTC))
+	return &reinv1.Workflow{
+		Id:          "managed-issue-pr-review-merge",
+		Name:        "Managed issue to merge",
+		Description: "Fake-backed issue to merge orchestration",
+		Version:     "0.2.0",
+		CreatedTime: created,
+		UpdatedTime: created,
+		Steps: []*reinv1.WorkflowStep{
+			{Id: "prepare-branch", Name: "Prepare issue branch and worktree", AdapterId: runtimeTrackerAdapterID, Inputs: map[string]string{workflowpkg.InputOperation: "prepare", workflowpkg.InputBail: "true", workflowpkg.InputOnCancel: string(workflowpkg.CancelPolicyRewind), workflowpkg.InputBackwardOperation: "cleanup-branch"}},
+			{Id: "open-pr", Name: "Open pull request", AdapterId: runtimeCodingAdapterID, Inputs: map[string]string{workflowpkg.InputLane: "review-cycle", workflowpkg.InputLaneAttach: "prepare-branch", workflowpkg.InputOperation: "open-pr", workflowpkg.InputBail: "true", workflowpkg.InputOnCancel: string(workflowpkg.CancelPolicyRewind), workflowpkg.InputBackwardOperation: "close-pr", workflowpkg.InputBackwardTo: "prepare-branch"}},
+			{Id: "approve-pr", Name: "Approve pull request", AdapterId: runtimeReviewAdapterID, Inputs: map[string]string{workflowpkg.InputLane: "review-cycle", workflowpkg.InputLaneAttach: "prepare-branch", workflowpkg.InputOperation: "approve-pr", workflowpkg.InputBail: "true", workflowpkg.InputOnCancel: string(workflowpkg.CancelPolicyRewind), workflowpkg.InputBackwardOperation: "dismiss-review", workflowpkg.InputBackwardTo: "open-pr"}},
+			{Id: "merge-pr", Name: "Merge pull request", AdapterId: runtimeTrackerAdapterID, Inputs: map[string]string{workflowpkg.InputOperation: "merge", workflowpkg.InputBail: "true", workflowpkg.InputBackwardOperation: "reopen-merge", workflowpkg.InputBackwardTo: "approve-pr"}},
+		},
+	}
+}
+
+func seedWorkflow(ctx context.Context, store *sqlite.Store, workflowEntity *reinv1.Workflow) error {
+	payload, err := protojson.Marshal(workflowEntity)
+	if err != nil {
+		return err
+	}
+	_, err = store.Create(ctx, sqlite.WorkflowKind, workflowEntity.GetId(), payload)
+	return err
+}
+
+func runtimeAdapterIDs(adapters []*reinv1.Adapter) []string {
+	ids := make([]string, 0, len(adapters))
+	for _, adapter := range adapters {
+		ids = append(ids, adapter.GetId())
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/service/managed.go
+++ b/internal/service/managed.go
@@ -1,0 +1,431 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+type ManagedAdapter interface {
+	Descriptor() *reinv1.Adapter
+	Run(context.Context, *workflow.RuntimeState, workflow.Phase, workflow.Direction, *workflow.SideEffect) error
+}
+
+type ManagedCatalog interface {
+	List() []*reinv1.Adapter
+	Lookup(string) (ManagedAdapter, bool)
+}
+
+func NewManagedSet(store *sqlite.Store, catalog ManagedCatalog) Set {
+	engine := workflow.New(store)
+	return Set{
+		Adapter:   &ManagedAdapterServer{catalog: catalog},
+		Execution: &ManagedExecutionServer{catalog: catalog, engine: engine, store: store},
+		Issue:     &ManagedIssueServer{store: store},
+		Project:   &ManagedProjectServer{store: store},
+		Workflow:  &ManagedWorkflowServer{catalog: catalog, engine: engine, store: store},
+	}
+}
+
+type ManagedAdapterServer struct {
+	reinv1.UnimplementedAdapterServiceServer
+	catalog ManagedCatalog
+}
+
+func (s *ManagedAdapterServer) ListAdapters(_ context.Context, _ *reinv1.ListAdaptersRequest) (*reinv1.ListAdaptersResponse, error) {
+	return &reinv1.ListAdaptersResponse{Adapters: s.catalog.List()}, nil
+}
+
+func (s *ManagedAdapterServer) GetAdapter(_ context.Context, req *reinv1.GetAdapterRequest) (*reinv1.GetAdapterResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	adapter, ok := s.catalog.Lookup(req.GetId())
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "adapter %q not found", req.GetId())
+	}
+	return &reinv1.GetAdapterResponse{Adapter: adapter.Descriptor()}, nil
+}
+
+func (s *ManagedAdapterServer) ValidateAdapter(_ context.Context, req *reinv1.ValidateAdapterRequest) (*reinv1.ValidateAdapterResponse, error) {
+	if req.GetAdapter() == nil {
+		return nil, status.Error(codes.InvalidArgument, "adapter is required")
+	}
+	var messages []*reinv1.ValidationMessage
+	if strings.TrimSpace(req.GetAdapter().GetId()) == "" {
+		messages = append(messages, &reinv1.ValidationMessage{Severity: reinv1.ValidationMessage_SEVERITY_ERROR, Field: "adapter.id", Message: "adapter id is required"})
+	}
+	if strings.TrimSpace(req.GetAdapter().GetName()) == "" {
+		messages = append(messages, &reinv1.ValidationMessage{Severity: reinv1.ValidationMessage_SEVERITY_ERROR, Field: "adapter.name", Message: "adapter name is required"})
+	}
+	if req.GetAdapter().GetCategory() == reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED {
+		messages = append(messages, &reinv1.ValidationMessage{Severity: reinv1.ValidationMessage_SEVERITY_ERROR, Field: "adapter.category", Message: "adapter category is required"})
+	}
+	return &reinv1.ValidateAdapterResponse{Valid: len(messages) == 0, Messages: messages}, nil
+}
+
+type ManagedWorkflowServer struct {
+	reinv1.UnimplementedWorkflowServiceServer
+	catalog ManagedCatalog
+	engine  *workflow.Engine
+	store   *sqlite.Store
+}
+
+func (s *ManagedWorkflowServer) GetWorkflow(ctx context.Context, req *reinv1.GetWorkflowRequest) (*reinv1.GetWorkflowResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	workflowEntity := &reinv1.Workflow{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.WorkflowKind, req.GetId(), workflowEntity); err != nil {
+		return nil, toStatusError("workflow", req.GetId(), err)
+	}
+	return &reinv1.GetWorkflowResponse{Workflow: workflowEntity}, nil
+}
+
+func (s *ManagedWorkflowServer) ValidateWorkflow(_ context.Context, req *reinv1.ValidateWorkflowRequest) (*reinv1.ValidateWorkflowResponse, error) {
+	if req.GetWorkflow() == nil {
+		return nil, status.Error(codes.InvalidArgument, "workflow is required")
+	}
+	messages := s.engine.Validate(req.GetWorkflow(), func(id string) bool {
+		_, ok := s.catalog.Lookup(id)
+		return ok
+	})
+	return &reinv1.ValidateWorkflowResponse{Valid: len(messages) == 0, Messages: messages}, nil
+}
+
+type ManagedProjectServer struct {
+	reinv1.UnimplementedProjectServiceServer
+	store *sqlite.Store
+}
+
+func (s *ManagedProjectServer) CreateProject(ctx context.Context, req *reinv1.CreateProjectRequest) (*reinv1.CreateProjectResponse, error) {
+	if req.GetProject() == nil {
+		return nil, status.Error(codes.InvalidArgument, "project is required")
+	}
+	project := proto.Clone(req.GetProject()).(*reinv1.Project)
+	if strings.TrimSpace(project.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "project.id is required")
+	}
+	if project.GetStatus() == reinv1.ProjectStatus_PROJECT_STATUS_UNSPECIFIED {
+		project.Status = reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE
+	}
+	if project.Labels == nil {
+		project.Labels = map[string]string{}
+	}
+	now := timestamppb.Now()
+	if project.CreatedTime == nil {
+		project.CreatedTime = now
+	}
+	project.UpdatedTime = now
+	if _, err := createStoredProto(ctx, s.store, sqlite.ProjectKind, project.GetId(), project); err != nil {
+		return nil, status.Errorf(codes.Internal, "create project %q: %v", project.GetId(), err)
+	}
+	return &reinv1.CreateProjectResponse{Project: project}, nil
+}
+
+func (s *ManagedProjectServer) GetProject(ctx context.Context, req *reinv1.GetProjectRequest) (*reinv1.GetProjectResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	project := &reinv1.Project{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.ProjectKind, req.GetId(), project); err != nil {
+		return nil, toStatusError("project", req.GetId(), err)
+	}
+	return &reinv1.GetProjectResponse{Project: project}, nil
+}
+
+type ManagedIssueServer struct {
+	reinv1.UnimplementedIssueServiceServer
+	store *sqlite.Store
+}
+
+func (s *ManagedIssueServer) CreateIssue(ctx context.Context, req *reinv1.CreateIssueRequest) (*reinv1.CreateIssueResponse, error) {
+	if req.GetIssue() == nil {
+		return nil, status.Error(codes.InvalidArgument, "issue is required")
+	}
+	issue := proto.Clone(req.GetIssue()).(*reinv1.Issue)
+	if strings.TrimSpace(issue.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "issue.id is required")
+	}
+	if strings.TrimSpace(issue.GetProjectId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "issue.project_id is required")
+	}
+	if issue.GetStatus() == reinv1.IssueStatus_ISSUE_STATUS_UNSPECIFIED {
+		issue.Status = reinv1.IssueStatus_ISSUE_STATUS_OPEN
+	}
+	if issue.Labels == nil {
+		issue.Labels = map[string]string{}
+	}
+	now := timestamppb.Now()
+	if issue.CreatedTime == nil {
+		issue.CreatedTime = now
+	}
+	issue.UpdatedTime = now
+	if _, err := createStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), issue); err != nil {
+		return nil, status.Errorf(codes.Internal, "create issue %q: %v", issue.GetId(), err)
+	}
+	return &reinv1.CreateIssueResponse{Issue: issue}, nil
+}
+
+func (s *ManagedIssueServer) GetIssue(ctx context.Context, req *reinv1.GetIssueRequest) (*reinv1.GetIssueResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	issue := &reinv1.Issue{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.IssueKind, req.GetId(), issue); err != nil {
+		return nil, toStatusError("issue", req.GetId(), err)
+	}
+	return &reinv1.GetIssueResponse{Issue: issue}, nil
+}
+
+type ManagedExecutionServer struct {
+	reinv1.UnimplementedExecutionServiceServer
+	catalog ManagedCatalog
+	engine  *workflow.Engine
+	store   *sqlite.Store
+}
+
+func (s *ManagedExecutionServer) StartExecution(ctx context.Context, req *reinv1.StartExecutionRequest) (*reinv1.StartExecutionResponse, error) {
+	if strings.TrimSpace(req.GetIssueId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "issue_id is required")
+	}
+	if strings.TrimSpace(req.GetWorkflowId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "workflow_id is required")
+	}
+
+	issue := &reinv1.Issue{}
+	issueRecord, err := loadStoredProto(ctx, s.store, sqlite.IssueKind, req.GetIssueId(), issue)
+	if err != nil {
+		return nil, toStatusError("issue", req.GetIssueId(), err)
+	}
+	workflowEntity := &reinv1.Workflow{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.WorkflowKind, req.GetWorkflowId(), workflowEntity); err != nil {
+		return nil, toStatusError("workflow", req.GetWorkflowId(), err)
+	}
+
+	messages := s.engine.Validate(workflowEntity, func(id string) bool {
+		_, ok := s.catalog.Lookup(id)
+		return ok
+	})
+	if len(messages) > 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "workflow %q is invalid", workflowEntity.GetId())
+	}
+
+	now := timestamppb.Now()
+	issue.Status = reinv1.IssueStatus_ISSUE_STATUS_IN_PROGRESS
+	issue.UpdatedTime = now
+	if issue.Labels == nil {
+		issue.Labels = map[string]string{}
+	}
+	issue.Labels["integration_status"] = "running"
+	issueRecord, err = updateStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), issueRecord.LockVersion, issue)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "update issue %q: %v", issue.GetId(), err)
+	}
+
+	execution := &reinv1.Execution{
+		Id:          executionID(req.GetIssueId()),
+		IssueId:     issue.GetId(),
+		WorkflowId:  workflowEntity.GetId(),
+		RequestedBy: req.GetRequestedBy(),
+		Status:      reinv1.ExecutionStatus_EXECUTION_STATUS_QUEUED,
+		CreatedTime: now,
+		Metadata:    cloneMap(req.GetInputs()),
+	}
+	if execution.Metadata == nil {
+		execution.Metadata = map[string]string{}
+	}
+	if execution.Metadata["base_branch"] == "" {
+		execution.Metadata["base_branch"] = "main"
+	}
+	executionRecord, err := createStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), execution)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create execution %q: %v", execution.GetId(), err)
+	}
+
+	firstAdapter, _ := firstWorkflowAdapter(workflowEntity)
+	execution.AdapterId = firstAdapter
+	execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_RUNNING
+	execution.StartedTime = now
+	executionRecord, err = updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start execution %q: %v", execution.GetId(), err)
+	}
+
+	state := &workflow.RuntimeState{Workflow: workflowEntity, Issue: issue, Execution: execution}
+	runner := catalogRunner{catalog: s.catalog}
+	if err := s.engine.Run(ctx, state, runner); err != nil {
+		execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_FAILED
+		execution.FinishedTime = timestamppb.Now()
+		execution.Metadata["result"] = "failed"
+		issue.Status = reinv1.IssueStatus_ISSUE_STATUS_BLOCKED
+		issue.UpdatedTime = timestamppb.Now()
+		issue.Labels["integration_status"] = "failed"
+		if _, updateErr := updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution); updateErr != nil {
+			return nil, status.Errorf(codes.Internal, "execution %q failed with %v and could not be stored: %v", execution.GetId(), err, updateErr)
+		}
+		if _, updateErr := updateStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), issueRecord.LockVersion, issue); updateErr != nil {
+			return nil, status.Errorf(codes.Internal, "issue %q failed with %v and could not be stored: %v", issue.GetId(), err, updateErr)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition, "run workflow %q: %v", workflowEntity.GetId(), err)
+	}
+
+	issue.Status = reinv1.IssueStatus_ISSUE_STATUS_RESOLVED
+	issue.UpdatedTime = timestamppb.Now()
+	if execution.Metadata["result"] == "" {
+		execution.Metadata["result"] = "succeeded"
+	}
+	issue.Labels["integration_status"] = execution.Metadata["result"]
+	if issue.Labels["integration_status"] == "succeeded" {
+		issue.Labels["integration_status"] = "merged"
+	}
+	execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED
+	execution.FinishedTime = timestamppb.Now()
+	if _, err := updateStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), issueRecord.LockVersion, issue); err != nil {
+		return nil, status.Errorf(codes.Internal, "resolve issue %q: %v", issue.GetId(), err)
+	}
+	if _, err := updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution); err != nil {
+		return nil, status.Errorf(codes.Internal, "finish execution %q: %v", execution.GetId(), err)
+	}
+	return &reinv1.StartExecutionResponse{Execution: execution}, nil
+}
+
+func (s *ManagedExecutionServer) GetExecution(ctx context.Context, req *reinv1.GetExecutionRequest) (*reinv1.GetExecutionResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	execution := &reinv1.Execution{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.ExecutionKind, req.GetId(), execution); err != nil {
+		return nil, toStatusError("execution", req.GetId(), err)
+	}
+	return &reinv1.GetExecutionResponse{Execution: execution}, nil
+}
+
+func (s *ManagedExecutionServer) CancelExecution(ctx context.Context, req *reinv1.CancelExecutionRequest) (*reinv1.CancelExecutionResponse, error) {
+	if strings.TrimSpace(req.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	execution := &reinv1.Execution{}
+	executionRecord, err := loadStoredProto(ctx, s.store, sqlite.ExecutionKind, req.GetId(), execution)
+	if err != nil {
+		return nil, toStatusError("execution", req.GetId(), err)
+	}
+	if execution.GetStatus() != reinv1.ExecutionStatus_EXECUTION_STATUS_RUNNING {
+		return nil, status.Errorf(codes.FailedPrecondition, "execution %q is not running", execution.GetId())
+	}
+	issue := &reinv1.Issue{}
+	issueRecord, err := loadStoredProto(ctx, s.store, sqlite.IssueKind, execution.GetIssueId(), issue)
+	if err != nil {
+		return nil, toStatusError("issue", execution.GetIssueId(), err)
+	}
+	workflowEntity := &reinv1.Workflow{}
+	if _, err := loadStoredProto(ctx, s.store, sqlite.WorkflowKind, execution.GetWorkflowId(), workflowEntity); err != nil {
+		return nil, toStatusError("workflow", execution.GetWorkflowId(), err)
+	}
+	state := &workflow.RuntimeState{Workflow: workflowEntity, Issue: issue, Execution: execution}
+	if err := s.engine.Cancel(ctx, state, catalogRunner{catalog: s.catalog}, req.GetReason()); err != nil {
+		return nil, status.Errorf(codes.Internal, "cancel execution %q: %v", execution.GetId(), err)
+	}
+	execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_CANCELED
+	execution.FinishedTime = timestamppb.Now()
+	if execution.Metadata == nil {
+		execution.Metadata = map[string]string{}
+	}
+	execution.Metadata["result"] = "canceled"
+	execution.Metadata["cancel_reason"] = req.GetReason()
+	issue.Status = reinv1.IssueStatus_ISSUE_STATUS_CANCELED
+	issue.UpdatedTime = timestamppb.Now()
+	if issue.Labels == nil {
+		issue.Labels = map[string]string{}
+	}
+	issue.Labels["integration_status"] = "canceled"
+	if _, err := updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution); err != nil {
+		return nil, status.Errorf(codes.Internal, "persist canceled execution %q: %v", execution.GetId(), err)
+	}
+	if _, err := updateStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), issueRecord.LockVersion, issue); err != nil {
+		return nil, status.Errorf(codes.Internal, "persist canceled issue %q: %v", issue.GetId(), err)
+	}
+	return &reinv1.CancelExecutionResponse{Execution: execution}, nil
+}
+
+type catalogRunner struct{ catalog ManagedCatalog }
+
+func (r catalogRunner) Run(ctx context.Context, state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, effect *workflow.SideEffect) error {
+	adapter, ok := r.catalog.Lookup(phase.AdapterID)
+	if !ok {
+		return fmt.Errorf("adapter %q not found", phase.AdapterID)
+	}
+	return adapter.Run(ctx, state, phase, direction, effect)
+}
+
+func createStoredProto(ctx context.Context, store *sqlite.Store, kind sqlite.EntityKind, id string, message proto.Message) (sqlite.Record, error) {
+	payload, err := protojson.Marshal(message)
+	if err != nil {
+		return sqlite.Record{}, err
+	}
+	return store.Create(ctx, kind, id, payload)
+}
+
+func updateStoredProto(ctx context.Context, store *sqlite.Store, kind sqlite.EntityKind, id string, lockVersion int64, message proto.Message) (sqlite.Record, error) {
+	payload, err := protojson.Marshal(message)
+	if err != nil {
+		return sqlite.Record{}, err
+	}
+	return store.Update(ctx, kind, id, lockVersion, payload)
+}
+
+func loadStoredProto(ctx context.Context, store *sqlite.Store, kind sqlite.EntityKind, id string, message proto.Message) (sqlite.Record, error) {
+	record, err := store.Get(ctx, kind, id)
+	if err != nil {
+		return sqlite.Record{}, err
+	}
+	if err := protojson.Unmarshal(record.Payload, message); err != nil {
+		return sqlite.Record{}, err
+	}
+	return record, nil
+}
+
+func toStatusError(kind, id string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sqlite.ErrNotFound) {
+		return status.Errorf(codes.NotFound, "%s %q not found", kind, id)
+	}
+	return status.Errorf(codes.Internal, "%s %q: %v", kind, id, err)
+}
+
+func cloneMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func executionID(issueID string) string {
+	return fmt.Sprintf("exec-%s-001", strings.ToLower(issueID))
+}
+
+func firstWorkflowAdapter(workflowEntity *reinv1.Workflow) (string, bool) {
+	for _, step := range workflowEntity.GetSteps() {
+		if strings.TrimSpace(step.GetAdapterId()) != "" {
+			return step.GetAdapterId(), true
+		}
+	}
+	return "", false
+}

--- a/internal/storage/sqlite/store.go
+++ b/internal/storage/sqlite/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -68,6 +69,11 @@ type Record struct {
 	Payload     json.RawMessage
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+}
+
+type ListOptions struct {
+	JSONEquals map[string]string
+	Limit      int
 }
 
 type Store struct {
@@ -279,6 +285,69 @@ func (s *Store) Update(ctx context.Context, kind EntityKind, id string, expected
 	}
 
 	return record, nil
+}
+
+func (s *Store) List(ctx context.Context, kind EntityKind, options ListOptions) ([]Record, error) {
+	table, err := tableFor(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G201 -- table is selected from the fixed entity kind map via tableFor.
+	query := fmt.Sprintf(`SELECT id, lock_version, payload, created_at, updated_at FROM %s`, table)
+	args := make([]any, 0, len(options.JSONEquals)*2+1)
+	if len(options.JSONEquals) > 0 {
+		keys := make([]string, 0, len(options.JSONEquals))
+		for key := range options.JSONEquals {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+
+		clauses := make([]string, 0, len(keys))
+		for _, key := range keys {
+			clauses = append(clauses, `json_extract(payload, ?) = ?`)
+			args = append(args, "$."+key, options.JSONEquals[key])
+		}
+		query += " WHERE " + strings.Join(clauses, " AND ")
+	}
+	query += " ORDER BY created_at ASC"
+	if options.Limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, options.Limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list %s: %w", kind, err)
+	}
+	defer rows.Close()
+
+	var records []Record
+	for rows.Next() {
+		var (
+			record       Record
+			createdAtRaw string
+			updatedAtRaw string
+		)
+		if err := rows.Scan(&record.ID, &record.LockVersion, &record.Payload, &createdAtRaw, &updatedAtRaw); err != nil {
+			return nil, fmt.Errorf("sqlite: scan %s row: %w", kind, err)
+		}
+		record.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: parse created_at for %s %q: %w", kind, record.ID, err)
+		}
+		record.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAtRaw)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: parse updated_at for %s %q: %w", kind, record.ID, err)
+		}
+		record.Payload = clonePayload(record.Payload)
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate %s rows: %w", kind, err)
+	}
+
+	return records, nil
 }
 
 func (s *Store) Delete(ctx context.Context, kind EntityKind, id string, expectedLockVersion int64) error {

--- a/internal/storage/sqlite/store_test.go
+++ b/internal/storage/sqlite/store_test.go
@@ -75,6 +75,49 @@ func TestStoreRejectsInvalidPayload(t *testing.T) {
 	}
 }
 
+func TestStoreListByJSONField(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestStore(t, ctx)
+
+	records := map[string]json.RawMessage{
+		"sideeffect-1": json.RawMessage(`{"execution_id":"exec-1","status":"pending"}`),
+		"sideeffect-2": json.RawMessage(`{"execution_id":"exec-1","status":"applied"}`),
+		"sideeffect-3": json.RawMessage(`{"execution_id":"exec-2","status":"pending"}`),
+	}
+	for id, payload := range records {
+		if _, err := store.Create(ctx, SideEffectKind, id, payload); err != nil {
+			t.Fatalf("Create(%q) error = %v", id, err)
+		}
+	}
+
+	got, err := store.List(ctx, SideEffectKind, ListOptions{
+		JSONEquals: map[string]string{
+			"execution_id": "exec-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List() len = %d, want 2", len(got))
+	}
+
+	limited, err := store.List(ctx, SideEffectKind, ListOptions{
+		JSONEquals: map[string]string{
+			"status": "pending",
+		},
+		Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("List() with limit error = %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("List() with limit len = %d, want 1", len(limited))
+	}
+}
+
 func TestOpenInMemoryAndMigrate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,0 +1,628 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+const (
+	// Workflow step inputs carry engine semantics until the protobuf surface grows
+	// dedicated workflow-engine fields.
+	InputLane              = "lane"
+	InputLaneAttach        = "lane_attach"
+	InputOperation         = "operation"
+	InputBail              = "bail"
+	InputOnCancel          = "on_cancel"
+	InputBackwardOperation = "backward_operation"
+	InputBackwardTo        = "backward_to"
+
+	trunkLane = "trunk"
+)
+
+var ErrInvalidWorkflow = errors.New("workflow: invalid workflow")
+
+type CancelPolicy string
+
+const (
+	CancelPolicyBail   CancelPolicy = "bail"
+	CancelPolicyRewind CancelPolicy = "rewind"
+)
+
+type Direction string
+
+const (
+	DirectionForward  Direction = "forward"
+	DirectionBackward Direction = "backward"
+)
+
+type EffectStatus string
+
+const (
+	EffectStatusPending EffectStatus = "pending"
+	EffectStatusApplied EffectStatus = "applied"
+	EffectStatusFailed  EffectStatus = "failed"
+)
+
+type StepStatus string
+
+const (
+	StepStatusRunning   StepStatus = "running"
+	StepStatusSucceeded StepStatus = "succeeded"
+	StepStatusFailed    StepStatus = "failed"
+)
+
+type Phase struct {
+	ID                string
+	Name              string
+	AdapterID         string
+	Lane              string
+	LaneAttach        string
+	Operation         string
+	BackwardOperation string
+	BackwardTo        string
+	Bail              bool
+	OnCancel          CancelPolicy
+	Inputs            map[string]string
+}
+
+type Lateral struct {
+	ID     string
+	Attach string
+	Phases []Phase
+}
+
+type Definition struct {
+	Trunk     []Phase
+	Laterals  []Lateral
+	phaseByID map[string]Phase
+}
+
+func (d Definition) Phase(id string) (Phase, bool) {
+	phase, ok := d.phaseByID[id]
+	return phase, ok
+}
+
+func (d Definition) LateralsFor(phaseID string) []Lateral {
+	var laterals []Lateral
+	for _, lateral := range d.Laterals {
+		if lateral.Attach == phaseID {
+			laterals = append(laterals, lateral)
+		}
+	}
+	return laterals
+}
+
+type TaskStep struct {
+	ExecutionID string     `json:"execution_id"`
+	WorkflowID  string     `json:"workflow_id"`
+	IssueID     string     `json:"issue_id"`
+	PhaseID     string     `json:"phase_id"`
+	Lane        string     `json:"lane"`
+	Direction   Direction  `json:"direction"`
+	Operation   string     `json:"operation"`
+	Status      StepStatus `json:"status"`
+	Sequence    int        `json:"sequence"`
+	Error       string     `json:"error,omitempty"`
+}
+
+type SideEffect struct {
+	ExecutionID string            `json:"execution_id"`
+	WorkflowID  string            `json:"workflow_id"`
+	IssueID     string            `json:"issue_id"`
+	PhaseID     string            `json:"phase_id"`
+	Lane        string            `json:"lane"`
+	Direction   Direction         `json:"direction"`
+	AdapterID   string            `json:"adapter_id"`
+	Operation   string            `json:"operation"`
+	Status      EffectStatus      `json:"status"`
+	Sequence    int               `json:"sequence"`
+	Reason      string            `json:"reason,omitempty"`
+	TargetPhase string            `json:"target_phase,omitempty"`
+	Inputs      map[string]string `json:"inputs,omitempty"`
+	Outputs     map[string]string `json:"outputs,omitempty"`
+	Error       string            `json:"error,omitempty"`
+}
+
+type RuntimeState struct {
+	Workflow  *reinv1.Workflow
+	Issue     *reinv1.Issue
+	Execution *reinv1.Execution
+}
+
+type Runner interface {
+	Run(context.Context, *RuntimeState, Phase, Direction, *SideEffect) error
+}
+
+type Engine struct {
+	store *sqlite.Store
+}
+
+func New(store *sqlite.Store) *Engine {
+	return &Engine{store: store}
+}
+
+func Compile(workflow *reinv1.Workflow) (Definition, []*reinv1.ValidationMessage) {
+	var messages []*reinv1.ValidationMessage
+	if workflow == nil {
+		return Definition{}, []*reinv1.ValidationMessage{validationError("workflow", "workflow is required")}
+	}
+	if strings.TrimSpace(workflow.GetId()) == "" {
+		messages = append(messages, validationError("workflow.id", "workflow id is required"))
+	}
+	if strings.TrimSpace(workflow.GetName()) == "" {
+		messages = append(messages, validationError("workflow.name", "workflow name is required"))
+	}
+	if len(workflow.GetSteps()) == 0 {
+		messages = append(messages, validationError("workflow.steps", "workflow must declare at least one step"))
+		return Definition{}, messages
+	}
+
+	definition := Definition{phaseByID: map[string]Phase{}}
+	lateralIndex := map[string]int{}
+	seen := map[string]struct{}{}
+
+	for index, step := range workflow.GetSteps() {
+		field := fmt.Sprintf("workflow.steps[%d]", index)
+		phase, stepMessages := compilePhase(field, step)
+		messages = append(messages, stepMessages...)
+		if len(stepMessages) > 0 {
+			continue
+		}
+		if _, ok := seen[phase.ID]; ok {
+			messages = append(messages, validationError(field+".id", "step id must be unique"))
+			continue
+		}
+		seen[phase.ID] = struct{}{}
+		definition.phaseByID[phase.ID] = phase
+
+		if phase.Lane == trunkLane {
+			definition.Trunk = append(definition.Trunk, phase)
+			continue
+		}
+
+		idx, ok := lateralIndex[phase.Lane]
+		if !ok {
+			definition.Laterals = append(definition.Laterals, Lateral{ID: phase.Lane, Attach: phase.LaneAttach})
+			idx = len(definition.Laterals) - 1
+			lateralIndex[phase.Lane] = idx
+		}
+		lateral := &definition.Laterals[idx]
+		if lateral.Attach != phase.LaneAttach {
+			messages = append(messages, validationError(field+".inputs.lane_attach", fmt.Sprintf("lateral %q must attach to a single trunk phase", phase.Lane)))
+			continue
+		}
+		lateral.Phases = append(lateral.Phases, phase)
+	}
+
+	messages = append(messages, validateDefinition(definition)...)
+	if len(messages) > 0 {
+		return Definition{}, messages
+	}
+	return definition, nil
+}
+
+func (e *Engine) Validate(workflow *reinv1.Workflow, hasAdapter func(string) bool) []*reinv1.ValidationMessage {
+	definition, messages := Compile(workflow)
+	if len(messages) > 0 {
+		return messages
+	}
+	for _, phase := range definition.Trunk {
+		if hasAdapter != nil && !hasAdapter(phase.AdapterID) {
+			messages = append(messages, validationError("workflow.trunk", fmt.Sprintf("unknown adapter %q", phase.AdapterID)))
+		}
+	}
+	for _, lateral := range definition.Laterals {
+		for _, phase := range lateral.Phases {
+			if hasAdapter != nil && !hasAdapter(phase.AdapterID) {
+				messages = append(messages, validationError("workflow.laterals", fmt.Sprintf("unknown adapter %q", phase.AdapterID)))
+			}
+		}
+	}
+	return messages
+}
+
+func (e *Engine) Run(ctx context.Context, state *RuntimeState, runner Runner) error {
+	definition, messages := Compile(state.Workflow)
+	if len(messages) > 0 {
+		return fmt.Errorf("%w: %s", ErrInvalidWorkflow, messages[0].GetMessage())
+	}
+
+	stack, err := e.completedStack(ctx, definition, state.Execution.GetId())
+	if err != nil {
+		return err
+	}
+
+	for _, phase := range definition.Trunk {
+		if containsPhase(stack, phase.ID) {
+			continue
+		}
+		if err := e.runPhase(ctx, state, runner, phase, DirectionForward, "", ""); err != nil {
+			if phase.Bail {
+				if rewindErr := e.rewind(ctx, state, runner, stack, "", "bail"); rewindErr != nil {
+					return errors.Join(err, rewindErr)
+				}
+			}
+			return err
+		}
+		stack = append(stack, phase)
+		for _, lateral := range definition.LateralsFor(phase.ID) {
+			for _, lateralPhase := range lateral.Phases {
+				if containsPhase(stack, lateralPhase.ID) {
+					continue
+				}
+				if err := e.runPhase(ctx, state, runner, lateralPhase, DirectionForward, "", lateral.Attach); err != nil {
+					if lateralPhase.Bail {
+						if rewindErr := e.rewind(ctx, state, runner, stack, "", "bail"); rewindErr != nil {
+							return errors.Join(err, rewindErr)
+						}
+					}
+					return err
+				}
+				stack = append(stack, lateralPhase)
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Engine) Cancel(ctx context.Context, state *RuntimeState, runner Runner, reason string) error {
+	definition, messages := Compile(state.Workflow)
+	if len(messages) > 0 {
+		return fmt.Errorf("%w: %s", ErrInvalidWorkflow, messages[0].GetMessage())
+	}
+	stack, err := e.completedStack(ctx, definition, state.Execution.GetId())
+	if err != nil {
+		return err
+	}
+	for len(stack) > 0 {
+		phase := stack[len(stack)-1]
+		if phase.OnCancel != CancelPolicyRewind {
+			break
+		}
+		if err := e.runPhase(ctx, state, runner, phase, DirectionBackward, "cancel:"+reason, phase.BackwardTo); err != nil {
+			return err
+		}
+		stack = stack[:len(stack)-1]
+	}
+	return nil
+}
+
+func (e *Engine) Rewind(ctx context.Context, state *RuntimeState, runner Runner, targetPhaseID, reason string) error {
+	definition, messages := Compile(state.Workflow)
+	if len(messages) > 0 {
+		return fmt.Errorf("%w: %s", ErrInvalidWorkflow, messages[0].GetMessage())
+	}
+	stack, err := e.completedStack(ctx, definition, state.Execution.GetId())
+	if err != nil {
+		return err
+	}
+	if targetPhaseID != "" && !containsPhase(stack, targetPhaseID) {
+		return fmt.Errorf("workflow: phase %q is not active", targetPhaseID)
+	}
+	return e.rewind(ctx, state, runner, stack, targetPhaseID, "rewind:"+reason)
+}
+
+func (e *Engine) ListTaskSteps(ctx context.Context, executionID string) ([]TaskStep, error) {
+	records, err := e.store.List(ctx, sqlite.TaskStepKind, sqlite.ListOptions{JSONEquals: map[string]string{"execution_id": executionID}})
+	if err != nil {
+		return nil, err
+	}
+	steps := make([]TaskStep, 0, len(records))
+	for _, record := range records {
+		var step TaskStep
+		if err := json.Unmarshal(record.Payload, &step); err != nil {
+			return nil, fmt.Errorf("workflow: decode task step %q: %w", record.ID, err)
+		}
+		steps = append(steps, step)
+	}
+	return steps, nil
+}
+
+func (e *Engine) ListSideEffects(ctx context.Context, executionID string) ([]SideEffect, error) {
+	records, err := e.store.List(ctx, sqlite.SideEffectKind, sqlite.ListOptions{JSONEquals: map[string]string{"execution_id": executionID}})
+	if err != nil {
+		return nil, err
+	}
+	effects := make([]SideEffect, 0, len(records))
+	for _, record := range records {
+		var effect SideEffect
+		if err := json.Unmarshal(record.Payload, &effect); err != nil {
+			return nil, fmt.Errorf("workflow: decode side effect %q: %w", record.ID, err)
+		}
+		effects = append(effects, effect)
+	}
+	return effects, nil
+}
+
+func (e *Engine) completedStack(ctx context.Context, definition Definition, executionID string) ([]Phase, error) {
+	steps, err := e.ListTaskSteps(ctx, executionID)
+	if err != nil {
+		return nil, err
+	}
+	var stack []Phase
+	for _, step := range steps {
+		phase, ok := definition.Phase(step.PhaseID)
+		if !ok || step.Status != StepStatusSucceeded {
+			continue
+		}
+		switch step.Direction {
+		case DirectionForward:
+			stack = append(stack, phase)
+		case DirectionBackward:
+			if len(stack) == 0 {
+				continue
+			}
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return stack, nil
+}
+
+func (e *Engine) rewind(ctx context.Context, state *RuntimeState, runner Runner, stack []Phase, targetPhaseID, reason string) error {
+	for len(stack) > 0 {
+		phase := stack[len(stack)-1]
+		if targetPhaseID != "" && phase.ID == targetPhaseID {
+			break
+		}
+		if err := e.runPhase(ctx, state, runner, phase, DirectionBackward, reason, phase.BackwardTo); err != nil {
+			return err
+		}
+		stack = stack[:len(stack)-1]
+	}
+	return nil
+}
+
+func (e *Engine) runPhase(ctx context.Context, state *RuntimeState, runner Runner, phase Phase, direction Direction, reason, target string) error {
+	sequence, err := e.nextSequence(ctx, state.Execution.GetId())
+	if err != nil {
+		return err
+	}
+	operation := phase.Operation
+	if direction == DirectionBackward {
+		operation = phase.BackwardOperation
+		if operation == "" {
+			operation = "rewind"
+		}
+	}
+
+	step := TaskStep{
+		ExecutionID: state.Execution.GetId(),
+		WorkflowID:  state.Workflow.GetId(),
+		IssueID:     state.Issue.GetId(),
+		PhaseID:     phase.ID,
+		Lane:        phase.Lane,
+		Direction:   direction,
+		Operation:   operation,
+		Status:      StepStatusRunning,
+		Sequence:    sequence,
+	}
+	stepRecord, err := e.createTaskStep(ctx, step)
+	if err != nil {
+		return err
+	}
+
+	effect := SideEffect{
+		ExecutionID: state.Execution.GetId(),
+		WorkflowID:  state.Workflow.GetId(),
+		IssueID:     state.Issue.GetId(),
+		PhaseID:     phase.ID,
+		Lane:        phase.Lane,
+		Direction:   direction,
+		AdapterID:   phase.AdapterID,
+		Operation:   operation,
+		Status:      EffectStatusPending,
+		Sequence:    sequence,
+		Reason:      reason,
+		TargetPhase: target,
+		Inputs:      cloneStringMap(phase.Inputs),
+	}
+	effectRecord, err := e.createSideEffect(ctx, effect)
+	if err != nil {
+		return err
+	}
+
+	shouldInvokeRunner := direction == DirectionForward || phase.BackwardOperation != ""
+	if shouldInvokeRunner && runner != nil {
+		err = runner.Run(ctx, state, phase, direction, &effect)
+	}
+	if err != nil {
+		effect.Status = EffectStatusFailed
+		effect.Error = err.Error()
+		step.Status = StepStatusFailed
+		step.Error = err.Error()
+	} else {
+		effect.Status = EffectStatusApplied
+		step.Status = StepStatusSucceeded
+	}
+
+	if _, updateErr := e.updateSideEffect(ctx, effectRecord, effect); updateErr != nil {
+		return updateErr
+	}
+	if _, updateErr := e.updateTaskStep(ctx, stepRecord, step); updateErr != nil {
+		return updateErr
+	}
+	return err
+}
+
+func (e *Engine) nextSequence(ctx context.Context, executionID string) (int, error) {
+	effects, err := e.ListSideEffects(ctx, executionID)
+	if err != nil {
+		return 0, err
+	}
+	return len(effects) + 1, nil
+}
+
+func (e *Engine) createTaskStep(ctx context.Context, step TaskStep) (sqlite.Record, error) {
+	payload, err := json.Marshal(step)
+	if err != nil {
+		return sqlite.Record{}, fmt.Errorf("workflow: encode task step: %w", err)
+	}
+	return e.store.Create(ctx, sqlite.TaskStepKind, recordID(step.ExecutionID, step.Sequence, step.Direction, step.PhaseID, "step"), payload)
+}
+
+func (e *Engine) updateTaskStep(ctx context.Context, record sqlite.Record, step TaskStep) (sqlite.Record, error) {
+	payload, err := json.Marshal(step)
+	if err != nil {
+		return sqlite.Record{}, fmt.Errorf("workflow: encode task step: %w", err)
+	}
+	return e.store.Update(ctx, sqlite.TaskStepKind, record.ID, record.LockVersion, payload)
+}
+
+func (e *Engine) createSideEffect(ctx context.Context, effect SideEffect) (sqlite.Record, error) {
+	payload, err := json.Marshal(effect)
+	if err != nil {
+		return sqlite.Record{}, fmt.Errorf("workflow: encode side effect: %w", err)
+	}
+	return e.store.Create(ctx, sqlite.SideEffectKind, recordID(effect.ExecutionID, effect.Sequence, effect.Direction, effect.PhaseID, "effect"), payload)
+}
+
+func (e *Engine) updateSideEffect(ctx context.Context, record sqlite.Record, effect SideEffect) (sqlite.Record, error) {
+	payload, err := json.Marshal(effect)
+	if err != nil {
+		return sqlite.Record{}, fmt.Errorf("workflow: encode side effect: %w", err)
+	}
+	return e.store.Update(ctx, sqlite.SideEffectKind, record.ID, record.LockVersion, payload)
+}
+
+func compilePhase(field string, step *reinv1.WorkflowStep) (Phase, []*reinv1.ValidationMessage) {
+	var messages []*reinv1.ValidationMessage
+	if step == nil {
+		return Phase{}, []*reinv1.ValidationMessage{validationError(field, "step is required")}
+	}
+	phase := Phase{
+		ID:        strings.TrimSpace(step.GetId()),
+		Name:      strings.TrimSpace(step.GetName()),
+		AdapterID: strings.TrimSpace(step.GetAdapterId()),
+		Operation: strings.TrimSpace(step.GetInputs()[InputOperation]),
+		Inputs:    cloneStringMap(step.GetInputs()),
+	}
+	if phase.Operation == "" {
+		phase.Operation = phase.ID
+	}
+	lane := strings.TrimSpace(step.GetInputs()[InputLane])
+	if lane == "" {
+		lane = trunkLane
+	}
+	phase.Lane = lane
+	phase.LaneAttach = strings.TrimSpace(step.GetInputs()[InputLaneAttach])
+	phase.BackwardOperation = strings.TrimSpace(step.GetInputs()[InputBackwardOperation])
+	phase.BackwardTo = strings.TrimSpace(step.GetInputs()[InputBackwardTo])
+	if phase.BackwardTo == "" && phase.Lane != trunkLane {
+		phase.BackwardTo = phase.LaneAttach
+	}
+	if phase.BackwardTo == "" && phase.Lane == trunkLane && len(step.GetDependsOn()) > 0 {
+		phase.BackwardTo = step.GetDependsOn()[0]
+	}
+
+	if phase.ID == "" {
+		messages = append(messages, validationError(field+".id", "step id is required"))
+	}
+	if phase.Name == "" {
+		messages = append(messages, validationError(field+".name", "step name is required"))
+	}
+	if phase.AdapterID == "" {
+		messages = append(messages, validationError(field+".adapter_id", "step adapter_id is required"))
+	}
+	if phase.Lane != trunkLane && phase.LaneAttach == "" {
+		messages = append(messages, validationError(field+".inputs.lane_attach", "lateral steps require lane_attach"))
+	}
+
+	if raw := strings.TrimSpace(step.GetInputs()[InputBail]); raw != "" {
+		bail, err := strconv.ParseBool(raw)
+		if err != nil {
+			messages = append(messages, validationError(field+".inputs.bail", "bail must be a boolean"))
+		} else {
+			phase.Bail = bail
+		}
+	}
+
+	rawCancel := strings.TrimSpace(step.GetInputs()[InputOnCancel])
+	switch rawCancel {
+	case "", string(CancelPolicyBail):
+		phase.OnCancel = CancelPolicyBail
+	case string(CancelPolicyRewind):
+		phase.OnCancel = CancelPolicyRewind
+	default:
+		messages = append(messages, validationError(field+".inputs.on_cancel", "on_cancel must be bail or rewind"))
+	}
+	return phase, messages
+}
+
+func validateDefinition(definition Definition) []*reinv1.ValidationMessage {
+	var messages []*reinv1.ValidationMessage
+	if len(definition.Trunk) == 0 {
+		messages = append(messages, validationError("workflow.steps", "workflow must declare at least one trunk step"))
+		return messages
+	}
+
+	for index, phase := range definition.Trunk {
+		if phase.LaneAttach != "" {
+			messages = append(messages, validationError("workflow.trunk", fmt.Sprintf("trunk step %q cannot declare lane_attach", phase.ID)))
+		}
+		if index == 0 {
+			continue
+		}
+	}
+
+	seenAttach := map[string]struct{}{}
+	for _, phase := range definition.Trunk {
+		seenAttach[phase.ID] = struct{}{}
+	}
+	for _, lateral := range definition.Laterals {
+		if _, ok := seenAttach[lateral.Attach]; !ok {
+			messages = append(messages, validationError("workflow.laterals", fmt.Sprintf("lateral %q attaches to unknown trunk phase %q", lateral.ID, lateral.Attach)))
+			continue
+		}
+		if len(lateral.Phases) == 0 {
+			messages = append(messages, validationError("workflow.laterals", fmt.Sprintf("lateral %q must contain at least one step", lateral.ID)))
+			continue
+		}
+		for _, phase := range lateral.Phases {
+			if phase.LaneAttach != lateral.Attach {
+				messages = append(messages, validationError("workflow.laterals", fmt.Sprintf("lateral %q must attach all steps to %q", lateral.ID, lateral.Attach)))
+			}
+		}
+	}
+	return messages
+}
+
+func validationError(field, message string) *reinv1.ValidationMessage {
+	return &reinv1.ValidationMessage{Severity: reinv1.ValidationMessage_SEVERITY_ERROR, Field: field, Message: message}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	cloned := make(map[string]string, len(keys))
+	for _, key := range keys {
+		cloned[key] = values[key]
+	}
+	return cloned
+}
+
+func containsPhase(phases []Phase, id string) bool {
+	for _, phase := range phases {
+		if phase.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func recordID(executionID string, sequence int, direction Direction, phaseID, suffix string) string {
+	return fmt.Sprintf("%s-%03d-%s-%s-%s", executionID, sequence, direction, phaseID, suffix)
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1,0 +1,234 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+func TestCompileRejectsLateralWithoutAttach(t *testing.T) {
+	t.Parallel()
+
+	_, messages := Compile(&reinv1.Workflow{
+		Id:   "wf-invalid",
+		Name: "invalid",
+		Steps: []*reinv1.WorkflowStep{{
+			Id:        "open-pr",
+			Name:      "Open PR",
+			AdapterId: "coding",
+			Inputs: map[string]string{
+				InputLane:      "review-cycle",
+				InputOperation: "open-pr",
+			},
+		}},
+	})
+	if len(messages) == 0 {
+		t.Fatal("Compile() messages = 0, want validation errors")
+	}
+}
+
+func TestEngineBailRewindsCompletedPhases(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	engine, state := newEngineTestHarness(t, managedWorkflowDefinition())
+	runner := &scriptedRunner{
+		fail: map[string]error{
+			"forward:merge-pr:merge": errors.New("merge failed"),
+		},
+	}
+
+	err := engine.Run(ctx, state, runner)
+	if err == nil || err.Error() != "merge failed" {
+		t.Fatalf("Run() error = %v, want merge failed", err)
+	}
+
+	wantCalls := []string{
+		"forward:prepare-branch:prepare",
+		"forward:open-pr:open-pr",
+		"forward:approve-pr:approve-pr",
+		"forward:merge-pr:merge",
+		"backward:approve-pr:dismiss-review",
+		"backward:open-pr:close-pr",
+		"backward:prepare-branch:cleanup-branch",
+	}
+	if got := runner.calls; fmt.Sprint(got) != fmt.Sprint(wantCalls) {
+		t.Fatalf("Run() calls = %v, want %v", got, wantCalls)
+	}
+
+	effects, err := engine.ListSideEffects(ctx, state.Execution.GetId())
+	if err != nil {
+		t.Fatalf("ListSideEffects() error = %v", err)
+	}
+	if len(effects) != len(wantCalls) {
+		t.Fatalf("ListSideEffects() len = %d, want %d", len(effects), len(wantCalls))
+	}
+	if got := effects[len(effects)-1].Operation; got != "cleanup-branch" {
+		t.Fatalf("last side effect operation = %q, want cleanup-branch", got)
+	}
+}
+
+func TestEngineRewindAndCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	engine, state := newEngineTestHarness(t, managedWorkflowDefinition())
+	runner := &scriptedRunner{}
+
+	if err := engine.Run(ctx, state, runner); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if err := engine.Rewind(ctx, state, runner, "prepare-branch", "operator rewind"); err != nil {
+		t.Fatalf("Rewind() error = %v", err)
+	}
+	if err := engine.Cancel(ctx, state, runner, "user canceled"); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+
+	wantCalls := []string{
+		"forward:prepare-branch:prepare",
+		"forward:open-pr:open-pr",
+		"forward:approve-pr:approve-pr",
+		"forward:merge-pr:merge",
+		"backward:merge-pr:reopen-merge",
+		"backward:approve-pr:dismiss-review",
+		"backward:open-pr:close-pr",
+		"backward:prepare-branch:cleanup-branch",
+	}
+	if got := runner.calls; fmt.Sprint(got) != fmt.Sprint(wantCalls) {
+		t.Fatalf("calls = %v, want %v", got, wantCalls)
+	}
+
+	steps, err := engine.ListTaskSteps(ctx, state.Execution.GetId())
+	if err != nil {
+		t.Fatalf("ListTaskSteps() error = %v", err)
+	}
+	if len(steps) != len(wantCalls) {
+		t.Fatalf("ListTaskSteps() len = %d, want %d", len(steps), len(wantCalls))
+	}
+	if got := steps[len(steps)-1].Direction; got != DirectionBackward {
+		t.Fatalf("last task step direction = %s, want %s", got, DirectionBackward)
+	}
+}
+
+func newEngineTestHarness(t *testing.T, workflowEntity *reinv1.Workflow) (*Engine, *RuntimeState) {
+	t.Helper()
+
+	store, err := sqlite.OpenInMemoryAndMigrate(context.Background(), t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	})
+
+	return New(store), &RuntimeState{
+		Workflow: workflowEntity,
+		Issue: &reinv1.Issue{
+			Id:     "RN-10",
+			Labels: map[string]string{},
+		},
+		Execution: &reinv1.Execution{
+			Id:       "exec-rn-10-001",
+			IssueId:  "RN-10",
+			Metadata: map[string]string{"base_branch": "main"},
+		},
+	}
+}
+
+type scriptedRunner struct {
+	calls []string
+	fail  map[string]error
+}
+
+func (r *scriptedRunner) Run(_ context.Context, state *RuntimeState, phase Phase, direction Direction, effect *SideEffect) error {
+	key := fmt.Sprintf("%s:%s:%s", direction, phase.ID, effect.Operation)
+	r.calls = append(r.calls, key)
+	if state.Execution.Metadata == nil {
+		state.Execution.Metadata = map[string]string{}
+	}
+	if state.Issue.Labels == nil {
+		state.Issue.Labels = map[string]string{}
+	}
+	state.Execution.Metadata[phase.ID] = string(direction)
+	state.Issue.Labels[phase.ID] = effect.Operation
+	effect.Outputs = map[string]string{"phase": phase.ID, "direction": string(direction)}
+	if err, ok := r.fail[key]; ok {
+		return err
+	}
+	return nil
+}
+
+func managedWorkflowDefinition() *reinv1.Workflow {
+	created := timestamppb.New(time.Date(2026, time.May, 2, 12, 0, 0, 0, time.UTC))
+	return &reinv1.Workflow{
+		Id:          "managed-issue-pr-review-merge",
+		Name:        "Managed issue to merge",
+		Description: "Trunk plus review lateral workflow",
+		Version:     "0.2.0",
+		CreatedTime: created,
+		UpdatedTime: created,
+		Steps: []*reinv1.WorkflowStep{
+			{
+				Id:        "prepare-branch",
+				Name:      "Prepare issue branch and worktree",
+				AdapterId: "tracker",
+				Inputs: map[string]string{
+					InputOperation:         "prepare",
+					InputBail:              "true",
+					InputOnCancel:          string(CancelPolicyRewind),
+					InputBackwardOperation: "cleanup-branch",
+				},
+			},
+			{
+				Id:        "open-pr",
+				Name:      "Open pull request",
+				AdapterId: "coding",
+				Inputs: map[string]string{
+					InputLane:              "review-cycle",
+					InputLaneAttach:        "prepare-branch",
+					InputOperation:         "open-pr",
+					InputBail:              "true",
+					InputOnCancel:          string(CancelPolicyRewind),
+					InputBackwardOperation: "close-pr",
+					InputBackwardTo:        "prepare-branch",
+				},
+			},
+			{
+				Id:        "approve-pr",
+				Name:      "Approve pull request",
+				AdapterId: "review",
+				Inputs: map[string]string{
+					InputLane:              "review-cycle",
+					InputLaneAttach:        "prepare-branch",
+					InputOperation:         "approve-pr",
+					InputBail:              "true",
+					InputOnCancel:          string(CancelPolicyRewind),
+					InputBackwardOperation: "dismiss-review",
+					InputBackwardTo:        "open-pr",
+				},
+			},
+			{
+				Id:        "merge-pr",
+				Name:      "Merge pull request",
+				AdapterId: "tracker",
+				Inputs: map[string]string{
+					InputOperation:         "merge",
+					InputBail:              "true",
+					InputOnCancel:          string(CancelPolicyBail),
+					InputBackwardOperation: "reopen-merge",
+					InputBackwardTo:        "approve-pr",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add a reusable internal workflow engine that compiles trunk and lateral lanes from workflow step inputs and persists TaskStep/SideEffect records
- add managed store-backed services that validate workflows and execute deterministic forward, rewind, bail, and cancel paths against adapter catalogs
- cover the engine with unit and bufconn runtime tests, plus SQLite JSON listing helpers for workflow state inspection

## Validation
- just ci

Closes #9