### PR TITLE
RN-15: Add built-in credential providers

### DIFF
--- a/internal/credentials/providers.go
+++ b/internal/credentials/providers.go
@@ -1,0 +1,312 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+var ErrUnsupportedPlatform = errors.New("credentials: unsupported platform")
+
+type EnvProvider struct{}
+
+func (EnvProvider) Scheme() string {
+	return "env"
+}
+
+func (EnvProvider) Resolve(_ context.Context, reference Reference, scope ExecutionScope) (string, error) {
+	name, err := envVariableName(reference)
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := scope.lookupEnv(name)
+	if !ok {
+		return "", fmt.Errorf("%w: env %q", ErrCredentialNotFound, name)
+	}
+
+	return value, nil
+}
+
+type FileProvider struct{}
+
+func (FileProvider) Scheme() string {
+	return "file"
+}
+
+func (FileProvider) Resolve(_ context.Context, reference Reference, _ ExecutionScope) (string, error) {
+	path, err := filePath(reference)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("credentials: read file %q: %w", path, err)
+	}
+
+	return string(content), nil
+}
+
+type KeychainBackend interface {
+	FindGenericPassword(ctx context.Context, service, account, keychain string) (string, error)
+}
+
+type KeychainProvider struct {
+	Backend KeychainBackend
+}
+
+func (KeychainProvider) Scheme() string {
+	return "keychain"
+}
+
+func (p KeychainProvider) Resolve(ctx context.Context, reference Reference, _ ExecutionScope) (string, error) {
+	service, account, keychain, err := keychainLocator(reference)
+	if err != nil {
+		return "", err
+	}
+
+	backend := p.Backend
+	if backend == nil {
+		backend = NewDefaultKeychainBackend(nil, runtime.GOOS)
+	}
+
+	value, err := backend.FindGenericPassword(ctx, service, account, keychain)
+	if err != nil {
+		return "", fmt.Errorf("credentials: resolve %s: %w", reference.String(), err)
+	}
+
+	return value, nil
+}
+
+type LibsecretBackend interface {
+	Lookup(ctx context.Context, attributes map[string]string) (string, error)
+}
+
+type LibsecretProvider struct {
+	Backend LibsecretBackend
+}
+
+func (LibsecretProvider) Scheme() string {
+	return "libsecret"
+}
+
+func (p LibsecretProvider) Resolve(ctx context.Context, reference Reference, _ ExecutionScope) (string, error) {
+	attributes, err := libsecretAttributes(reference)
+	if err != nil {
+		return "", err
+	}
+
+	backend := p.Backend
+	if backend == nil {
+		backend = NewDefaultLibsecretBackend(nil, runtime.GOOS)
+	}
+
+	value, err := backend.Lookup(ctx, attributes)
+	if err != nil {
+		return "", fmt.Errorf("credentials: resolve %s: %w", reference.String(), err)
+	}
+
+	return value, nil
+}
+
+type CommandRunner interface {
+	CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+func NewDefaultKeychainBackend(runner CommandRunner, goos string) KeychainBackend {
+	if runner == nil {
+		runner = execCommandRunner{}
+	}
+	return commandKeychainBackend{
+		runner: runner,
+		goos:   goos,
+	}
+}
+
+func NewDefaultLibsecretBackend(runner CommandRunner, goos string) LibsecretBackend {
+	if runner == nil {
+		runner = execCommandRunner{}
+	}
+	return commandLibsecretBackend{
+		runner: runner,
+		goos:   goos,
+	}
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+type commandKeychainBackend struct {
+	runner CommandRunner
+	goos   string
+}
+
+func (b commandKeychainBackend) FindGenericPassword(ctx context.Context, service, account, keychain string) (string, error) {
+	if b.goos != "darwin" {
+		return "", ErrUnsupportedPlatform
+	}
+
+	args := []string{"find-generic-password", "-s", service, "-a", account, "-w"}
+	if keychain != "" {
+		args = append(args, keychain)
+	}
+
+	output, err := runCommand(ctx, b.runner, "security", args...)
+	if err != nil {
+		return "", err
+	}
+
+	return trimSingleTrailingNewline(string(output)), nil
+}
+
+type commandLibsecretBackend struct {
+	runner CommandRunner
+	goos   string
+}
+
+func (b commandLibsecretBackend) Lookup(ctx context.Context, attributes map[string]string) (string, error) {
+	if b.goos != "linux" {
+		return "", ErrUnsupportedPlatform
+	}
+
+	keys := make([]string, 0, len(attributes))
+	for key := range attributes {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	args := []string{"lookup"}
+	for _, key := range keys {
+		args = append(args, key, attributes[key])
+	}
+
+	output, err := runCommand(ctx, b.runner, "secret-tool", args...)
+	if err != nil {
+		return "", err
+	}
+
+	return trimSingleTrailingNewline(string(output)), nil
+}
+
+func envVariableName(reference Reference) (string, error) {
+	if reference.Host() != "" && strings.TrimPrefix(reference.Path(), "/") != "" {
+		return "", fmt.Errorf("%w: env references must use either host or path", ErrInvalidReference)
+	}
+
+	name := strings.TrimSpace(reference.Host())
+	if name == "" {
+		name = strings.TrimPrefix(strings.TrimSpace(reference.Path()), "/")
+	}
+	if !isEnvironmentVariableName(name) {
+		return "", fmt.Errorf("%w: invalid env variable name %q", ErrInvalidReference, name)
+	}
+
+	return name, nil
+}
+
+func filePath(reference Reference) (string, error) {
+	host := reference.Host()
+	if host != "" && host != "localhost" {
+		return "", fmt.Errorf("%w: file references must use an empty host or localhost", ErrInvalidReference)
+	}
+
+	path := reference.Path()
+	if path == "" {
+		return "", fmt.Errorf("%w: file path is required", ErrInvalidReference)
+	}
+
+	return path, nil
+}
+
+func keychainLocator(reference Reference) (service, account, keychain string, err error) {
+	service = strings.TrimSpace(reference.Host())
+	account = strings.TrimPrefix(strings.TrimSpace(reference.Path()), "/")
+	if service == "" || account == "" {
+		return "", "", "", fmt.Errorf("%w: keychain references must use keychain://service/account", ErrInvalidReference)
+	}
+
+	query := reference.Query()
+	for key, values := range query {
+		if len(values) != 1 || strings.TrimSpace(values[0]) == "" {
+			return "", "", "", fmt.Errorf("%w: query %q must have exactly one non-empty value", ErrInvalidReference, key)
+		}
+		if key != "keychain" {
+			return "", "", "", fmt.Errorf("%w: unsupported keychain query %q", ErrInvalidReference, key)
+		}
+		keychain = values[0]
+	}
+
+	return service, account, keychain, nil
+}
+
+func libsecretAttributes(reference Reference) (map[string]string, error) {
+	attributes := map[string]string{}
+
+	if service := strings.TrimSpace(reference.Host()); service != "" {
+		attributes["service"] = service
+	}
+	if account := strings.TrimPrefix(strings.TrimSpace(reference.Path()), "/"); account != "" {
+		attributes["account"] = account
+	}
+
+	for key, values := range reference.Query() {
+		if len(values) != 1 || strings.TrimSpace(values[0]) == "" {
+			return nil, fmt.Errorf("%w: query %q must have exactly one non-empty value", ErrInvalidReference, key)
+		}
+		attributes[key] = values[0]
+	}
+
+	if len(attributes) == 0 {
+		return nil, fmt.Errorf("%w: libsecret references require at least one lookup attribute", ErrInvalidReference)
+	}
+
+	return attributes, nil
+}
+
+func isEnvironmentVariableName(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	for index, r := range name {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case index > 0 && r >= '0' && r <= '9':
+		case r == '_':
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+func runCommand(ctx context.Context, runner CommandRunner, name string, args ...string) ([]byte, error) {
+	output, err := runner.CombinedOutput(ctx, name, args...)
+	if err == nil {
+		return output, nil
+	}
+
+	if trimmed := strings.TrimSpace(string(output)); trimmed != "" {
+		return nil, fmt.Errorf("%s %s: %s: %w", name, strings.Join(args, " "), trimmed, err)
+	}
+
+	return nil, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+}
+
+func trimSingleTrailingNewline(value string) string {
+	if strings.HasSuffix(value, "\r\n") {
+		return strings.TrimSuffix(value, "\r\n")
+	}
+	return strings.TrimSuffix(value, "\n")
+}

--- a/internal/credentials/providers_test.go
+++ b/internal/credentials/providers_test.go
@@ -1,0 +1,259 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseReference(t *testing.T) {
+	t.Parallel()
+
+	reference, err := ParseReference("env://GITHUB_TOKEN")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+	if reference.Scheme() != "env" {
+		t.Fatalf("ParseReference() scheme = %q, want env", reference.Scheme())
+	}
+
+	if _, err := ParseReference("vault://team/app"); !errors.Is(err, ErrUnsupportedScheme) {
+		t.Fatalf("ParseReference() unsupported scheme error = %v, want %v", err, ErrUnsupportedScheme)
+	}
+	if _, err := ParseReference("not-a-uri"); !errors.Is(err, ErrInvalidReference) {
+		t.Fatalf("ParseReference() invalid reference error = %v, want %v", err, ErrInvalidReference)
+	}
+}
+
+func TestRegistryResolveRequiresExecutionScope(t *testing.T) {
+	t.Parallel()
+
+	registry := NewBuiltinRegistry(BuiltinOptions{})
+	_, err := registry.Resolve(context.Background(), "env://TOKEN", ExecutionScope{})
+	if !errors.Is(err, ErrInvalidScope) {
+		t.Fatalf("Resolve() scope error = %v, want %v", err, ErrInvalidScope)
+	}
+}
+
+func TestRegistryResolveAllKeepsOpaqueReferencesSeparate(t *testing.T) {
+	t.Parallel()
+
+	references := map[string]string{
+		"github_token": "env://RN15_GITHUB_TOKEN",
+	}
+	registry := NewBuiltinRegistry(BuiltinOptions{})
+
+	resolved, err := registry.ResolveAll(context.Background(), references, ExecutionScope{
+		ExecutionID: "exec-1",
+		LookupEnv: func(name string) (string, bool) {
+			if name != "RN15_GITHUB_TOKEN" {
+				return "", false
+			}
+			return "super-secret-token", true
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveAll() error = %v", err)
+	}
+
+	if references["github_token"] != "env://RN15_GITHUB_TOKEN" {
+		t.Fatalf("ResolveAll() mutated reference map: %+v", references)
+	}
+	if resolved["github_token"] != "super-secret-token" {
+		t.Fatalf("ResolveAll() resolved value = %q, want secret", resolved["github_token"])
+	}
+}
+
+func TestEnvProviderRejectsMissingVariables(t *testing.T) {
+	t.Parallel()
+
+	reference, err := ParseReference("env://RN15_TOKEN")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	_, err = EnvProvider{}.Resolve(context.Background(), reference, ExecutionScope{
+		ExecutionID: "exec-1",
+		LookupEnv: func(string) (string, bool) {
+			return "", false
+		},
+	})
+	if !errors.Is(err, ErrCredentialNotFound) {
+		t.Fatalf("Resolve() missing env error = %v, want %v", err, ErrCredentialNotFound)
+	}
+}
+
+func TestFileProviderReadsSecretFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("file-secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	reference, err := ParseReference("file://" + path)
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	got, err := FileProvider{}.Resolve(context.Background(), reference, ExecutionScope{ExecutionID: "exec-1"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got != "file-secret" {
+		t.Fatalf("Resolve() = %q, want file-secret", got)
+	}
+}
+
+func TestKeychainProviderUsesBackend(t *testing.T) {
+	t.Parallel()
+
+	reference, err := ParseReference("keychain://rein/github?keychain=login.keychain-db")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	backend := &fakeKeychainBackend{value: "kc-secret"}
+	got, err := KeychainProvider{Backend: backend}.Resolve(context.Background(), reference, ExecutionScope{ExecutionID: "exec-1"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got != "kc-secret" {
+		t.Fatalf("Resolve() = %q, want kc-secret", got)
+	}
+
+	if backend.service != "rein" || backend.account != "github" || backend.keychain != "login.keychain-db" {
+		t.Fatalf("backend locator = service=%q account=%q keychain=%q", backend.service, backend.account, backend.keychain)
+	}
+}
+
+func TestLibsecretProviderUsesBackend(t *testing.T) {
+	t.Parallel()
+
+	reference, err := ParseReference("libsecret://rein/github?stage=prod")
+	if err != nil {
+		t.Fatalf("ParseReference() error = %v", err)
+	}
+
+	backend := &fakeLibsecretBackend{value: "ls-secret"}
+	got, err := LibsecretProvider{Backend: backend}.Resolve(context.Background(), reference, ExecutionScope{ExecutionID: "exec-1"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got != "ls-secret" {
+		t.Fatalf("Resolve() = %q, want ls-secret", got)
+	}
+
+	want := map[string]string{
+		"service": "rein",
+		"account": "github",
+		"stage":   "prod",
+	}
+	if !reflect.DeepEqual(backend.attributes, want) {
+		t.Fatalf("Lookup() attributes = %#v, want %#v", backend.attributes, want)
+	}
+}
+
+func TestDefaultKeychainBackendBuildsSecurityCommand(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeCommandRunner{output: []byte("kc-secret\n")}
+	backend := NewDefaultKeychainBackend(runner, "darwin")
+
+	got, err := backend.FindGenericPassword(context.Background(), "rein", "github", "/Users/test/login.keychain-db")
+	if err != nil {
+		t.Fatalf("FindGenericPassword() error = %v", err)
+	}
+	if got != "kc-secret" {
+		t.Fatalf("FindGenericPassword() = %q, want kc-secret", got)
+	}
+
+	if runner.name != "security" {
+		t.Fatalf("command name = %q, want security", runner.name)
+	}
+	wantArgs := []string{"find-generic-password", "-s", "rein", "-a", "github", "-w", "/Users/test/login.keychain-db"}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("command args = %#v, want %#v", runner.args, wantArgs)
+	}
+}
+
+func TestDefaultLibsecretBackendBuildsSecretToolCommand(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeCommandRunner{output: []byte("ls-secret\n")}
+	backend := NewDefaultLibsecretBackend(runner, "linux")
+
+	got, err := backend.Lookup(context.Background(), map[string]string{
+		"service": "rein",
+		"account": "github",
+	})
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if got != "ls-secret" {
+		t.Fatalf("Lookup() = %q, want ls-secret", got)
+	}
+
+	if runner.name != "secret-tool" {
+		t.Fatalf("command name = %q, want secret-tool", runner.name)
+	}
+	wantArgs := []string{"lookup", "account", "github", "service", "rein"}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("command args = %#v, want %#v", runner.args, wantArgs)
+	}
+}
+
+func TestDefaultBackendsRejectUnsupportedPlatforms(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewDefaultKeychainBackend(&fakeCommandRunner{}, "linux").FindGenericPassword(context.Background(), "rein", "github", ""); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Fatalf("FindGenericPassword() error = %v, want %v", err, ErrUnsupportedPlatform)
+	}
+
+	if _, err := NewDefaultLibsecretBackend(&fakeCommandRunner{}, "darwin").Lookup(context.Background(), map[string]string{"service": "rein"}); !errors.Is(err, ErrUnsupportedPlatform) {
+		t.Fatalf("Lookup() error = %v, want %v", err, ErrUnsupportedPlatform)
+	}
+}
+
+type fakeKeychainBackend struct {
+	service  string
+	account  string
+	keychain string
+	value    string
+	err      error
+}
+
+func (b *fakeKeychainBackend) FindGenericPassword(_ context.Context, service, account, keychain string) (string, error) {
+	b.service = service
+	b.account = account
+	b.keychain = keychain
+	return b.value, b.err
+}
+
+type fakeLibsecretBackend struct {
+	attributes map[string]string
+	value      string
+	err        error
+}
+
+func (b *fakeLibsecretBackend) Lookup(_ context.Context, attributes map[string]string) (string, error) {
+	b.attributes = attributes
+	return b.value, b.err
+}
+
+type fakeCommandRunner struct {
+	name   string
+	args   []string
+	output []byte
+	err    error
+}
+
+func (r *fakeCommandRunner) CombinedOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.name = name
+	r.args = append([]string(nil), args...)
+	return r.output, r.err
+}

--- a/internal/credentials/reference.go
+++ b/internal/credentials/reference.go
@@ -1,0 +1,86 @@
+package credentials
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+var (
+	ErrInvalidReference   = errors.New("credentials: invalid reference")
+	ErrUnsupportedScheme  = errors.New("credentials: unsupported scheme")
+	ErrCredentialNotFound = errors.New("credentials: not found")
+	ErrInvalidScope       = errors.New("credentials: invalid execution scope")
+)
+
+type Reference struct {
+	raw string
+	uri url.URL
+}
+
+func ParseReference(raw string) (Reference, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Reference{}, fmt.Errorf("%w: reference is required", ErrInvalidReference)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return Reference{}, fmt.Errorf("%w: parse %q: %v", ErrInvalidReference, raw, err)
+	}
+	if parsed.Scheme == "" {
+		return Reference{}, fmt.Errorf("%w: scheme is required", ErrInvalidReference)
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	switch parsed.Scheme {
+	case "env", "file", "keychain", "libsecret":
+	default:
+		return Reference{}, fmt.Errorf("%w: %s", ErrUnsupportedScheme, parsed.Scheme)
+	}
+
+	return Reference{raw: raw, uri: *parsed}, nil
+}
+
+func (r Reference) String() string {
+	return r.raw
+}
+
+func (r Reference) Scheme() string {
+	return r.uri.Scheme
+}
+
+func (r Reference) Host() string {
+	return r.uri.Host
+}
+
+func (r Reference) Path() string {
+	return r.uri.Path
+}
+
+func (r Reference) Query() url.Values {
+	return r.uri.Query()
+}
+
+type ExecutionScope struct {
+	ProjectID   string
+	WorkflowID  string
+	ExecutionID string
+	LookupEnv   func(string) (string, bool)
+}
+
+func (s ExecutionScope) Validate() error {
+	if strings.TrimSpace(s.ExecutionID) == "" {
+		return fmt.Errorf("%w: execution_id is required", ErrInvalidScope)
+	}
+	return nil
+}
+
+func (s ExecutionScope) lookupEnv(name string) (string, bool) {
+	if s.LookupEnv != nil {
+		return s.LookupEnv(name)
+	}
+	return os.LookupEnv(name)
+}

--- a/internal/credentials/registry.go
+++ b/internal/credentials/registry.go
@@ -1,0 +1,105 @@
+package credentials
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+)
+
+type Provider interface {
+	Scheme() string
+	Resolve(context.Context, Reference, ExecutionScope) (string, error)
+}
+
+type Registry struct {
+	providers map[string]Provider
+}
+
+type BuiltinOptions struct {
+	KeychainBackend  KeychainBackend
+	LibsecretBackend LibsecretBackend
+}
+
+func NewRegistry(providers ...Provider) (*Registry, error) {
+	registry := &Registry{providers: make(map[string]Provider, len(providers))}
+	for _, provider := range providers {
+		if provider == nil {
+			continue
+		}
+
+		scheme := provider.Scheme()
+		if _, exists := registry.providers[scheme]; exists {
+			return nil, fmt.Errorf("credentials: duplicate provider for scheme %q", scheme)
+		}
+		registry.providers[scheme] = provider
+	}
+	return registry, nil
+}
+
+func NewBuiltinRegistry(options BuiltinOptions) *Registry {
+	keychainBackend := options.KeychainBackend
+	if keychainBackend == nil {
+		keychainBackend = NewDefaultKeychainBackend(nil, runtime.GOOS)
+	}
+
+	libsecretBackend := options.LibsecretBackend
+	if libsecretBackend == nil {
+		libsecretBackend = NewDefaultLibsecretBackend(nil, runtime.GOOS)
+	}
+
+	registry, err := NewRegistry(
+		EnvProvider{},
+		FileProvider{},
+		KeychainProvider{Backend: keychainBackend},
+		LibsecretProvider{Backend: libsecretBackend},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return registry
+}
+
+func (r *Registry) Resolve(ctx context.Context, rawReference string, scope ExecutionScope) (string, error) {
+	reference, err := ParseReference(rawReference)
+	if err != nil {
+		return "", err
+	}
+	return r.ResolveReference(ctx, reference, scope)
+}
+
+func (r *Registry) ResolveReference(ctx context.Context, reference Reference, scope ExecutionScope) (string, error) {
+	if err := scope.Validate(); err != nil {
+		return "", err
+	}
+
+	provider, ok := r.providers[reference.Scheme()]
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedScheme, reference.Scheme())
+	}
+
+	return provider.Resolve(ctx, reference, scope)
+}
+
+func (r *Registry) ResolveAll(ctx context.Context, references map[string]string, scope ExecutionScope) (map[string]string, error) {
+	if len(references) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(references))
+	for name := range references {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	resolved := make(map[string]string, len(references))
+	for _, name := range names {
+		value, err := r.Resolve(ctx, references[name], scope)
+		if err != nil {
+			return nil, fmt.Errorf("resolve credential %q: %w", name, err)
+		}
+		resolved[name] = value
+	}
+
+	return resolved, nil
+}

--- a/internal/server/managed_flow_harness_test.go
+++ b/internal/server/managed_flow_harness_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/earchibald/rein/adaptertest"
 	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
 	"github.com/earchibald/rein/internal/cost"
+	"github.com/earchibald/rein/internal/credentials"
 	"github.com/earchibald/rein/internal/service"
 	"github.com/earchibald/rein/internal/storage/sqlite"
 )
@@ -320,11 +322,87 @@ func TestManagedFlowHarnessBudgetHardLimitBlocksNewLaunches(t *testing.T) {
 	}
 }
 
+func TestManagedFlowHarnessStoresCredentialReferencesNotValues(t *testing.T) {
+	t.Parallel()
+
+	harness := newManagedFlowHarness(t)
+	harness.executionServer.lookupEnv = func(name string) (string, bool) {
+		if name != "RN15_GITHUB_TOKEN" {
+			return "", false
+		}
+		return "super-secret-token", true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	workflow := managedFlowWorkflow()
+	if err := harness.seedWorkflow(ctx, workflow); err != nil {
+		t.Fatalf("seedWorkflow() error = %v", err)
+	}
+
+	projectResp, err := harness.projectClient.CreateProject(ctx, &reinv1.CreateProjectRequest{
+		Project: &reinv1.Project{
+			Id:          "project-rein",
+			Slug:        "rein",
+			DisplayName: "rein",
+			Summary:     "Managed flow harness",
+			Status:      reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+
+	issueResp, err := harness.issueClient.CreateIssue(ctx, &reinv1.CreateIssueRequest{
+		Issue: &reinv1.Issue{
+			Id:         "RN-15",
+			ProjectId:  projectResp.GetProject().GetId(),
+			Title:      "Credential providers",
+			Summary:    "Ensure execution credentials resolve without persisting values",
+			Status:     reinv1.IssueStatus_ISSUE_STATUS_OPEN,
+			Priority:   reinv1.IssuePriority_ISSUE_PRIORITY_HIGH,
+			WorkflowId: workflow.GetId(),
+			Assignee:   "copilot",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	startResp, err := harness.executionClient.StartExecution(ctx, &reinv1.StartExecutionRequest{
+		IssueId:     issueResp.GetIssue().GetId(),
+		WorkflowId:  workflow.GetId(),
+		RequestedBy: "copilot",
+		Inputs: map[string]string{
+			"base_branch":                 "main",
+			"credential_ref.github_token": "env://RN15_GITHUB_TOKEN",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartExecution() error = %v", err)
+	}
+
+	execution := startResp.GetExecution()
+	if got := execution.GetMetadata()["credential_ref.github_token"]; got != "env://RN15_GITHUB_TOKEN" {
+		t.Fatalf("StartExecution() credential ref = %q, want opaque env ref", got)
+	}
+	if got := execution.GetMetadata()["auth_mode"]; got != "credential" {
+		t.Fatalf("StartExecution() auth_mode = %q, want credential", got)
+	}
+	for key, value := range execution.GetMetadata() {
+		if value == "super-secret-token" {
+			t.Fatalf("StartExecution() metadata[%q] leaked secret value", key)
+		}
+	}
+}
+
 type managedFlowHarness struct {
 	adapterClient   reinv1.AdapterServiceClient
 	costRecorder    *cost.Recorder
 	costStream      *cost.Stream
 	executionClient reinv1.ExecutionServiceClient
+	executionServer *managedFlowExecutionService
 	issueClient     reinv1.IssueServiceClient
 	projectClient   reinv1.ProjectServiceClient
 	workflowClient  reinv1.WorkflowServiceClient
@@ -347,17 +425,20 @@ func newManagedFlowHarness(tb testing.TB) *managedFlowHarness {
 	adapters := newManagedFlowAdapterCatalog(tb)
 	costStream := cost.NewStream()
 	costRecorder := cost.NewRecorder(store, cost.WithPublisher(costStream))
+	executionServer := &managedFlowExecutionService{
+		adapters:           adapters,
+		costRecorder:       costRecorder,
+		credentialRegistry: credentials.NewBuiltinRegistry(credentials.BuiltinOptions{}),
+		lookupEnv:          os.LookupEnv,
+		store:              store,
+	}
 	bufconn := newBufconnHarness(tb, Options{
 		Services: service.Set{
-			Adapter: &managedFlowAdapterService{catalog: adapters},
-			Execution: &managedFlowExecutionService{
-				adapters:     adapters,
-				costRecorder: costRecorder,
-				store:        store,
-			},
-			Issue:    &managedFlowIssueService{store: store},
-			Project:  &managedFlowProjectService{store: store},
-			Workflow: &managedFlowWorkflowService{catalog: adapters, store: store},
+			Adapter:   &managedFlowAdapterService{catalog: adapters},
+			Execution: executionServer,
+			Issue:     &managedFlowIssueService{store: store},
+			Project:   &managedFlowProjectService{store: store},
+			Workflow:  &managedFlowWorkflowService{catalog: adapters, store: store},
 		},
 	})
 
@@ -366,6 +447,7 @@ func newManagedFlowHarness(tb testing.TB) *managedFlowHarness {
 		costRecorder:    costRecorder,
 		costStream:      costStream,
 		executionClient: reinv1.NewExecutionServiceClient(bufconn.conn),
+		executionServer: executionServer,
 		issueClient:     reinv1.NewIssueServiceClient(bufconn.conn),
 		projectClient:   reinv1.NewProjectServiceClient(bufconn.conn),
 		workflowClient:  reinv1.NewWorkflowServiceClient(bufconn.conn),
@@ -546,9 +628,11 @@ func (s *managedFlowIssueService) GetIssue(ctx context.Context, req *reinv1.GetI
 
 type managedFlowExecutionService struct {
 	reinv1.UnimplementedExecutionServiceServer
-	adapters     *managedFlowAdapterCatalog
-	costRecorder *cost.Recorder
-	store        *sqlite.Store
+	adapters           *managedFlowAdapterCatalog
+	costRecorder       *cost.Recorder
+	credentialRegistry *credentials.Registry
+	lookupEnv          func(string) (string, bool)
+	store              *sqlite.Store
 }
 
 func (s *managedFlowExecutionService) StartExecution(ctx context.Context, req *reinv1.StartExecutionRequest) (*reinv1.StartExecutionResponse, error) {
@@ -614,8 +698,20 @@ func (s *managedFlowExecutionService) StartExecution(ctx context.Context, req *r
 		return nil, status.Errorf(codes.Internal, "start execution %q: %v", execution.GetId(), err)
 	}
 
+	resolvedCredentials, err := s.resolveCredentials(ctx, issue, execution)
+	if err != nil {
+		execution.Status = reinv1.ExecutionStatus_EXECUTION_STATUS_FAILED
+		execution.FinishedTime = timestamppb.Now()
+		execution.Metadata["result"] = "failed"
+		if _, updateErr := updateStoredProto(ctx, s.store, sqlite.ExecutionKind, execution.GetId(), executionRecord.LockVersion, execution); updateErr != nil {
+			return nil, status.Errorf(codes.Internal, "execution %q credential resolution failed with %v and could not be stored: %v", execution.GetId(), err, updateErr)
+		}
+		return nil, status.Errorf(codes.FailedPrecondition, "resolve execution credentials: %v", err)
+	}
+
 	state := &managedFlowState{
 		costRecorder: s.costRecorder,
+		credentials:  resolvedCredentials,
 		execution:    execution,
 		issue:        issue,
 		workflow:     workflow,
@@ -698,9 +794,32 @@ func (s *managedFlowExecutionService) GetExecution(ctx context.Context, req *rei
 
 type managedFlowState struct {
 	costRecorder *cost.Recorder
+	credentials  map[string]string
 	execution    *reinv1.Execution
 	issue        *reinv1.Issue
 	workflow     *reinv1.Workflow
+}
+
+func (s *managedFlowExecutionService) resolveCredentials(ctx context.Context, issue *reinv1.Issue, execution *reinv1.Execution) (map[string]string, error) {
+	if s.credentialRegistry == nil {
+		return nil, nil
+	}
+
+	references := map[string]string{}
+	for key, value := range execution.GetMetadata() {
+		name, ok := strings.CutPrefix(key, "credential_ref.")
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		references[name] = value
+	}
+
+	return s.credentialRegistry.ResolveAll(ctx, references, credentials.ExecutionScope{
+		ProjectID:   issue.GetProjectId(),
+		WorkflowID:  execution.GetWorkflowId(),
+		ExecutionID: execution.GetId(),
+		LookupEnv:   s.lookupEnv,
+	})
 }
 
 type managedFlowAdapterCatalog struct {
@@ -883,6 +1002,13 @@ func (a *managedFlowCodingAdapter) Descriptor() *reinv1.Adapter {
 func (a *managedFlowCodingAdapter) Run(ctx context.Context, state *managedFlowState, step *reinv1.WorkflowStep) error {
 	if len(step.GetDependsOn()) == 0 || state.execution.Metadata["branch"] == "" || state.execution.Metadata["worktree"] == "" {
 		return errors.New("branch and worktree must exist before opening a pull request")
+	}
+
+	if _, ok := state.execution.Metadata["credential_ref.github_token"]; ok {
+		if state.credentials["github_token"] == "" {
+			return errors.New("github_token credential must resolve before opening a pull request")
+		}
+		state.execution.Metadata["auth_mode"] = "credential"
 	}
 
 	state.execution.Metadata["pr_url"] = "https://tracker.fake/repos/rein/pull/101"


### PR DESCRIPTION
## Summary
- add an internal credential provider layer for env, file, keychain, and libsecret references
- keep stored execution metadata as opaque credential refs while resolving values per execution in the managed-flow harness
- add hermetic tests for provider parsing, resolution, CLI seams, and no-leak behavior

## Testing
- just ci

Closes #15