### PR TITLE
RN-16: Add instance-aware state layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # rein
 Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMIs (CLI/TUI) + plugin marketplace.
 
+## Instance state layout
+
+- Rein keeps per-instance state under `~/.local/state/rein/instances/<name>/` by default, or under `$XDG_STATE_HOME/rein/instances/<name>/` when `XDG_STATE_HOME` is set.
+- The active instance is selected with `--instance <name>` or `REIN_INSTANCE=<name>`; when neither is set, rein uses the `live` instance.
+- Only the `live` instance is eligible for future auto-start behavior. Other instances must be started explicitly.
+- The current reserved layout is:
+  - `grpc.sock` — default unix gRPC listener socket for that instance.
+  - `rein.db` — canonical SQLite path reserved for that instance's persisted state.
+- `rein doctor` will validate that commands and on-disk state follow this canonical layout in a future issue.
+
 ## Development
 
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.

--- a/cmd/rein/config.go
+++ b/cmd/rein/config.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/server"
+)
+
+type runtimeConfig struct {
+	instance instance.Layout
+	listener server.ListenerConfig
+}
+
+func parseRuntimeConfig(args []string, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error)) (runtimeConfig, error) {
+	defaults := server.DefaultListenerConfig()
+	flagSet := flag.NewFlagSet("rein", flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+
+	instanceName := flagSet.String("instance", "", fmt.Sprintf("instance name (default %q or %s)", instance.DefaultName, instance.EnvVar))
+	network := flagSet.String("grpc-network", "", fmt.Sprintf("listener network: tcp or unix (default %q)", defaults.Network))
+	address := flagSet.String("grpc-address", "", "listener address or unix socket path")
+	requirePeerCredentials := flagSet.Bool("grpc-require-peer-credentials", defaults.RequirePeerCredentials, "require SO_PEERCRED same-UID authentication for unix sockets")
+
+	if err := flagSet.Parse(args); err != nil {
+		return runtimeConfig{}, err
+	}
+
+	layout, err := instance.Resolve(instance.ResolveOptions{
+		Name:        *instanceName,
+		LookupEnv:   lookupEnv,
+		UserHomeDir: userHomeDir,
+	})
+	if err != nil {
+		return runtimeConfig{}, err
+	}
+
+	visited := map[string]bool{}
+	flagSet.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+
+	listener := defaults
+	if visited["grpc-network"] {
+		listener.Network = *network
+	}
+	listener.Address = defaultListenerAddress(listener.Network, layout)
+	if visited["grpc-address"] {
+		listener.Address = *address
+	}
+	listener.RequirePeerCredentials = *requirePeerCredentials
+	listener.UnixSocketMode = 0o600
+
+	return runtimeConfig{
+		instance: layout,
+		listener: listener,
+	}, nil
+}
+
+func defaultListenerAddress(network string, layout instance.Layout) string {
+	if network == "unix" {
+		return layout.SocketPath
+	}
+
+	return server.DefaultListenerAddress(network)
+}

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"testing"
+
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/server"
+)
+
+func TestParseRuntimeConfigUsesDefaultLiveInstance(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseRuntimeConfig(nil, io.Discard, nil, func() (string, error) {
+		return "/Users/tester", nil
+	})
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig() error = %v", err)
+	}
+
+	if config.instance.Name != instance.DefaultName {
+		t.Fatalf("instance name = %q, want %q", config.instance.Name, instance.DefaultName)
+	}
+	if config.listener.Network != server.DefaultListenerNetwork() {
+		t.Fatalf("listener network = %q, want %q", config.listener.Network, server.DefaultListenerNetwork())
+	}
+	if config.listener.Network == "unix" && config.listener.Address != config.instance.SocketPath {
+		t.Fatalf("listener address = %q, want %q", config.listener.Address, config.instance.SocketPath)
+	}
+}
+
+func TestParseRuntimeConfigUsesEnvSelectedInstance(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseRuntimeConfig(nil, io.Discard, func(key string) (string, bool) {
+		switch key {
+		case instance.EnvVar:
+			return "staging", true
+		case "XDG_STATE_HOME":
+			return "/state", true
+		default:
+			return "", false
+		}
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig() error = %v", err)
+	}
+
+	if config.instance.Name != "staging" {
+		t.Fatalf("instance name = %q, want %q", config.instance.Name, "staging")
+	}
+	if config.listener.Address != config.instance.SocketPath {
+		t.Fatalf("listener address = %q, want %q", config.listener.Address, config.instance.SocketPath)
+	}
+}
+
+func TestParseRuntimeConfigFlagOverridesEnv(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseRuntimeConfig([]string{"--instance", "dev"}, io.Discard, func(key string) (string, bool) {
+		switch key {
+		case instance.EnvVar:
+			return "staging", true
+		case "XDG_STATE_HOME":
+			return "/state", true
+		default:
+			return "", false
+		}
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig() error = %v", err)
+	}
+
+	if config.instance.Name != "dev" {
+		t.Fatalf("instance name = %q, want %q", config.instance.Name, "dev")
+	}
+}
+
+func TestParseRuntimeConfigUsesTCPDefaultsWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseRuntimeConfig([]string{"--grpc-network", "tcp"}, io.Discard, func(key string) (string, bool) {
+		if key == "XDG_STATE_HOME" {
+			return "/state", true
+		}
+		return "", false
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig() error = %v", err)
+	}
+
+	if config.listener.Network != "tcp" {
+		t.Fatalf("listener network = %q, want %q", config.listener.Network, "tcp")
+	}
+	if config.listener.Address != server.DefaultListenerAddress("tcp") {
+		t.Fatalf("listener address = %q, want %q", config.listener.Address, server.DefaultListenerAddress("tcp"))
+	}
+}
+
+func TestParseRuntimeConfigHonorsExplicitAddress(t *testing.T) {
+	t.Parallel()
+
+	config, err := parseRuntimeConfig([]string{"--grpc-network", "unix", "--grpc-address", "/override.sock"}, io.Discard, func(key string) (string, bool) {
+		if key == "XDG_STATE_HOME" {
+			return "/state", true
+		}
+		return "", false
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseRuntimeConfig() error = %v", err)
+	}
+
+	if config.listener.Address != "/override.sock" {
+		t.Fatalf("listener address = %q, want %q", config.listener.Address, "/override.sock")
+	}
+}
+
+func TestParseRuntimeConfigRejectsInvalidInstance(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRuntimeConfig(nil, io.Discard, func(key string) (string, bool) {
+		switch key {
+		case instance.EnvVar:
+			return "../oops", true
+		case "XDG_STATE_HOME":
+			return "/state", true
+		default:
+			return "", false
+		}
+	}, nil)
+	if err == nil {
+		t.Fatal("parseRuntimeConfig() error = nil, want non-nil")
+	}
+}
+
+func TestParseErrorExitCodeHandlesHelpAndDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	if got := parseErrorExitCode(flag.ErrHelp, &stderr); got != 0 {
+		t.Fatalf("parseErrorExitCode(flag.ErrHelp) = %d, want 0", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty for help", stderr.String())
+	}
+
+	if got := parseErrorExitCode(instance.ErrInvalidName, &stderr); got != 2 {
+		t.Fatalf("parseErrorExitCode(invalid) = %d, want 2", got)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("stderr = empty, want diagnostic output")
+	}
+}

--- a/cmd/rein/main.go
+++ b/cmd/rein/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -17,22 +20,21 @@ func main() {
 }
 
 func run() int {
-	defaults := server.DefaultListenerConfig()
-
-	network := flag.String("grpc-network", defaults.Network, "listener network: tcp or unix")
-	address := flag.String("grpc-address", defaults.Address, "listener address or unix socket path")
-	requirePeerCredentials := flag.Bool("grpc-require-peer-credentials", defaults.RequirePeerCredentials, "require SO_PEERCRED same-UID authentication for unix sockets")
-	flag.Parse()
+	config, err := parseRuntimeConfig(os.Args[1:], os.Stderr, os.LookupEnv, os.UserHomeDir)
+	if err != nil {
+		return parseErrorExitCode(err, os.Stderr)
+	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	if err := config.instance.EnsureRootDir(); err != nil {
+		logger.Error("failed to prepare instance state directory", "error", err)
+		return 1
+	}
 
-	listener, err := server.Listen(server.ListenerConfig{
-		Network:                *network,
-		Address:                *address,
-		UnixSocketMode:         0o600,
-		RequirePeerCredentials: *requirePeerCredentials,
-		Logger:                 logger,
-	})
+	listenerConfig := config.listener
+	listenerConfig.Logger = logger
+
+	listener, err := server.Listen(listenerConfig)
 	if err != nil {
 		logger.Error("failed to create listener", "error", err)
 		return 1
@@ -47,7 +49,14 @@ func run() int {
 		Services: service.NewSet(),
 	})
 
-	logger.Info("rein gRPC server starting", "network", *network, "address", listener.Addr().String())
+	logger.Info(
+		"rein gRPC server starting",
+		"instance", config.instance.Name,
+		"state_dir", config.instance.RootDir,
+		"network", listenerConfig.Network,
+		"address", listener.Addr().String(),
+		"auto_start", config.instance.AutoStartEnabled(),
+	)
 	logger.Info(
 		"rein HTTP/SSE gateway v2 stub ready",
 		"routes", len(runtime.Gateway().Routes()),
@@ -63,4 +72,13 @@ func run() int {
 	}
 
 	return 0
+}
+
+func parseErrorExitCode(err error, stderr io.Writer) int {
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+
+	_, _ = fmt.Fprintln(stderr, err)
+	return 2
 }

--- a/internal/instance/layout.go
+++ b/internal/instance/layout.go
@@ -1,0 +1,164 @@
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const (
+	DefaultName      = "live"
+	EnvVar           = "REIN_INSTANCE"
+	rootDirName      = "rein"
+	instancesDirName = "instances"
+	socketFileName   = "grpc.sock"
+	storeFileName    = "rein.db"
+)
+
+var (
+	ErrEmptyName         = errors.New("instance: empty name")
+	ErrInvalidName       = errors.New("instance: invalid name")
+	ErrMissingStateHome  = errors.New("instance: state home unavailable")
+	ErrRelativeStateHome = errors.New("instance: state home must be absolute")
+
+	instanceNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+)
+
+type Layout struct {
+	Name         string
+	StateHome    string
+	RootDir      string
+	SocketPath   string
+	DatabasePath string
+}
+
+type ResolveOptions struct {
+	Name        string
+	LookupEnv   func(string) (string, bool)
+	UserHomeDir func() (string, error)
+}
+
+func Resolve(options ResolveOptions) (Layout, error) {
+	name := options.Name
+	if name == "" {
+		if lookupEnv := options.LookupEnv; lookupEnv != nil {
+			if value, ok := lookupEnv(EnvVar); ok && value != "" {
+				name = value
+			}
+		}
+	}
+	if name == "" {
+		name = DefaultName
+	}
+
+	stateHome, err := resolveStateHome(options)
+	if err != nil {
+		return Layout{}, err
+	}
+
+	return NewLayout(name, stateHome)
+}
+
+func NewLayout(name, stateHome string) (Layout, error) {
+	if err := ValidateName(name); err != nil {
+		return Layout{}, err
+	}
+	if stateHome == "" {
+		return Layout{}, ErrMissingStateHome
+	}
+	if !filepath.IsAbs(stateHome) {
+		return Layout{}, fmt.Errorf("%w: %q", ErrRelativeStateHome, stateHome)
+	}
+
+	stateHome = filepath.Clean(stateHome)
+	rootDir := filepath.Join(stateHome, rootDirName, instancesDirName, name)
+
+	layout := Layout{
+		Name:         name,
+		StateHome:    stateHome,
+		RootDir:      rootDir,
+		SocketPath:   filepath.Join(rootDir, socketFileName),
+		DatabasePath: filepath.Join(rootDir, storeFileName),
+	}
+
+	if err := layout.Validate(); err != nil {
+		return Layout{}, err
+	}
+
+	return layout, nil
+}
+
+func ValidateName(name string) error {
+	switch {
+	case name == "":
+		return ErrEmptyName
+	case name == "." || name == "..":
+		return fmt.Errorf("%w %q", ErrInvalidName, name)
+	case !instanceNamePattern.MatchString(name):
+		return fmt.Errorf("%w %q", ErrInvalidName, name)
+	}
+
+	return nil
+}
+
+func (l Layout) Validate() error {
+	if err := ValidateName(l.Name); err != nil {
+		return err
+	}
+	if l.StateHome == "" {
+		return ErrMissingStateHome
+	}
+	if !filepath.IsAbs(l.StateHome) {
+		return fmt.Errorf("%w: %q", ErrRelativeStateHome, l.StateHome)
+	}
+
+	expectedRoot := filepath.Join(filepath.Clean(l.StateHome), rootDirName, instancesDirName, l.Name)
+	if filepath.Clean(l.RootDir) != expectedRoot {
+		return fmt.Errorf("instance: root dir %q does not match canonical layout %q", l.RootDir, expectedRoot)
+	}
+	if filepath.Clean(l.SocketPath) != filepath.Join(expectedRoot, socketFileName) {
+		return fmt.Errorf("instance: socket path %q does not match canonical layout", l.SocketPath)
+	}
+	if filepath.Clean(l.DatabasePath) != filepath.Join(expectedRoot, storeFileName) {
+		return fmt.Errorf("instance: database path %q does not match canonical layout", l.DatabasePath)
+	}
+
+	return nil
+}
+
+func (l Layout) EnsureRootDir() error {
+	if err := l.Validate(); err != nil {
+		return err
+	}
+
+	return os.MkdirAll(l.RootDir, 0o755)
+}
+
+func (l Layout) AutoStartEnabled() bool {
+	return l.Name == DefaultName
+}
+
+func resolveStateHome(options ResolveOptions) (string, error) {
+	if lookupEnv := options.LookupEnv; lookupEnv != nil {
+		if value, ok := lookupEnv("XDG_STATE_HOME"); ok && value != "" {
+			return value, nil
+		}
+	}
+
+	userHomeDir := options.UserHomeDir
+	if userHomeDir == nil {
+		userHomeDir = os.UserHomeDir
+	}
+
+	homeDir, err := userHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("instance: resolve home dir: %w", err)
+	}
+	if homeDir == "" {
+		return "", ErrMissingStateHome
+	}
+
+	return filepath.Join(homeDir, ".local", "state"), nil
+}

--- a/internal/instance/layout_test.go
+++ b/internal/instance/layout_test.go
@@ -1,0 +1,158 @@
+package instance
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveUsesFlagThenEnvThenDefault(t *testing.T) {
+	t.Parallel()
+
+	lookupEnv := func(key string) (string, bool) {
+		switch key {
+		case EnvVar:
+			return "staging", true
+		case "XDG_STATE_HOME":
+			return "/state", true
+		default:
+			return "", false
+		}
+	}
+
+	layout, err := Resolve(ResolveOptions{
+		Name:      "dev",
+		LookupEnv: lookupEnv,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if layout.Name != "dev" {
+		t.Fatalf("Resolve() name = %q, want %q", layout.Name, "dev")
+	}
+
+	layout, err = Resolve(ResolveOptions{
+		LookupEnv: lookupEnv,
+	})
+	if err != nil {
+		t.Fatalf("Resolve() env error = %v", err)
+	}
+	if layout.Name != "staging" {
+		t.Fatalf("Resolve() env name = %q, want %q", layout.Name, "staging")
+	}
+
+	layout, err = Resolve(ResolveOptions{
+		LookupEnv: func(key string) (string, bool) {
+			if key == "XDG_STATE_HOME" {
+				return "/state", true
+			}
+			return "", false
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() default error = %v", err)
+	}
+	if layout.Name != DefaultName {
+		t.Fatalf("Resolve() default name = %q, want %q", layout.Name, DefaultName)
+	}
+}
+
+func TestResolveFallsBackToHomeDirStatePath(t *testing.T) {
+	t.Parallel()
+
+	layout, err := Resolve(ResolveOptions{
+		UserHomeDir: func() (string, error) {
+			return filepath.Join(string(filepath.Separator), "Users", "tester"), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	want := filepath.Join(string(filepath.Separator), "Users", "tester", ".local", "state", "rein", "instances", DefaultName)
+	if layout.RootDir != want {
+		t.Fatalf("Resolve() root dir = %q, want %q", layout.RootDir, want)
+	}
+}
+
+func TestResolveRejectsMissingStateHome(t *testing.T) {
+	t.Parallel()
+
+	_, err := Resolve(ResolveOptions{
+		UserHomeDir: func() (string, error) {
+			return "", nil
+		},
+	})
+	if !errors.Is(err, ErrMissingStateHome) {
+		t.Fatalf("Resolve() error = %v, want %v", err, ErrMissingStateHome)
+	}
+}
+
+func TestNewLayoutRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewLayout("", "/state"); !errors.Is(err, ErrEmptyName) {
+		t.Fatalf("NewLayout() empty name error = %v, want %v", err, ErrEmptyName)
+	}
+	if _, err := NewLayout("../oops", "/state"); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("NewLayout() invalid name error = %v, want %v", err, ErrInvalidName)
+	}
+	if _, err := NewLayout("live", "relative"); !errors.Is(err, ErrRelativeStateHome) {
+		t.Fatalf("NewLayout() relative state home error = %v, want %v", err, ErrRelativeStateHome)
+	}
+}
+
+func TestLayoutValidateRejectsMismatchedPaths(t *testing.T) {
+	t.Parallel()
+
+	layout := Layout{
+		Name:         "live",
+		StateHome:    "/state",
+		RootDir:      "/state/rein/instances/live",
+		SocketPath:   "/state/rein/instances/live/custom.sock",
+		DatabasePath: "/state/rein/instances/live/rein.db",
+	}
+
+	if err := layout.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want non-nil")
+	}
+}
+
+func TestLayoutEnsureRootDirCreatesCanonicalDirectory(t *testing.T) {
+	t.Parallel()
+
+	layout, err := NewLayout("dev", t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLayout() error = %v", err)
+	}
+
+	if err := layout.EnsureRootDir(); err != nil {
+		t.Fatalf("EnsureRootDir() error = %v", err)
+	}
+	if info, err := os.Stat(layout.RootDir); err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", layout.RootDir, err)
+	} else if !info.IsDir() {
+		t.Fatalf("%q is not a directory", layout.RootDir)
+	}
+}
+
+func TestLayoutAutoStartEnabledOnlyForLive(t *testing.T) {
+	t.Parallel()
+
+	live, err := NewLayout("live", "/state")
+	if err != nil {
+		t.Fatalf("NewLayout(live) error = %v", err)
+	}
+	dev, err := NewLayout("dev", "/state")
+	if err != nil {
+		t.Fatalf("NewLayout(dev) error = %v", err)
+	}
+
+	if !live.AutoStartEnabled() {
+		t.Fatal("live instance should auto-start")
+	}
+	if dev.AutoStartEnabled() {
+		t.Fatal("non-live instance should not auto-start")
+	}
+}

--- a/internal/server/listener.go
+++ b/internal/server/listener.go
@@ -11,7 +11,10 @@ import (
 	"runtime"
 )
 
-const defaultUnixSocketMode fs.FileMode = 0o600
+const (
+	defaultUnixSocketMode fs.FileMode = 0o600
+	defaultTCPAddress                 = "127.0.0.1:7777"
+)
 
 type ListenerConfig struct {
 	Network                string
@@ -22,19 +25,32 @@ type ListenerConfig struct {
 }
 
 func DefaultListenerConfig() ListenerConfig {
-	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-		return ListenerConfig{
-			Network:                "unix",
-			Address:                filepath.Join(os.TempDir(), "rein.sock"),
-			UnixSocketMode:         defaultUnixSocketMode,
-			RequirePeerCredentials: true,
-		}
-	}
+	network := DefaultListenerNetwork()
 
 	return ListenerConfig{
-		Network:        "tcp",
-		Address:        "127.0.0.1:7777",
-		UnixSocketMode: defaultUnixSocketMode,
+		Network:                network,
+		Address:                DefaultListenerAddress(network),
+		UnixSocketMode:         defaultUnixSocketMode,
+		RequirePeerCredentials: network == "unix",
+	}
+}
+
+func DefaultListenerNetwork() string {
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		return "unix"
+	}
+
+	return "tcp"
+}
+
+func DefaultListenerAddress(network string) string {
+	switch network {
+	case "unix":
+		return filepath.Join(os.TempDir(), "rein.sock")
+	case "tcp":
+		return defaultTCPAddress
+	default:
+		return ""
 	}
 }
 
@@ -58,7 +74,10 @@ func (c ListenerConfig) withDefaults() ListenerConfig {
 		c.Network = defaults.Network
 	}
 	if c.Address == "" {
-		c.Address = defaults.Address
+		c.Address = DefaultListenerAddress(c.Network)
+		if c.Address == "" {
+			c.Address = defaults.Address
+		}
 	}
 	if c.UnixSocketMode == 0 {
 		c.UnixSocketMode = defaultUnixSocketMode


### PR DESCRIPTION
## Summary
- add a reusable instance layout package for canonical state paths, validation, and live-only auto-start semantics
- route rein startup through --instance / REIN_INSTANCE so the default unix socket lives under the selected instance state dir
- document the layout and cover selection/defaulting behavior with new unit tests

## Validation
- just ci

Closes #16