### PR TITLE
RN-17: canonical rein CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
   - `rein.db` — canonical SQLite path reserved for that instance's persisted state.
 - `rein doctor` will validate that commands and on-disk state follow this canonical layout in a future issue.
 
+## CLI surface
+
+- `rein` is the canonical gRPC client CLI. By default it connects to the selected instance over that instance's unix socket.
+- Use `rein daemon serve` to start the daemon for the selected instance.
+- Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
+- Request flags map 1:1 to top-level gRPC request fields. Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
+- Responses are emitted as JSON using protobuf field names.
+
 ## Development
 
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -1,0 +1,525 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+
+	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/server"
+	"github.com/earchibald/rein/internal/service"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+	protofiles "github.com/earchibald/rein/proto"
+)
+
+const defaultRPCTimeout = 10 * time.Second
+
+type app struct {
+	stdout      io.Writer
+	stderr      io.Writer
+	lookupEnv   func(string) (string, bool)
+	userHomeDir func() (string, error)
+}
+
+type rpcCommand struct {
+	noun       string
+	verb       string
+	service    protoreflect.ServiceDescriptor
+	method     protoreflect.MethodDescriptor
+	input      protoreflect.MessageDescriptor
+	output     protoreflect.MessageDescriptor
+	fullMethod string
+}
+
+type fieldBinding struct {
+	field protoreflect.FieldDescriptor
+	raw   string
+	set   bool
+}
+
+func newApp(stdout, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error)) *app {
+	return &app{
+		stdout:      stdout,
+		stderr:      stderr,
+		lookupEnv:   lookupEnv,
+		userHomeDir: userHomeDir,
+	}
+}
+
+func (a *app) run(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		a.printRootHelp()
+		return flag.ErrHelp
+	}
+
+	root, remaining, err := parseRootConfig(args, a.stderr, a.lookupEnv, a.userHomeDir)
+	if err != nil {
+		return err
+	}
+	if len(remaining) == 0 {
+		a.printRootHelp()
+		return flag.ErrHelp
+	}
+
+	switch remaining[0] {
+	case "daemon":
+		return a.runDaemon(root, remaining[1:])
+	default:
+		return a.runRPC(root, remaining)
+	}
+}
+
+func (a *app) runDaemon(root rootConfig, args []string) error {
+	if len(args) == 0 || (len(args) == 1 && isHelpToken(args[0])) {
+		a.printDaemonHelp()
+		return flag.ErrHelp
+	}
+	if args[0] != "serve" {
+		return fmt.Errorf("unknown daemon command %q", args[0])
+	}
+
+	serveConfig, err := parseDaemonServeConfig(root, args[1:], a.stderr)
+	if err != nil {
+		return err
+	}
+	return a.serveDaemon(serveConfig)
+}
+
+func (a *app) serveDaemon(config daemonServeConfig) error {
+	logger := slog.New(slog.NewTextHandler(a.stdout, nil))
+	if err := config.instance.EnsureRootDir(); err != nil {
+		return fmt.Errorf("prepare instance state directory: %w", err)
+	}
+
+	store, err := sqlite.OpenAndMigrate(context.Background(), sqlite.Config{Path: config.instance.DatabasePath})
+	if err != nil {
+		return fmt.Errorf("open instance database: %w", err)
+	}
+	defer store.Close()
+
+	catalog, err := service.NewManagedCatalogFromRoot(".", adapter.DiscoveryOptions{})
+	if err != nil {
+		return fmt.Errorf("load adapter registry: %w", err)
+	}
+
+	listenerConfig := config.listener
+	listenerConfig.Logger = logger
+	listener, err := server.Listen(listenerConfig)
+	if err != nil {
+		return fmt.Errorf("create listener: %w", err)
+	}
+	defer listener.Close()
+
+	runtime := server.New(server.Options{Services: service.NewManagedSet(store, catalog)})
+	logger.Info(
+		"rein daemon starting",
+		"instance", config.instance.Name,
+		"state_dir", config.instance.RootDir,
+		"database", config.instance.DatabasePath,
+		"network", listenerConfig.Network,
+		"address", listener.Addr().String(),
+		"auto_start", config.instance.AutoStartEnabled(),
+	)
+	logger.Info(
+		"rein HTTP/SSE gateway v2 stub ready",
+		"routes", len(runtime.Gateway().Routes()),
+		"streams", len(runtime.Gateway().Streams()),
+	)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return runtime.Serve(ctx, listener)
+}
+
+func (a *app) runRPC(root rootConfig, args []string) error {
+	commands, err := loadRPCCommands()
+	if err != nil {
+		return err
+	}
+	if len(args) < 2 {
+		a.printRootHelp()
+		return flag.ErrHelp
+	}
+
+	command, ok := commands[args[0]+" "+args[1]]
+	if !ok {
+		return fmt.Errorf("unknown command %q", strings.Join(args[:sliceMin(len(args), 2)], " "))
+	}
+	if len(args) > 2 && isHelpToken(args[2]) {
+		a.printCommandHelp(command)
+		return flag.ErrHelp
+	}
+
+	flagSet := flag.NewFlagSet("rein "+command.noun+" "+command.verb, flag.ContinueOnError)
+	flagSet.SetOutput(a.stderr)
+	flagSet.Usage = func() {
+		a.printCommandHelp(command)
+	}
+
+	bindings := make([]*fieldBinding, 0, command.input.Fields().Len())
+	for i := 0; i < command.input.Fields().Len(); i++ {
+		field := command.input.Fields().Get(i)
+		binding := &fieldBinding{field: field}
+		flagSet.Var(binding, string(field.Name()), fieldUsage(field))
+		bindings = append(bindings, binding)
+	}
+
+	if err := flagSet.Parse(args[2:]); err != nil {
+		return err
+	}
+	if flagSet.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %v", flagSet.Args())
+	}
+
+	request, err := buildRequest(command.input, bindings)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRPCTimeout)
+	defer cancel()
+
+	conn, err := dialGRPC(ctx, root.client)
+	if err != nil {
+		return fmt.Errorf("connect to daemon: %w", err)
+	}
+	defer conn.Close()
+
+	response := dynamicpb.NewMessage(command.output)
+	if err := conn.Invoke(ctx, command.fullMethod, request, response); err != nil {
+		return err
+	}
+
+	return writeJSON(a.stdout, response)
+}
+
+func dialGRPC(_ context.Context, config clientConfig) (*grpc.ClientConn, error) {
+	target := "passthrough:///" + config.Address
+	return grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, config.Network, config.Address)
+		}),
+	)
+}
+
+func loadRPCCommands() (map[string]rpcCommand, error) {
+	services := []struct {
+		fullName protoreflect.FullName
+		noun     string
+	}{
+		{fullName: "rein.v1.ProjectService", noun: "project"},
+		{fullName: "rein.v1.IssueService", noun: "issue"},
+		{fullName: "rein.v1.ExecutionService", noun: "execution"},
+		{fullName: "rein.v1.WorkflowService", noun: "workflow"},
+		{fullName: "rein.v1.AdapterService", noun: "adapter"},
+	}
+
+	commands := make(map[string]rpcCommand, 16)
+	for _, entry := range services {
+		descriptor, err := protoregistry.GlobalFiles.FindDescriptorByName(entry.fullName)
+		if err != nil {
+			return nil, err
+		}
+		serviceDescriptor, ok := descriptor.(protoreflect.ServiceDescriptor)
+		if !ok {
+			return nil, fmt.Errorf("%s is not a service descriptor", entry.fullName)
+		}
+
+		for i := 0; i < serviceDescriptor.Methods().Len(); i++ {
+			method := serviceDescriptor.Methods().Get(i)
+			verb, ok := methodVerb(method.Name())
+			if !ok {
+				continue
+			}
+			command := rpcCommand{
+				noun:       entry.noun,
+				verb:       verb,
+				service:    serviceDescriptor,
+				method:     method,
+				input:      method.Input(),
+				output:     method.Output(),
+				fullMethod: "/" + string(serviceDescriptor.FullName()) + "/" + string(method.Name()),
+			}
+			commands[command.noun+" "+command.verb] = command
+		}
+	}
+	return commands, nil
+}
+
+func methodVerb(name protoreflect.Name) (string, bool) {
+	for _, prefix := range []string{"List", "Get", "Create", "Update", "Start", "Cancel", "Validate"} {
+		if strings.HasPrefix(string(name), prefix) {
+			return strings.ToLower(prefix), true
+		}
+	}
+	return "", false
+}
+
+func buildRequest(descriptor protoreflect.MessageDescriptor, bindings []*fieldBinding) (proto.Message, error) {
+	values := map[string]json.RawMessage{}
+	for _, binding := range bindings {
+		if !binding.set {
+			continue
+		}
+		token, err := binding.jsonValue()
+		if err != nil {
+			return nil, fmt.Errorf("--%s: %w", binding.field.Name(), err)
+		}
+		values[binding.field.JSONName()] = token
+	}
+
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	request := dynamicpb.NewMessage(descriptor)
+	if err := protojson.Unmarshal(payload, request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func writeJSON(w io.Writer, message proto.Message) error {
+	data, err := protojson.MarshalOptions{
+		Indent:        "  ",
+		Multiline:     true,
+		UseProtoNames: true,
+	}.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *fieldBinding) String() string {
+	return b.raw
+}
+
+func (b *fieldBinding) Set(value string) error {
+	b.raw = value
+	b.set = true
+	return nil
+}
+
+func (b *fieldBinding) IsBoolFlag() bool {
+	return !b.field.IsList() && !b.field.IsMap() && b.field.Kind() == protoreflect.BoolKind
+}
+
+func (b *fieldBinding) jsonValue() (json.RawMessage, error) {
+	switch {
+	case b.field.IsList(), b.field.IsMap(), b.field.Kind() == protoreflect.MessageKind:
+		if !json.Valid([]byte(b.raw)) {
+			return nil, fmt.Errorf("value must be valid JSON")
+		}
+		return json.RawMessage(b.raw), nil
+	case b.field.Kind() == protoreflect.StringKind:
+		encoded, _ := json.Marshal(b.raw)
+		return encoded, nil
+	case b.field.Kind() == protoreflect.BoolKind:
+		value, err := strconv.ParseBool(b.raw)
+		if err != nil {
+			return nil, err
+		}
+		if value {
+			return json.RawMessage("true"), nil
+		}
+		return json.RawMessage("false"), nil
+	case b.field.Kind() == protoreflect.EnumKind:
+		if _, err := strconv.Atoi(b.raw); err == nil {
+			return json.RawMessage(b.raw), nil
+		}
+		encoded, _ := json.Marshal(b.raw)
+		return encoded, nil
+	case isIntegerKind(b.field.Kind()):
+		if _, err := strconv.ParseInt(b.raw, 10, 64); err != nil {
+			return nil, err
+		}
+		return json.RawMessage(b.raw), nil
+	case isUnsignedKind(b.field.Kind()):
+		if _, err := strconv.ParseUint(b.raw, 10, 64); err != nil {
+			return nil, err
+		}
+		return json.RawMessage(b.raw), nil
+	case b.field.Kind() == protoreflect.FloatKind || b.field.Kind() == protoreflect.DoubleKind:
+		if _, err := strconv.ParseFloat(b.raw, 64); err != nil {
+			return nil, err
+		}
+		return json.RawMessage(b.raw), nil
+	default:
+		encoded, _ := json.Marshal(b.raw)
+		return encoded, nil
+	}
+}
+
+func isIntegerKind(kind protoreflect.Kind) bool {
+	switch kind {
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind, protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return true
+	default:
+		return false
+	}
+}
+
+func isUnsignedKind(kind protoreflect.Kind) bool {
+	switch kind {
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind, protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *app) printRootHelp() {
+	commands, err := loadRPCCommands()
+	if err != nil {
+		fmt.Fprintf(a.stderr, "failed to load command descriptors: %v\n", err)
+		return
+	}
+
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] <service> <verb> [flags]")
+	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Global flags:")
+	fmt.Fprintf(a.stderr, "  --instance string\n    Select the daemon instance (default %q or %s)\n", instance.DefaultName, instance.EnvVar)
+	fmt.Fprintln(a.stderr, "  --grpc-network string")
+	fmt.Fprintln(a.stderr, "    Override the daemon network for client connections.")
+	fmt.Fprintln(a.stderr, "  --grpc-address string")
+	fmt.Fprintln(a.stderr, "    Override the daemon address for client connections.")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Commands:")
+
+	grouped := map[string][]rpcCommand{}
+	for _, command := range commands {
+		grouped[command.noun] = append(grouped[command.noun], command)
+	}
+	nouns := make([]string, 0, len(grouped))
+	for noun := range grouped {
+		nouns = append(nouns, noun)
+	}
+	sort.Strings(nouns)
+	for _, noun := range nouns {
+		commandsForNoun := grouped[noun]
+		sort.Slice(commandsForNoun, func(i, j int) bool { return commandsForNoun[i].verb < commandsForNoun[j].verb })
+		fmt.Fprintf(a.stderr, "  %s\t%s\n", noun, cleanComment(commentText(commandsForNoun[0].service)))
+		for _, command := range commandsForNoun {
+			fmt.Fprintf(a.stderr, "    %s %s\t%s\n", noun, command.verb, cleanComment(commentText(command.method)))
+		}
+	}
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "  daemon serve\tStart the daemon and expose the canonical gRPC surface.")
+}
+
+func (a *app) printDaemonHelp() {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Flags:")
+	fmt.Fprintf(a.stderr, "  --grpc-network string\n    Listener network: tcp or unix (default %q)\n", server.DefaultListenerNetwork())
+	fmt.Fprintln(a.stderr, "  --grpc-address string")
+	fmt.Fprintln(a.stderr, "    Listener address or unix socket path.")
+	fmt.Fprintf(a.stderr, "  --grpc-require-peer-credentials bool\n    Require SO_PEERCRED same-UID authentication for unix sockets (default %t)\n", server.DefaultListenerConfig().RequirePeerCredentials)
+}
+
+func (a *app) printCommandHelp(command rpcCommand) {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintf(a.stderr, "  rein [global flags] %s %s", command.noun, command.verb)
+	for i := 0; i < command.input.Fields().Len(); i++ {
+		field := command.input.Fields().Get(i)
+		fmt.Fprintf(a.stderr, " [--%s <%s>]", field.Name(), fieldTypeLabel(field))
+	}
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr)
+	if comment := cleanComment(commentText(command.method)); comment != "" {
+		fmt.Fprintln(a.stderr, comment)
+		fmt.Fprintln(a.stderr)
+	}
+	fmt.Fprintln(a.stderr, "Flags:")
+	for i := 0; i < command.input.Fields().Len(); i++ {
+		field := command.input.Fields().Get(i)
+		fmt.Fprintf(a.stderr, "  --%s %s\n    %s\n", field.Name(), fieldTypeLabel(field), fieldUsage(field))
+	}
+}
+
+func fieldUsage(field protoreflect.FieldDescriptor) string {
+	comment := cleanComment(commentText(field))
+	if comment == "" {
+		comment = fmt.Sprintf("Set request field %s.", field.Name())
+	}
+	if field.IsList() || field.IsMap() || field.Kind() == protoreflect.MessageKind {
+		return comment + " Pass JSON."
+	}
+	return comment
+}
+
+func fieldTypeLabel(field protoreflect.FieldDescriptor) string {
+	switch {
+	case field.IsList(), field.IsMap(), field.Kind() == protoreflect.MessageKind:
+		return "json"
+	case field.Kind() == protoreflect.BoolKind:
+		return "bool"
+	case field.Kind() == protoreflect.EnumKind:
+		return "enum"
+	case field.Kind() == protoreflect.StringKind:
+		return "string"
+	case isIntegerKind(field.Kind()), isUnsignedKind(field.Kind()):
+		return "int"
+	case field.Kind() == protoreflect.FloatKind || field.Kind() == protoreflect.DoubleKind:
+		return "number"
+	default:
+		return "value"
+	}
+}
+
+func commentText(descriptor protoreflect.Descriptor) string {
+	if comment := protofiles.Comment(string(descriptor.FullName())); comment != "" {
+		return comment
+	}
+	location := descriptor.ParentFile().SourceLocations().ByDescriptor(descriptor)
+	return strings.TrimSpace(location.LeadingComments)
+}
+
+func cleanComment(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func isHelpToken(value string) bool {
+	return value == "-h" || value == "--help" || value == "help"
+}
+
+func sliceMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/rein/config.go
+++ b/cmd/rein/config.go
@@ -9,23 +9,31 @@ import (
 	"github.com/earchibald/rein/internal/server"
 )
 
-type runtimeConfig struct {
+type rootConfig struct {
+	instance instance.Layout
+	client   clientConfig
+}
+
+type clientConfig struct {
+	Network string
+	Address string
+}
+
+type daemonServeConfig struct {
 	instance instance.Layout
 	listener server.ListenerConfig
 }
 
-func parseRuntimeConfig(args []string, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error)) (runtimeConfig, error) {
-	defaults := server.DefaultListenerConfig()
+func parseRootConfig(args []string, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error)) (rootConfig, []string, error) {
 	flagSet := flag.NewFlagSet("rein", flag.ContinueOnError)
 	flagSet.SetOutput(stderr)
 
 	instanceName := flagSet.String("instance", "", fmt.Sprintf("instance name (default %q or %s)", instance.DefaultName, instance.EnvVar))
-	network := flagSet.String("grpc-network", "", fmt.Sprintf("listener network: tcp or unix (default %q)", defaults.Network))
-	address := flagSet.String("grpc-address", "", "listener address or unix socket path")
-	requirePeerCredentials := flagSet.Bool("grpc-require-peer-credentials", defaults.RequirePeerCredentials, "require SO_PEERCRED same-UID authentication for unix sockets")
+	network := flagSet.String("grpc-network", "", "daemon network override: tcp or unix")
+	address := flagSet.String("grpc-address", "", "daemon address override")
 
 	if err := flagSet.Parse(args); err != nil {
-		return runtimeConfig{}, err
+		return rootConfig{}, nil, err
 	}
 
 	layout, err := instance.Resolve(instance.ResolveOptions{
@@ -34,35 +42,79 @@ func parseRuntimeConfig(args []string, stderr io.Writer, lookupEnv func(string) 
 		UserHomeDir: userHomeDir,
 	})
 	if err != nil {
-		return runtimeConfig{}, err
+		return rootConfig{}, nil, err
 	}
 
-	visited := map[string]bool{}
-	flagSet.Visit(func(f *flag.Flag) {
-		visited[f.Name] = true
-	})
+	client := defaultClientConfig(layout)
+	visited := visitedFlags(flagSet)
+	if visited["grpc-network"] {
+		client.Network = *network
+		client.Address = defaultConnectionAddress(client.Network, layout)
+	}
+	if visited["grpc-address"] {
+		client.Address = *address
+	}
+
+	return rootConfig{
+		instance: layout,
+		client:   client,
+	}, flagSet.Args(), nil
+}
+
+func parseDaemonServeConfig(root rootConfig, args []string, stderr io.Writer) (daemonServeConfig, error) {
+	defaults := server.DefaultListenerConfig()
+	flagSet := flag.NewFlagSet("rein daemon serve", flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+
+	network := flagSet.String("grpc-network", "", fmt.Sprintf("listener network: tcp or unix (default %q)", defaults.Network))
+	address := flagSet.String("grpc-address", "", "listener address or unix socket path")
+	requirePeerCredentials := flagSet.Bool("grpc-require-peer-credentials", defaults.RequirePeerCredentials, "require SO_PEERCRED same-UID authentication for unix sockets")
+
+	if err := flagSet.Parse(args); err != nil {
+		return daemonServeConfig{}, err
+	}
+	if flagSet.NArg() != 0 {
+		return daemonServeConfig{}, fmt.Errorf("unexpected arguments: %v", flagSet.Args())
+	}
 
 	listener := defaults
+	listener.Address = defaultConnectionAddress(listener.Network, root.instance)
+	visited := visitedFlags(flagSet)
 	if visited["grpc-network"] {
 		listener.Network = *network
+		listener.Address = defaultConnectionAddress(listener.Network, root.instance)
 	}
-	listener.Address = defaultListenerAddress(listener.Network, layout)
 	if visited["grpc-address"] {
 		listener.Address = *address
 	}
 	listener.RequirePeerCredentials = *requirePeerCredentials
 	listener.UnixSocketMode = 0o600
 
-	return runtimeConfig{
-		instance: layout,
+	return daemonServeConfig{
+		instance: root.instance,
 		listener: listener,
 	}, nil
 }
 
-func defaultListenerAddress(network string, layout instance.Layout) string {
+func defaultClientConfig(layout instance.Layout) clientConfig {
+	network := server.DefaultListenerNetwork()
+	return clientConfig{
+		Network: network,
+		Address: defaultConnectionAddress(network, layout),
+	}
+}
+
+func defaultConnectionAddress(network string, layout instance.Layout) string {
 	if network == "unix" {
 		return layout.SocketPath
 	}
-
 	return server.DefaultListenerAddress(network)
+}
+
+func visitedFlags(flagSet *flag.FlagSet) map[string]bool {
+	visited := map[string]bool{}
+	flagSet.Visit(func(f *flag.Flag) {
+		visited[f.Name] = true
+	})
+	return visited
 }

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -4,37 +4,41 @@ import (
 	"bytes"
 	"flag"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/earchibald/rein/internal/instance"
 	"github.com/earchibald/rein/internal/server"
 )
 
-func TestParseRuntimeConfigUsesDefaultLiveInstance(t *testing.T) {
+func TestParseRootConfigUsesDefaultLiveInstance(t *testing.T) {
 	t.Parallel()
 
-	config, err := parseRuntimeConfig(nil, io.Discard, nil, func() (string, error) {
+	config, args, err := parseRootConfig([]string{"project", "list"}, io.Discard, nil, func() (string, error) {
 		return "/Users/tester", nil
 	})
 	if err != nil {
-		t.Fatalf("parseRuntimeConfig() error = %v", err)
+		t.Fatalf("parseRootConfig() error = %v", err)
 	}
 
+	if len(args) != 2 || args[0] != "project" || args[1] != "list" {
+		t.Fatalf("remaining args = %v, want project list", args)
+	}
 	if config.instance.Name != instance.DefaultName {
 		t.Fatalf("instance name = %q, want %q", config.instance.Name, instance.DefaultName)
 	}
-	if config.listener.Network != server.DefaultListenerNetwork() {
-		t.Fatalf("listener network = %q, want %q", config.listener.Network, server.DefaultListenerNetwork())
+	if config.client.Network != server.DefaultListenerNetwork() {
+		t.Fatalf("client network = %q, want %q", config.client.Network, server.DefaultListenerNetwork())
 	}
-	if config.listener.Network == "unix" && config.listener.Address != config.instance.SocketPath {
-		t.Fatalf("listener address = %q, want %q", config.listener.Address, config.instance.SocketPath)
+	if config.client.Network == "unix" && config.client.Address != config.instance.SocketPath {
+		t.Fatalf("client address = %q, want %q", config.client.Address, config.instance.SocketPath)
 	}
 }
 
-func TestParseRuntimeConfigUsesEnvSelectedInstance(t *testing.T) {
+func TestParseRootConfigUsesEnvSelectedInstance(t *testing.T) {
 	t.Parallel()
 
-	config, err := parseRuntimeConfig(nil, io.Discard, func(key string) (string, bool) {
+	config, _, err := parseRootConfig([]string{"project", "list"}, io.Discard, func(key string) (string, bool) {
 		switch key {
 		case instance.EnvVar:
 			return "staging", true
@@ -45,21 +49,21 @@ func TestParseRuntimeConfigUsesEnvSelectedInstance(t *testing.T) {
 		}
 	}, nil)
 	if err != nil {
-		t.Fatalf("parseRuntimeConfig() error = %v", err)
+		t.Fatalf("parseRootConfig() error = %v", err)
 	}
 
 	if config.instance.Name != "staging" {
-		t.Fatalf("instance name = %q, want %q", config.instance.Name, "staging")
+		t.Fatalf("instance name = %q, want staging", config.instance.Name)
 	}
-	if config.listener.Address != config.instance.SocketPath {
-		t.Fatalf("listener address = %q, want %q", config.listener.Address, config.instance.SocketPath)
+	if config.client.Address != config.instance.SocketPath {
+		t.Fatalf("client address = %q, want %q", config.client.Address, config.instance.SocketPath)
 	}
 }
 
-func TestParseRuntimeConfigFlagOverridesEnv(t *testing.T) {
+func TestParseRootConfigFlagOverridesEnv(t *testing.T) {
 	t.Parallel()
 
-	config, err := parseRuntimeConfig([]string{"--instance", "dev"}, io.Discard, func(key string) (string, bool) {
+	config, _, err := parseRootConfig([]string{"--instance", "dev", "project", "list"}, io.Discard, func(key string) (string, bool) {
 		switch key {
 		case instance.EnvVar:
 			return "staging", true
@@ -70,57 +74,62 @@ func TestParseRuntimeConfigFlagOverridesEnv(t *testing.T) {
 		}
 	}, nil)
 	if err != nil {
-		t.Fatalf("parseRuntimeConfig() error = %v", err)
+		t.Fatalf("parseRootConfig() error = %v", err)
 	}
 
 	if config.instance.Name != "dev" {
-		t.Fatalf("instance name = %q, want %q", config.instance.Name, "dev")
+		t.Fatalf("instance name = %q, want dev", config.instance.Name)
 	}
 }
 
-func TestParseRuntimeConfigUsesTCPDefaultsWhenRequested(t *testing.T) {
+func TestParseRootConfigUsesTCPDefaultsWhenRequested(t *testing.T) {
 	t.Parallel()
 
-	config, err := parseRuntimeConfig([]string{"--grpc-network", "tcp"}, io.Discard, func(key string) (string, bool) {
+	config, _, err := parseRootConfig([]string{"--grpc-network", "tcp", "project", "list"}, io.Discard, func(key string) (string, bool) {
 		if key == "XDG_STATE_HOME" {
 			return "/state", true
 		}
 		return "", false
 	}, nil)
 	if err != nil {
-		t.Fatalf("parseRuntimeConfig() error = %v", err)
+		t.Fatalf("parseRootConfig() error = %v", err)
 	}
 
-	if config.listener.Network != "tcp" {
-		t.Fatalf("listener network = %q, want %q", config.listener.Network, "tcp")
+	if config.client.Network != "tcp" {
+		t.Fatalf("client network = %q, want tcp", config.client.Network)
 	}
-	if config.listener.Address != server.DefaultListenerAddress("tcp") {
-		t.Fatalf("listener address = %q, want %q", config.listener.Address, server.DefaultListenerAddress("tcp"))
+	if config.client.Address != server.DefaultListenerAddress("tcp") {
+		t.Fatalf("client address = %q, want %q", config.client.Address, server.DefaultListenerAddress("tcp"))
 	}
 }
 
-func TestParseRuntimeConfigHonorsExplicitAddress(t *testing.T) {
+func TestParseDaemonServeConfigHonorsExplicitAddress(t *testing.T) {
 	t.Parallel()
 
-	config, err := parseRuntimeConfig([]string{"--grpc-network", "unix", "--grpc-address", "/override.sock"}, io.Discard, func(key string) (string, bool) {
+	root, _, err := parseRootConfig([]string{"daemon", "serve"}, io.Discard, func(key string) (string, bool) {
 		if key == "XDG_STATE_HOME" {
 			return "/state", true
 		}
 		return "", false
 	}, nil)
 	if err != nil {
-		t.Fatalf("parseRuntimeConfig() error = %v", err)
+		t.Fatalf("parseRootConfig() error = %v", err)
+	}
+
+	config, err := parseDaemonServeConfig(root, []string{"--grpc-network", "unix", "--grpc-address", "/override.sock"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseDaemonServeConfig() error = %v", err)
 	}
 
 	if config.listener.Address != "/override.sock" {
-		t.Fatalf("listener address = %q, want %q", config.listener.Address, "/override.sock")
+		t.Fatalf("listener address = %q, want /override.sock", config.listener.Address)
 	}
 }
 
-func TestParseRuntimeConfigRejectsInvalidInstance(t *testing.T) {
+func TestParseRootConfigRejectsInvalidInstance(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseRuntimeConfig(nil, io.Discard, func(key string) (string, bool) {
+	_, _, err := parseRootConfig([]string{"project", "list"}, io.Discard, func(key string) (string, bool) {
 		switch key {
 		case instance.EnvVar:
 			return "../oops", true
@@ -131,7 +140,7 @@ func TestParseRuntimeConfigRejectsInvalidInstance(t *testing.T) {
 		}
 	}, nil)
 	if err == nil {
-		t.Fatal("parseRuntimeConfig() error = nil, want non-nil")
+		t.Fatal("parseRootConfig() error = nil, want non-nil")
 	}
 }
 
@@ -151,5 +160,30 @@ func TestParseErrorExitCodeHandlesHelpAndDiagnostics(t *testing.T) {
 	}
 	if stderr.Len() == 0 {
 		t.Fatal("stderr = empty, want diagnostic output")
+	}
+}
+
+func TestAppCommandHelpUsesProtoComments(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	})
+
+	err := app.run([]string{"project", "list", "--help"})
+	if err != flag.ErrHelp {
+		t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+	}
+
+	output := stderr.String()
+	for _, want := range []string{
+		"List projects stored in the daemon.",
+		"--status enum",
+		"Filter projects by status.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q\n%s", want, output)
+		}
 	}
 }

--- a/cmd/rein/main.go
+++ b/cmd/rein/main.go
@@ -1,19 +1,11 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/earchibald/rein/internal/adapter"
-	"github.com/earchibald/rein/internal/server"
-	"github.com/earchibald/rein/internal/service"
 )
 
 func main() {
@@ -21,61 +13,10 @@ func main() {
 }
 
 func run() int {
-	config, err := parseRuntimeConfig(os.Args[1:], os.Stderr, os.LookupEnv, os.UserHomeDir)
-	if err != nil {
+	app := newApp(os.Stdout, os.Stderr, os.LookupEnv, os.UserHomeDir)
+	if err := app.run(os.Args[1:]); err != nil {
 		return parseErrorExitCode(err, os.Stderr)
 	}
-
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	if err := config.instance.EnsureRootDir(); err != nil {
-		logger.Error("failed to prepare instance state directory", "error", err)
-		return 1
-	}
-
-	listenerConfig := config.listener
-	listenerConfig.Logger = logger
-
-	listener, err := server.Listen(listenerConfig)
-	if err != nil {
-		logger.Error("failed to create listener", "error", err)
-		return 1
-	}
-	defer func() {
-		if err := listener.Close(); err != nil {
-			logger.Error("failed to close listener", "error", err)
-		}
-	}()
-
-	services, err := service.NewSetFromRoot(".", adapter.DiscoveryOptions{})
-	if err != nil {
-		logger.Error("failed to load adapter registry", "error", err)
-		return 1
-	}
-
-	runtime := server.New(server.Options{Services: services})
-
-	logger.Info(
-		"rein gRPC server starting",
-		"instance", config.instance.Name,
-		"state_dir", config.instance.RootDir,
-		"network", listenerConfig.Network,
-		"address", listener.Addr().String(),
-		"auto_start", config.instance.AutoStartEnabled(),
-	)
-	logger.Info(
-		"rein HTTP/SSE gateway v2 stub ready",
-		"routes", len(runtime.Gateway().Routes()),
-		"streams", len(runtime.Gateway().Streams()),
-	)
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	if err := runtime.Serve(ctx, listener); err != nil {
-		logger.Error("rein server exited with error", "error", err)
-		return 1
-	}
-
 	return 0
 }
 

--- a/gen/go/rein/v1/adapter.pb.go
+++ b/gen/go/rein/v1/adapter.pb.go
@@ -22,10 +22,13 @@ const (
 )
 
 type ListAdaptersRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *PageRequest           `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
-	Category      AdapterCategory        `protobuf:"varint,2,opt,name=category,proto3,enum=rein.v1.AdapterCategory" json:"category,omitempty"`
-	EnabledOnly   bool                   `protobuf:"varint,3,opt,name=enabled_only,json=enabledOnly,proto3" json:"enabled_only,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Paginate adapter results. Pass JSON matching PageRequest.
+	Page *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	// Filter adapters by category.
+	Category AdapterCategory `protobuf:"varint,2,opt,name=category,proto3,enum=rein.v1.AdapterCategory" json:"category,omitempty"`
+	// Exclude disabled adapters when true.
+	EnabledOnly   bool `protobuf:"varint,3,opt,name=enabled_only,json=enabledOnly,proto3" json:"enabled_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -134,8 +137,9 @@ func (x *ListAdaptersResponse) GetPage() *PageResponse {
 }
 
 type GetAdapterRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Adapter identifier.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -222,8 +226,9 @@ func (x *GetAdapterResponse) GetAdapter() *Adapter {
 }
 
 type ValidateAdapterRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Adapter       *Adapter               `protobuf:"bytes,1,opt,name=adapter,proto3" json:"adapter,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Adapter payload. Pass JSON matching Adapter.
+	Adapter       *Adapter `protobuf:"bytes,1,opt,name=adapter,proto3" json:"adapter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/rein/v1/adapter_grpc.pb.go
+++ b/gen/go/rein/v1/adapter_grpc.pb.go
@@ -27,9 +27,14 @@ const (
 // AdapterServiceClient is the client API for AdapterService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// AdapterService manages adapters available to the daemon.
 type AdapterServiceClient interface {
+	// List adapters available to the daemon.
 	ListAdapters(ctx context.Context, in *ListAdaptersRequest, opts ...grpc.CallOption) (*ListAdaptersResponse, error)
+	// Get a single adapter by id.
 	GetAdapter(ctx context.Context, in *GetAdapterRequest, opts ...grpc.CallOption) (*GetAdapterResponse, error)
+	// Validate an adapter payload without storing it.
 	ValidateAdapter(ctx context.Context, in *ValidateAdapterRequest, opts ...grpc.CallOption) (*ValidateAdapterResponse, error)
 }
 
@@ -74,9 +79,14 @@ func (c *adapterServiceClient) ValidateAdapter(ctx context.Context, in *Validate
 // AdapterServiceServer is the server API for AdapterService service.
 // All implementations should embed UnimplementedAdapterServiceServer
 // for forward compatibility.
+//
+// AdapterService manages adapters available to the daemon.
 type AdapterServiceServer interface {
+	// List adapters available to the daemon.
 	ListAdapters(context.Context, *ListAdaptersRequest) (*ListAdaptersResponse, error)
+	// Get a single adapter by id.
 	GetAdapter(context.Context, *GetAdapterRequest) (*GetAdapterResponse, error)
+	// Validate an adapter payload without storing it.
 	ValidateAdapter(context.Context, *ValidateAdapterRequest) (*ValidateAdapterResponse, error)
 }
 

--- a/gen/go/rein/v1/execution.pb.go
+++ b/gen/go/rein/v1/execution.pb.go
@@ -22,10 +22,13 @@ const (
 )
 
 type ListExecutionsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *PageRequest           `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
-	IssueId       string                 `protobuf:"bytes,2,opt,name=issue_id,json=issueId,proto3" json:"issue_id,omitempty"`
-	Status        ExecutionStatus        `protobuf:"varint,3,opt,name=status,proto3,enum=rein.v1.ExecutionStatus" json:"status,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Paginate execution results. Pass JSON matching PageRequest.
+	Page *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	// Filter executions by issue id.
+	IssueId string `protobuf:"bytes,2,opt,name=issue_id,json=issueId,proto3" json:"issue_id,omitempty"`
+	// Filter executions by status.
+	Status        ExecutionStatus `protobuf:"varint,3,opt,name=status,proto3,enum=rein.v1.ExecutionStatus" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -134,8 +137,9 @@ func (x *ListExecutionsResponse) GetPage() *PageResponse {
 }
 
 type GetExecutionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Execution identifier.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -222,11 +226,15 @@ func (x *GetExecutionResponse) GetExecution() *Execution {
 }
 
 type StartExecutionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	IssueId       string                 `protobuf:"bytes,1,opt,name=issue_id,json=issueId,proto3" json:"issue_id,omitempty"`
-	WorkflowId    string                 `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
-	RequestedBy   string                 `protobuf:"bytes,3,opt,name=requested_by,json=requestedBy,proto3" json:"requested_by,omitempty"`
-	Inputs        map[string]string      `protobuf:"bytes,4,rep,name=inputs,proto3" json:"inputs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Issue identifier.
+	IssueId string `protobuf:"bytes,1,opt,name=issue_id,json=issueId,proto3" json:"issue_id,omitempty"`
+	// Workflow identifier.
+	WorkflowId string `protobuf:"bytes,2,opt,name=workflow_id,json=workflowId,proto3" json:"workflow_id,omitempty"`
+	// Actor requesting the execution.
+	RequestedBy string `protobuf:"bytes,3,opt,name=requested_by,json=requestedBy,proto3" json:"requested_by,omitempty"`
+	// Execution input values. Pass a JSON object.
+	Inputs        map[string]string `protobuf:"bytes,4,rep,name=inputs,proto3" json:"inputs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -334,9 +342,11 @@ func (x *StartExecutionResponse) GetExecution() *Execution {
 }
 
 type CancelExecutionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Execution identifier.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Human-readable cancellation reason.
+	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/rein/v1/execution_grpc.pb.go
+++ b/gen/go/rein/v1/execution_grpc.pb.go
@@ -28,10 +28,16 @@ const (
 // ExecutionServiceClient is the client API for ExecutionService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// ExecutionService manages workflow executions stored by the daemon.
 type ExecutionServiceClient interface {
+	// List executions stored in the daemon.
 	ListExecutions(ctx context.Context, in *ListExecutionsRequest, opts ...grpc.CallOption) (*ListExecutionsResponse, error)
+	// Get a single execution by id.
 	GetExecution(ctx context.Context, in *GetExecutionRequest, opts ...grpc.CallOption) (*GetExecutionResponse, error)
+	// Start a workflow execution for an issue.
 	StartExecution(ctx context.Context, in *StartExecutionRequest, opts ...grpc.CallOption) (*StartExecutionResponse, error)
+	// Cancel a running execution.
 	CancelExecution(ctx context.Context, in *CancelExecutionRequest, opts ...grpc.CallOption) (*CancelExecutionResponse, error)
 }
 
@@ -86,10 +92,16 @@ func (c *executionServiceClient) CancelExecution(ctx context.Context, in *Cancel
 // ExecutionServiceServer is the server API for ExecutionService service.
 // All implementations should embed UnimplementedExecutionServiceServer
 // for forward compatibility.
+//
+// ExecutionService manages workflow executions stored by the daemon.
 type ExecutionServiceServer interface {
+	// List executions stored in the daemon.
 	ListExecutions(context.Context, *ListExecutionsRequest) (*ListExecutionsResponse, error)
+	// Get a single execution by id.
 	GetExecution(context.Context, *GetExecutionRequest) (*GetExecutionResponse, error)
+	// Start a workflow execution for an issue.
 	StartExecution(context.Context, *StartExecutionRequest) (*StartExecutionResponse, error)
+	// Cancel a running execution.
 	CancelExecution(context.Context, *CancelExecutionRequest) (*CancelExecutionResponse, error)
 }
 

--- a/gen/go/rein/v1/issue.pb.go
+++ b/gen/go/rein/v1/issue.pb.go
@@ -22,12 +22,17 @@ const (
 )
 
 type ListIssuesRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *PageRequest           `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
-	ProjectId     string                 `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
-	Status        IssueStatus            `protobuf:"varint,3,opt,name=status,proto3,enum=rein.v1.IssueStatus" json:"status,omitempty"`
-	Assignee      string                 `protobuf:"bytes,4,opt,name=assignee,proto3" json:"assignee,omitempty"`
-	Query         string                 `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Paginate issue results. Pass JSON matching PageRequest.
+	Page *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	// Filter issues by project id.
+	ProjectId string `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// Filter issues by status.
+	Status IssueStatus `protobuf:"varint,3,opt,name=status,proto3,enum=rein.v1.IssueStatus" json:"status,omitempty"`
+	// Filter issues by assignee.
+	Assignee string `protobuf:"bytes,4,opt,name=assignee,proto3" json:"assignee,omitempty"`
+	// Match issue id, title, summary, workflow id, or assignee.
+	Query         string `protobuf:"bytes,5,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -150,8 +155,9 @@ func (x *ListIssuesResponse) GetPage() *PageResponse {
 }
 
 type GetIssueRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Issue identifier.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -238,8 +244,9 @@ func (x *GetIssueResponse) GetIssue() *Issue {
 }
 
 type CreateIssueRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Issue         *Issue                 `protobuf:"bytes,1,opt,name=issue,proto3" json:"issue,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Issue payload. Pass JSON matching Issue.
+	Issue         *Issue `protobuf:"bytes,1,opt,name=issue,proto3" json:"issue,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -326,8 +333,9 @@ func (x *CreateIssueResponse) GetIssue() *Issue {
 }
 
 type UpdateIssueRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Issue         *Issue                 `protobuf:"bytes,1,opt,name=issue,proto3" json:"issue,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Replacement issue payload. Pass JSON matching Issue.
+	Issue         *Issue `protobuf:"bytes,1,opt,name=issue,proto3" json:"issue,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/rein/v1/issue_grpc.pb.go
+++ b/gen/go/rein/v1/issue_grpc.pb.go
@@ -28,10 +28,16 @@ const (
 // IssueServiceClient is the client API for IssueService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// IssueService manages issues stored by the daemon.
 type IssueServiceClient interface {
+	// List issues stored in the daemon.
 	ListIssues(ctx context.Context, in *ListIssuesRequest, opts ...grpc.CallOption) (*ListIssuesResponse, error)
+	// Get a single issue by id.
 	GetIssue(ctx context.Context, in *GetIssueRequest, opts ...grpc.CallOption) (*GetIssueResponse, error)
+	// Create an issue record.
 	CreateIssue(ctx context.Context, in *CreateIssueRequest, opts ...grpc.CallOption) (*CreateIssueResponse, error)
+	// Update an issue record.
 	UpdateIssue(ctx context.Context, in *UpdateIssueRequest, opts ...grpc.CallOption) (*UpdateIssueResponse, error)
 }
 
@@ -86,10 +92,16 @@ func (c *issueServiceClient) UpdateIssue(ctx context.Context, in *UpdateIssueReq
 // IssueServiceServer is the server API for IssueService service.
 // All implementations should embed UnimplementedIssueServiceServer
 // for forward compatibility.
+//
+// IssueService manages issues stored by the daemon.
 type IssueServiceServer interface {
+	// List issues stored in the daemon.
 	ListIssues(context.Context, *ListIssuesRequest) (*ListIssuesResponse, error)
+	// Get a single issue by id.
 	GetIssue(context.Context, *GetIssueRequest) (*GetIssueResponse, error)
+	// Create an issue record.
 	CreateIssue(context.Context, *CreateIssueRequest) (*CreateIssueResponse, error)
+	// Update an issue record.
 	UpdateIssue(context.Context, *UpdateIssueRequest) (*UpdateIssueResponse, error)
 }
 

--- a/gen/go/rein/v1/project.pb.go
+++ b/gen/go/rein/v1/project.pb.go
@@ -22,10 +22,13 @@ const (
 )
 
 type ListProjectsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *PageRequest           `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
-	Status        ProjectStatus          `protobuf:"varint,2,opt,name=status,proto3,enum=rein.v1.ProjectStatus" json:"status,omitempty"`
-	Query         string                 `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Paginate project results. Pass JSON matching PageRequest.
+	Page *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	// Filter projects by status.
+	Status ProjectStatus `protobuf:"varint,2,opt,name=status,proto3,enum=rein.v1.ProjectStatus" json:"status,omitempty"`
+	// Match project id, slug, display name, or summary.
+	Query         string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -134,8 +137,9 @@ func (x *ListProjectsResponse) GetPage() *PageResponse {
 }
 
 type GetProjectRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project identifier.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -222,8 +226,9 @@ func (x *GetProjectResponse) GetProject() *Project {
 }
 
 type CreateProjectRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Project       *Project               `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Project payload. Pass JSON matching Project.
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -310,8 +315,9 @@ func (x *CreateProjectResponse) GetProject() *Project {
 }
 
 type UpdateProjectRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Project       *Project               `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Replacement project payload. Pass JSON matching Project.
+	Project       *Project `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/rein/v1/project_grpc.pb.go
+++ b/gen/go/rein/v1/project_grpc.pb.go
@@ -28,10 +28,16 @@ const (
 // ProjectServiceClient is the client API for ProjectService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// ProjectService manages projects stored by the daemon.
 type ProjectServiceClient interface {
+	// List projects stored in the daemon.
 	ListProjects(ctx context.Context, in *ListProjectsRequest, opts ...grpc.CallOption) (*ListProjectsResponse, error)
+	// Get a single project by id.
 	GetProject(ctx context.Context, in *GetProjectRequest, opts ...grpc.CallOption) (*GetProjectResponse, error)
+	// Create a project record.
 	CreateProject(ctx context.Context, in *CreateProjectRequest, opts ...grpc.CallOption) (*CreateProjectResponse, error)
+	// Update a project record.
 	UpdateProject(ctx context.Context, in *UpdateProjectRequest, opts ...grpc.CallOption) (*UpdateProjectResponse, error)
 }
 
@@ -86,10 +92,16 @@ func (c *projectServiceClient) UpdateProject(ctx context.Context, in *UpdateProj
 // ProjectServiceServer is the server API for ProjectService service.
 // All implementations should embed UnimplementedProjectServiceServer
 // for forward compatibility.
+//
+// ProjectService manages projects stored by the daemon.
 type ProjectServiceServer interface {
+	// List projects stored in the daemon.
 	ListProjects(context.Context, *ListProjectsRequest) (*ListProjectsResponse, error)
+	// Get a single project by id.
 	GetProject(context.Context, *GetProjectRequest) (*GetProjectResponse, error)
+	// Create a project record.
 	CreateProject(context.Context, *CreateProjectRequest) (*CreateProjectResponse, error)
+	// Update a project record.
 	UpdateProject(context.Context, *UpdateProjectRequest) (*UpdateProjectResponse, error)
 }
 

--- a/gen/go/rein/v1/workflow.pb.go
+++ b/gen/go/rein/v1/workflow.pb.go
@@ -22,9 +22,11 @@ const (
 )
 
 type ListWorkflowsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *PageRequest           `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
-	Query         string                 `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Paginate workflow results. Pass JSON matching PageRequest.
+	Page *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	// Match workflow id, name, description, or version.
+	Query         string `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -126,8 +128,9 @@ func (x *ListWorkflowsResponse) GetPage() *PageResponse {
 }
 
 type GetWorkflowRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Workflow identifier.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -214,8 +217,9 @@ func (x *GetWorkflowResponse) GetWorkflow() *Workflow {
 }
 
 type ValidateWorkflowRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Workflow      *Workflow              `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Workflow payload. Pass JSON matching Workflow.
+	Workflow      *Workflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/gen/go/rein/v1/workflow_grpc.pb.go
+++ b/gen/go/rein/v1/workflow_grpc.pb.go
@@ -27,9 +27,14 @@ const (
 // WorkflowServiceClient is the client API for WorkflowService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// WorkflowService manages workflows stored by the daemon.
 type WorkflowServiceClient interface {
+	// List workflows stored in the daemon.
 	ListWorkflows(ctx context.Context, in *ListWorkflowsRequest, opts ...grpc.CallOption) (*ListWorkflowsResponse, error)
+	// Get a single workflow by id.
 	GetWorkflow(ctx context.Context, in *GetWorkflowRequest, opts ...grpc.CallOption) (*GetWorkflowResponse, error)
+	// Validate a workflow payload without storing it.
 	ValidateWorkflow(ctx context.Context, in *ValidateWorkflowRequest, opts ...grpc.CallOption) (*ValidateWorkflowResponse, error)
 }
 
@@ -74,9 +79,14 @@ func (c *workflowServiceClient) ValidateWorkflow(ctx context.Context, in *Valida
 // WorkflowServiceServer is the server API for WorkflowService service.
 // All implementations should embed UnimplementedWorkflowServiceServer
 // for forward compatibility.
+//
+// WorkflowService manages workflows stored by the daemon.
 type WorkflowServiceServer interface {
+	// List workflows stored in the daemon.
 	ListWorkflows(context.Context, *ListWorkflowsRequest) (*ListWorkflowsResponse, error)
+	// Get a single workflow by id.
 	GetWorkflow(context.Context, *GetWorkflowRequest) (*GetWorkflowResponse, error)
+	// Validate a workflow payload without storing it.
 	ValidateWorkflow(context.Context, *ValidateWorkflowRequest) (*ValidateWorkflowResponse, error)
 }
 

--- a/internal/server/grpc_contract_test.go
+++ b/internal/server/grpc_contract_test.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/service"
+	"github.com/earchibald/rein/internal/storage/sqlite"
 )
 
 type grpcContract struct {
@@ -88,6 +90,7 @@ func TestRuntimeUnaryRPCErrorContracts(t *testing.T) {
 	)
 
 	runtime := New(Options{
+		Services: managedContractServices(t),
 		GRPCOptions: []grpc.ServerOption{
 			grpc.UnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 				mu.Lock()
@@ -177,12 +180,58 @@ func unaryExpectation(contract grpcContract) unaryRPCExpectation {
 		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
 	case reinv1.AdapterService_ValidateAdapter_FullMethodName:
 		return unaryRPCExpectation{code: codes.InvalidArgument, message: "adapter is required"}
+	case reinv1.ExecutionService_ListExecutions_FullMethodName:
+		return unaryRPCExpectation{code: codes.OK}
+	case reinv1.ExecutionService_GetExecution_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.ExecutionService_StartExecution_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "issue_id is required"}
+	case reinv1.ExecutionService_CancelExecution_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.IssueService_ListIssues_FullMethodName:
+		return unaryRPCExpectation{code: codes.OK}
+	case reinv1.IssueService_GetIssue_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.IssueService_CreateIssue_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "issue is required"}
+	case reinv1.IssueService_UpdateIssue_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "issue is required"}
+	case reinv1.ProjectService_ListProjects_FullMethodName:
+		return unaryRPCExpectation{code: codes.OK}
+	case reinv1.ProjectService_GetProject_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.ProjectService_CreateProject_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "project is required"}
+	case reinv1.ProjectService_UpdateProject_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "project is required"}
+	case reinv1.WorkflowService_ListWorkflows_FullMethodName:
+		return unaryRPCExpectation{code: codes.OK}
+	case reinv1.WorkflowService_GetWorkflow_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "id is required"}
+	case reinv1.WorkflowService_ValidateWorkflow_FullMethodName:
+		return unaryRPCExpectation{code: codes.InvalidArgument, message: "workflow is required"}
 	default:
 		return unaryRPCExpectation{
 			code:    codes.Unimplemented,
 			message: "method " + contract.method + " not implemented",
 		}
 	}
+}
+
+func managedContractServices(t testing.TB) service.Set {
+	t.Helper()
+
+	store, err := sqlite.OpenInMemoryAndMigrate(context.Background(), t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	return service.NewManagedSet(store, newRuntimeCatalog())
 }
 
 func findMethodDescriptor(t testing.TB, fullMethod string) protoreflect.MethodDescriptor {

--- a/internal/service/managed.go
+++ b/internal/service/managed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -43,8 +44,31 @@ type ManagedAdapterServer struct {
 	catalog ManagedCatalog
 }
 
-func (s *ManagedAdapterServer) ListAdapters(_ context.Context, _ *reinv1.ListAdaptersRequest) (*reinv1.ListAdaptersResponse, error) {
-	return &reinv1.ListAdaptersResponse{Adapters: s.catalog.List()}, nil
+func (s *ManagedAdapterServer) ListAdapters(_ context.Context, req *reinv1.ListAdaptersRequest) (*reinv1.ListAdaptersResponse, error) {
+	if s.catalog == nil {
+		return nil, status.Error(codes.FailedPrecondition, "adapter catalog is not configured")
+	}
+
+	adapters := s.catalog.List()
+	filtered := make([]*reinv1.Adapter, 0, len(adapters))
+	for _, adapter := range adapters {
+		if adapter == nil {
+			continue
+		}
+		if req.GetCategory() != reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED && adapter.GetCategory() != req.GetCategory() {
+			continue
+		}
+		if req.GetEnabledOnly() && !adapter.GetEnabled() {
+			continue
+		}
+		filtered = append(filtered, adapter)
+	}
+
+	paged, page, err := paginateResults(filtered, req.GetPage())
+	if err != nil {
+		return nil, err
+	}
+	return &reinv1.ListAdaptersResponse{Adapters: paged, Page: page}, nil
 }
 
 func (s *ManagedAdapterServer) GetAdapter(_ context.Context, req *reinv1.GetAdapterRequest) (*reinv1.GetAdapterResponse, error) {
@@ -93,6 +117,28 @@ func (s *ManagedWorkflowServer) GetWorkflow(ctx context.Context, req *reinv1.Get
 	return &reinv1.GetWorkflowResponse{Workflow: workflowEntity}, nil
 }
 
+func (s *ManagedWorkflowServer) ListWorkflows(ctx context.Context, req *reinv1.ListWorkflowsRequest) (*reinv1.ListWorkflowsResponse, error) {
+	workflows, err := listStoredMessages(ctx, s.store, sqlite.WorkflowKind, func() *reinv1.Workflow { return &reinv1.Workflow{} })
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list workflows: %v", err)
+	}
+
+	query := strings.ToLower(strings.TrimSpace(req.GetQuery()))
+	filtered := make([]*reinv1.Workflow, 0, len(workflows))
+	for _, workflowEntity := range workflows {
+		if query != "" && !matchesQuery(query, workflowEntity.GetId(), workflowEntity.GetName(), workflowEntity.GetDescription(), workflowEntity.GetVersion()) {
+			continue
+		}
+		filtered = append(filtered, workflowEntity)
+	}
+
+	paged, page, err := paginateResults(filtered, req.GetPage())
+	if err != nil {
+		return nil, err
+	}
+	return &reinv1.ListWorkflowsResponse{Workflows: paged, Page: page}, nil
+}
+
 func (s *ManagedWorkflowServer) ValidateWorkflow(_ context.Context, req *reinv1.ValidateWorkflowRequest) (*reinv1.ValidateWorkflowResponse, error) {
 	if req.GetWorkflow() == nil {
 		return nil, status.Error(codes.InvalidArgument, "workflow is required")
@@ -107,6 +153,31 @@ func (s *ManagedWorkflowServer) ValidateWorkflow(_ context.Context, req *reinv1.
 type ManagedProjectServer struct {
 	reinv1.UnimplementedProjectServiceServer
 	store *sqlite.Store
+}
+
+func (s *ManagedProjectServer) ListProjects(ctx context.Context, req *reinv1.ListProjectsRequest) (*reinv1.ListProjectsResponse, error) {
+	projects, err := listStoredMessages(ctx, s.store, sqlite.ProjectKind, func() *reinv1.Project { return &reinv1.Project{} })
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list projects: %v", err)
+	}
+
+	query := strings.ToLower(strings.TrimSpace(req.GetQuery()))
+	filtered := make([]*reinv1.Project, 0, len(projects))
+	for _, project := range projects {
+		if req.GetStatus() != reinv1.ProjectStatus_PROJECT_STATUS_UNSPECIFIED && project.GetStatus() != req.GetStatus() {
+			continue
+		}
+		if query != "" && !matchesQuery(query, project.GetId(), project.GetSlug(), project.GetDisplayName(), project.GetSummary()) {
+			continue
+		}
+		filtered = append(filtered, project)
+	}
+
+	paged, page, err := paginateResults(filtered, req.GetPage())
+	if err != nil {
+		return nil, err
+	}
+	return &reinv1.ListProjectsResponse{Projects: paged, Page: page}, nil
 }
 
 func (s *ManagedProjectServer) CreateProject(ctx context.Context, req *reinv1.CreateProjectRequest) (*reinv1.CreateProjectResponse, error) {
@@ -145,9 +216,76 @@ func (s *ManagedProjectServer) GetProject(ctx context.Context, req *reinv1.GetPr
 	return &reinv1.GetProjectResponse{Project: project}, nil
 }
 
+func (s *ManagedProjectServer) UpdateProject(ctx context.Context, req *reinv1.UpdateProjectRequest) (*reinv1.UpdateProjectResponse, error) {
+	if req.GetProject() == nil {
+		return nil, status.Error(codes.InvalidArgument, "project is required")
+	}
+
+	project := proto.Clone(req.GetProject()).(*reinv1.Project)
+	if strings.TrimSpace(project.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "project.id is required")
+	}
+
+	current := &reinv1.Project{}
+	record, err := loadStoredProto(ctx, s.store, sqlite.ProjectKind, project.GetId(), current)
+	if err != nil {
+		return nil, toStatusError("project", project.GetId(), err)
+	}
+
+	if project.GetStatus() == reinv1.ProjectStatus_PROJECT_STATUS_UNSPECIFIED {
+		project.Status = current.GetStatus()
+	}
+	if project.GetCreatedTime() == nil {
+		project.CreatedTime = current.GetCreatedTime()
+	}
+	if project.Labels == nil {
+		project.Labels = cloneMap(current.GetLabels())
+	}
+	if project.Labels == nil {
+		project.Labels = map[string]string{}
+	}
+	project.UpdatedTime = timestamppb.Now()
+
+	if _, err := updateStoredProto(ctx, s.store, sqlite.ProjectKind, project.GetId(), record.LockVersion, project); err != nil {
+		return nil, status.Errorf(codes.Internal, "update project %q: %v", project.GetId(), err)
+	}
+	return &reinv1.UpdateProjectResponse{Project: project}, nil
+}
+
 type ManagedIssueServer struct {
 	reinv1.UnimplementedIssueServiceServer
 	store *sqlite.Store
+}
+
+func (s *ManagedIssueServer) ListIssues(ctx context.Context, req *reinv1.ListIssuesRequest) (*reinv1.ListIssuesResponse, error) {
+	issues, err := listStoredMessages(ctx, s.store, sqlite.IssueKind, func() *reinv1.Issue { return &reinv1.Issue{} })
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list issues: %v", err)
+	}
+
+	query := strings.ToLower(strings.TrimSpace(req.GetQuery()))
+	filtered := make([]*reinv1.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if req.GetProjectId() != "" && issue.GetProjectId() != req.GetProjectId() {
+			continue
+		}
+		if req.GetStatus() != reinv1.IssueStatus_ISSUE_STATUS_UNSPECIFIED && issue.GetStatus() != req.GetStatus() {
+			continue
+		}
+		if req.GetAssignee() != "" && issue.GetAssignee() != req.GetAssignee() {
+			continue
+		}
+		if query != "" && !matchesQuery(query, issue.GetId(), issue.GetProjectId(), issue.GetTitle(), issue.GetSummary(), issue.GetWorkflowId(), issue.GetAssignee()) {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+
+	paged, page, err := paginateResults(filtered, req.GetPage())
+	if err != nil {
+		return nil, err
+	}
+	return &reinv1.ListIssuesResponse{Issues: paged, Page: page}, nil
 }
 
 func (s *ManagedIssueServer) CreateIssue(ctx context.Context, req *reinv1.CreateIssueRequest) (*reinv1.CreateIssueResponse, error) {
@@ -189,11 +327,74 @@ func (s *ManagedIssueServer) GetIssue(ctx context.Context, req *reinv1.GetIssueR
 	return &reinv1.GetIssueResponse{Issue: issue}, nil
 }
 
+func (s *ManagedIssueServer) UpdateIssue(ctx context.Context, req *reinv1.UpdateIssueRequest) (*reinv1.UpdateIssueResponse, error) {
+	if req.GetIssue() == nil {
+		return nil, status.Error(codes.InvalidArgument, "issue is required")
+	}
+
+	issue := proto.Clone(req.GetIssue()).(*reinv1.Issue)
+	if strings.TrimSpace(issue.GetId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "issue.id is required")
+	}
+	if strings.TrimSpace(issue.GetProjectId()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "issue.project_id is required")
+	}
+
+	current := &reinv1.Issue{}
+	record, err := loadStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), current)
+	if err != nil {
+		return nil, toStatusError("issue", issue.GetId(), err)
+	}
+
+	if issue.GetStatus() == reinv1.IssueStatus_ISSUE_STATUS_UNSPECIFIED {
+		issue.Status = current.GetStatus()
+	}
+	if issue.GetCreatedTime() == nil {
+		issue.CreatedTime = current.GetCreatedTime()
+	}
+	if issue.Labels == nil {
+		issue.Labels = cloneMap(current.GetLabels())
+	}
+	if issue.Labels == nil {
+		issue.Labels = map[string]string{}
+	}
+	issue.UpdatedTime = timestamppb.Now()
+
+	if _, err := updateStoredProto(ctx, s.store, sqlite.IssueKind, issue.GetId(), record.LockVersion, issue); err != nil {
+		return nil, status.Errorf(codes.Internal, "update issue %q: %v", issue.GetId(), err)
+	}
+	return &reinv1.UpdateIssueResponse{Issue: issue}, nil
+}
+
 type ManagedExecutionServer struct {
 	reinv1.UnimplementedExecutionServiceServer
 	catalog ManagedCatalog
 	engine  *workflow.Engine
 	store   *sqlite.Store
+}
+
+func (s *ManagedExecutionServer) ListExecutions(ctx context.Context, req *reinv1.ListExecutionsRequest) (*reinv1.ListExecutionsResponse, error) {
+	executions, err := listStoredMessages(ctx, s.store, sqlite.ExecutionKind, func() *reinv1.Execution { return &reinv1.Execution{} })
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list executions: %v", err)
+	}
+
+	filtered := make([]*reinv1.Execution, 0, len(executions))
+	for _, execution := range executions {
+		if req.GetIssueId() != "" && execution.GetIssueId() != req.GetIssueId() {
+			continue
+		}
+		if req.GetStatus() != reinv1.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED && execution.GetStatus() != req.GetStatus() {
+			continue
+		}
+		filtered = append(filtered, execution)
+	}
+
+	paged, page, err := paginateResults(filtered, req.GetPage())
+	if err != nil {
+		return nil, err
+	}
+	return &reinv1.ListExecutionsResponse{Executions: paged, Page: page}, nil
 }
 
 func (s *ManagedExecutionServer) StartExecution(ctx context.Context, req *reinv1.StartExecutionRequest) (*reinv1.StartExecutionResponse, error) {
@@ -415,6 +616,64 @@ func cloneMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func listStoredMessages[T proto.Message](ctx context.Context, store *sqlite.Store, kind sqlite.EntityKind, newMessage func() T) ([]T, error) {
+	records, err := store.List(ctx, kind, sqlite.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	messages := make([]T, 0, len(records))
+	for _, record := range records {
+		message := newMessage()
+		if err := protojson.Unmarshal(record.Payload, message); err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	return messages, nil
+}
+
+func paginateResults[T any](items []T, page *reinv1.PageRequest) ([]T, *reinv1.PageResponse, error) {
+	offset := 0
+	pageSize := 0
+	if page != nil {
+		if strings.TrimSpace(page.GetPageToken()) != "" {
+			value, err := strconv.Atoi(page.GetPageToken())
+			if err != nil || value < 0 {
+				return nil, nil, status.Error(codes.InvalidArgument, "page.page_token must be a non-negative integer offset")
+			}
+			offset = value
+		}
+		pageSize = int(page.GetPageSize())
+		if pageSize < 0 {
+			return nil, nil, status.Error(codes.InvalidArgument, "page.page_size must be non-negative")
+		}
+	}
+
+	if offset > len(items) {
+		offset = len(items)
+	}
+	items = items[offset:]
+	if pageSize == 0 || pageSize >= len(items) {
+		if len(items) == 0 {
+			return items, nil, nil
+		}
+		return items, nil, nil
+	}
+
+	nextOffset := offset + pageSize
+	return items[:pageSize], &reinv1.PageResponse{NextPageToken: strconv.Itoa(nextOffset)}, nil
+}
+
+func matchesQuery(query string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if strings.Contains(strings.ToLower(candidate), query) {
+			return true
+		}
+	}
+	return false
 }
 
 func executionID(issueID string) string {

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+func NewManagedCatalogFromRoot(root string, options adapter.DiscoveryOptions) (ManagedCatalog, error) {
+	registry, err := adapter.Load(root, options)
+	if err != nil {
+		return nil, err
+	}
+	return NewManagedCatalog(registry), nil
+}
+
+func NewManagedCatalog(registry *adapter.Registry) ManagedCatalog {
+	return &registryManagedCatalog{registry: registry}
+}
+
+type registryManagedCatalog struct {
+	registry *adapter.Registry
+}
+
+func (c *registryManagedCatalog) List() []*reinv1.Adapter {
+	if c == nil || c.registry == nil {
+		return nil
+	}
+	return c.registry.List(reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED, false)
+}
+
+func (c *registryManagedCatalog) Lookup(id string) (ManagedAdapter, bool) {
+	if c == nil || c.registry == nil {
+		return nil, false
+	}
+
+	descriptor, ok := c.registry.Get(id)
+	if !ok {
+		return nil, false
+	}
+	return &registryManagedAdapter{descriptor: descriptor}, true
+}
+
+type registryManagedAdapter struct {
+	descriptor *reinv1.Adapter
+}
+
+func (a *registryManagedAdapter) Descriptor() *reinv1.Adapter {
+	if a == nil || a.descriptor == nil {
+		return nil
+	}
+	return proto.Clone(a.descriptor).(*reinv1.Adapter)
+}
+
+func (a *registryManagedAdapter) Run(context.Context, *workflow.RuntimeState, workflow.Phase, workflow.Direction, *workflow.SideEffect) error {
+	if a == nil || a.descriptor == nil {
+		return fmt.Errorf("adapter execution is not configured")
+	}
+	return fmt.Errorf("adapter %q does not support managed execution yet", a.descriptor.GetId())
+}

--- a/internal/service/managed_test.go
+++ b/internal/service/managed_test.go
@@ -1,0 +1,262 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+func TestManagedServersListAndUpdateResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := sqlite.OpenInMemoryAndMigrate(ctx, t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	created := timestamppb.New(time.Date(2026, time.May, 1, 12, 0, 0, 0, time.UTC))
+	projectOne := &reinv1.Project{
+		Id:          "project-alpha",
+		Slug:        "alpha",
+		DisplayName: "Alpha",
+		Summary:     "First project",
+		Status:      reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE,
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+	projectTwo := &reinv1.Project{
+		Id:          "project-beta",
+		Slug:        "beta",
+		DisplayName: "Beta",
+		Summary:     "Archived project",
+		Status:      reinv1.ProjectStatus_PROJECT_STATUS_ARCHIVED,
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+	issueOne := &reinv1.Issue{
+		Id:          "RN-17",
+		ProjectId:   projectOne.GetId(),
+		Title:       "Canonical CLI",
+		Summary:     "Implement canonical command surface",
+		Status:      reinv1.IssueStatus_ISSUE_STATUS_OPEN,
+		Priority:    reinv1.IssuePriority_ISSUE_PRIORITY_HIGH,
+		WorkflowId:  "workflow-release",
+		Assignee:    "copilot",
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+	issueTwo := &reinv1.Issue{
+		Id:          "RN-18",
+		ProjectId:   projectTwo.GetId(),
+		Title:       "Other work",
+		Summary:     "Different issue",
+		Status:      reinv1.IssueStatus_ISSUE_STATUS_RESOLVED,
+		Priority:    reinv1.IssuePriority_ISSUE_PRIORITY_LOW,
+		WorkflowId:  "workflow-maintenance",
+		Assignee:    "teammate",
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+	executionOne := &reinv1.Execution{
+		Id:          "exec-RN-17-001",
+		IssueId:     issueOne.GetId(),
+		WorkflowId:  issueOne.GetWorkflowId(),
+		Status:      reinv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+		RequestedBy: "copilot",
+		CreatedTime: created,
+		StartedTime: created,
+	}
+	executionTwo := &reinv1.Execution{
+		Id:           "exec-RN-18-001",
+		IssueId:      issueTwo.GetId(),
+		WorkflowId:   issueTwo.GetWorkflowId(),
+		Status:       reinv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED,
+		RequestedBy:  "teammate",
+		CreatedTime:  created,
+		FinishedTime: created,
+	}
+	workflowOne := &reinv1.Workflow{
+		Id:          "workflow-release",
+		Name:        "Release Flow",
+		Description: "Ship the change",
+		Version:     "v1",
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+	workflowTwo := &reinv1.Workflow{
+		Id:          "workflow-maintenance",
+		Name:        "Maintenance Flow",
+		Description: "Keep the system healthy",
+		Version:     "v1",
+		CreatedTime: created,
+		UpdatedTime: created,
+	}
+
+	for _, seed := range []struct {
+		kind sqlite.EntityKind
+		id   string
+		msg  proto.Message
+	}{
+		{kind: sqlite.ProjectKind, id: projectOne.GetId(), msg: projectOne},
+		{kind: sqlite.ProjectKind, id: projectTwo.GetId(), msg: projectTwo},
+		{kind: sqlite.IssueKind, id: issueOne.GetId(), msg: issueOne},
+		{kind: sqlite.IssueKind, id: issueTwo.GetId(), msg: issueTwo},
+		{kind: sqlite.ExecutionKind, id: executionOne.GetId(), msg: executionOne},
+		{kind: sqlite.ExecutionKind, id: executionTwo.GetId(), msg: executionTwo},
+		{kind: sqlite.WorkflowKind, id: workflowOne.GetId(), msg: workflowOne},
+		{kind: sqlite.WorkflowKind, id: workflowTwo.GetId(), msg: workflowTwo},
+	} {
+		if _, err := createStoredProto(ctx, store, seed.kind, seed.id, seed.msg); err != nil {
+			t.Fatalf("createStoredProto(%s) error = %v", seed.id, err)
+		}
+	}
+
+	projectServer := &ManagedProjectServer{store: store}
+	projectList, err := projectServer.ListProjects(ctx, &reinv1.ListProjectsRequest{
+		Status: reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE,
+		Query:  "alpha",
+	})
+	if err != nil {
+		t.Fatalf("ListProjects() error = %v", err)
+	}
+	if len(projectList.GetProjects()) != 1 || projectList.GetProjects()[0].GetId() != projectOne.GetId() {
+		t.Fatalf("ListProjects() = %+v", projectList.GetProjects())
+	}
+
+	updatedProject, err := projectServer.UpdateProject(ctx, &reinv1.UpdateProjectRequest{Project: &reinv1.Project{
+		Id:          projectOne.GetId(),
+		Slug:        "alpha",
+		DisplayName: "Alpha Updated",
+		Summary:     "Updated summary",
+	}})
+	if err != nil {
+		t.Fatalf("UpdateProject() error = %v", err)
+	}
+	if updatedProject.GetProject().GetStatus() != reinv1.ProjectStatus_PROJECT_STATUS_ACTIVE {
+		t.Fatalf("UpdateProject() status = %s, want active", updatedProject.GetProject().GetStatus())
+	}
+	if updatedProject.GetProject().GetCreatedTime().AsTime() != created.AsTime() {
+		t.Fatalf("UpdateProject() created_time changed = %v", updatedProject.GetProject().GetCreatedTime())
+	}
+
+	issueServer := &ManagedIssueServer{store: store}
+	issueList, err := issueServer.ListIssues(ctx, &reinv1.ListIssuesRequest{
+		ProjectId: projectOne.GetId(),
+		Assignee:  "copilot",
+		Query:     "canonical",
+	})
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+	if len(issueList.GetIssues()) != 1 || issueList.GetIssues()[0].GetId() != issueOne.GetId() {
+		t.Fatalf("ListIssues() = %+v", issueList.GetIssues())
+	}
+
+	updatedIssue, err := issueServer.UpdateIssue(ctx, &reinv1.UpdateIssueRequest{Issue: &reinv1.Issue{
+		Id:         issueOne.GetId(),
+		ProjectId:  issueOne.GetProjectId(),
+		Title:      "Canonical CLI updated",
+		Summary:    "Updated issue summary",
+		Status:     reinv1.IssueStatus_ISSUE_STATUS_IN_PROGRESS,
+		Priority:   reinv1.IssuePriority_ISSUE_PRIORITY_HIGH,
+		WorkflowId: issueOne.GetWorkflowId(),
+		Assignee:   "copilot",
+	}})
+	if err != nil {
+		t.Fatalf("UpdateIssue() error = %v", err)
+	}
+	if updatedIssue.GetIssue().GetStatus() != reinv1.IssueStatus_ISSUE_STATUS_IN_PROGRESS {
+		t.Fatalf("UpdateIssue() status = %s, want in_progress", updatedIssue.GetIssue().GetStatus())
+	}
+	if updatedIssue.GetIssue().GetCreatedTime().AsTime() != created.AsTime() {
+		t.Fatalf("UpdateIssue() created_time changed = %v", updatedIssue.GetIssue().GetCreatedTime())
+	}
+
+	executionServer := &ManagedExecutionServer{store: store}
+	executionList, err := executionServer.ListExecutions(ctx, &reinv1.ListExecutionsRequest{
+		IssueId: issueOne.GetId(),
+		Status:  reinv1.ExecutionStatus_EXECUTION_STATUS_RUNNING,
+	})
+	if err != nil {
+		t.Fatalf("ListExecutions() error = %v", err)
+	}
+	if len(executionList.GetExecutions()) != 1 || executionList.GetExecutions()[0].GetId() != executionOne.GetId() {
+		t.Fatalf("ListExecutions() = %+v", executionList.GetExecutions())
+	}
+
+	workflowServer := &ManagedWorkflowServer{store: store}
+	workflowList, err := workflowServer.ListWorkflows(ctx, &reinv1.ListWorkflowsRequest{
+		Query: "release",
+		Page:  &reinv1.PageRequest{PageSize: 1},
+	})
+	if err != nil {
+		t.Fatalf("ListWorkflows() error = %v", err)
+	}
+	if len(workflowList.GetWorkflows()) != 1 || workflowList.GetWorkflows()[0].GetId() != workflowOne.GetId() {
+		t.Fatalf("ListWorkflows() = %+v", workflowList.GetWorkflows())
+	}
+}
+
+func TestManagedAdapterServerListFilters(t *testing.T) {
+	t.Parallel()
+
+	server := &ManagedAdapterServer{catalog: managedTestCatalog{
+		adapters: map[string]ManagedAdapter{
+			"coding": managedTestAdapter{descriptor: &reinv1.Adapter{Id: "coding", Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT, Enabled: true}},
+			"review": managedTestAdapter{descriptor: &reinv1.Adapter{Id: "review", Category: reinv1.AdapterCategory_ADAPTER_CATEGORY_REVIEW_AGENT, Enabled: false}},
+		},
+	}}
+
+	resp, err := server.ListAdapters(context.Background(), &reinv1.ListAdaptersRequest{
+		Category:    reinv1.AdapterCategory_ADAPTER_CATEGORY_CODING_AGENT,
+		EnabledOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("ListAdapters() error = %v", err)
+	}
+	if len(resp.GetAdapters()) != 1 || resp.GetAdapters()[0].GetId() != "coding" {
+		t.Fatalf("ListAdapters() = %+v", resp.GetAdapters())
+	}
+}
+
+type managedTestCatalog struct {
+	adapters map[string]ManagedAdapter
+}
+
+func (c managedTestCatalog) List() []*reinv1.Adapter {
+	list := make([]*reinv1.Adapter, 0, len(c.adapters))
+	for _, adapter := range c.adapters {
+		list = append(list, adapter.Descriptor())
+	}
+	return list
+}
+
+func (c managedTestCatalog) Lookup(id string) (ManagedAdapter, bool) {
+	adapter, ok := c.adapters[id]
+	return adapter, ok
+}
+
+type managedTestAdapter struct {
+	descriptor *reinv1.Adapter
+}
+
+func (a managedTestAdapter) Descriptor() *reinv1.Adapter {
+	return a.descriptor
+}
+
+func (managedTestAdapter) Run(context.Context, *workflow.RuntimeState, workflow.Phase, workflow.Direction, *workflow.SideEffect) error {
+	return nil
+}

--- a/proto/comments.go
+++ b/proto/comments.go
@@ -1,0 +1,110 @@
+package protofiles
+
+import (
+	"bufio"
+	"embed"
+	"io/fs"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+//go:embed rein/v1/*.proto
+var files embed.FS
+
+var (
+	loadComments sync.Once
+	comments     map[string]string
+
+	servicePattern = regexp.MustCompile(`^service\s+([A-Za-z0-9_]+)\s*\{`)
+	messagePattern = regexp.MustCompile(`^(message|enum)\s+([A-Za-z0-9_]+)\s*\{`)
+	rpcPattern     = regexp.MustCompile(`^rpc\s+([A-Za-z0-9_]+)\s*\(`)
+	fieldPattern   = regexp.MustCompile(`^(?:repeated\s+)?(?:map<[^>]+>\s+|[A-Za-z0-9_.]+\s+)([A-Za-z0-9_]+)\s*=\s*\d+`)
+)
+
+type block struct {
+	kind string
+	name string
+}
+
+func Comment(fullName string) string {
+	loadComments.Do(func() {
+		comments = map[string]string{}
+		entries, err := fs.Glob(files, "rein/v1/*.proto")
+		if err != nil {
+			return
+		}
+		for _, name := range entries {
+			loadFileComments(name)
+		}
+	})
+	return comments[fullName]
+}
+
+func loadFileComments(name string) {
+	data, err := files.ReadFile(name)
+	if err != nil {
+		return
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	var (
+		stack   []block
+		pending []string
+	)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "//"):
+			pending = append(pending, strings.TrimSpace(strings.TrimPrefix(line, "//")))
+			continue
+		case line == "":
+			pending = nil
+			continue
+		}
+
+		if matches := servicePattern.FindStringSubmatch(line); len(matches) == 2 {
+			fullName := "rein.v1." + matches[1]
+			storeComment(fullName, pending)
+			stack = append(stack, block{kind: "service", name: fullName})
+			pending = nil
+			continue
+		}
+		if matches := messagePattern.FindStringSubmatch(line); len(matches) == 3 {
+			parent := "rein.v1"
+			if len(stack) > 0 && stack[len(stack)-1].kind == "message" {
+				parent = stack[len(stack)-1].name
+			}
+			fullName := parent + "." + matches[2]
+			stack = append(stack, block{kind: matches[1], name: fullName})
+			pending = nil
+			continue
+		}
+		if len(stack) > 0 && stack[len(stack)-1].kind == "service" {
+			if matches := rpcPattern.FindStringSubmatch(line); len(matches) == 2 {
+				storeComment(stack[len(stack)-1].name+"."+matches[1], pending)
+				pending = nil
+				continue
+			}
+		}
+		if len(stack) > 0 && stack[len(stack)-1].kind == "message" {
+			if matches := fieldPattern.FindStringSubmatch(line); len(matches) == 2 {
+				storeComment(stack[len(stack)-1].name+"."+matches[1], pending)
+			}
+		}
+		if strings.Contains(line, "}") {
+			closeCount := strings.Count(line, "}")
+			for i := 0; i < closeCount && len(stack) > 0; i++ {
+				stack = stack[:len(stack)-1]
+			}
+		}
+		pending = nil
+	}
+}
+
+func storeComment(fullName string, lines []string) {
+	if len(lines) == 0 {
+		return
+	}
+	comments[fullName] = strings.TrimSpace(strings.Join(lines, " "))
+}

--- a/proto/rein/v1/adapter.proto
+++ b/proto/rein/v1/adapter.proto
@@ -6,15 +6,22 @@ option go_package = "github.com/earchibald/rein/gen/go/rein/v1;reinv1";
 
 import "rein/v1/types.proto";
 
+// AdapterService manages adapters available to the daemon.
 service AdapterService {
+  // List adapters available to the daemon.
   rpc ListAdapters(ListAdaptersRequest) returns (ListAdaptersResponse);
+  // Get a single adapter by id.
   rpc GetAdapter(GetAdapterRequest) returns (GetAdapterResponse);
+  // Validate an adapter payload without storing it.
   rpc ValidateAdapter(ValidateAdapterRequest) returns (ValidateAdapterResponse);
 }
 
 message ListAdaptersRequest {
+  // Paginate adapter results. Pass JSON matching PageRequest.
   PageRequest page = 1;
+  // Filter adapters by category.
   AdapterCategory category = 2;
+  // Exclude disabled adapters when true.
   bool enabled_only = 3;
 }
 
@@ -24,6 +31,7 @@ message ListAdaptersResponse {
 }
 
 message GetAdapterRequest {
+  // Adapter identifier.
   string id = 1;
 }
 
@@ -32,6 +40,7 @@ message GetAdapterResponse {
 }
 
 message ValidateAdapterRequest {
+  // Adapter payload. Pass JSON matching Adapter.
   Adapter adapter = 1;
 }
 

--- a/proto/rein/v1/execution.proto
+++ b/proto/rein/v1/execution.proto
@@ -6,16 +6,24 @@ option go_package = "github.com/earchibald/rein/gen/go/rein/v1;reinv1";
 
 import "rein/v1/types.proto";
 
+// ExecutionService manages workflow executions stored by the daemon.
 service ExecutionService {
+  // List executions stored in the daemon.
   rpc ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse);
+  // Get a single execution by id.
   rpc GetExecution(GetExecutionRequest) returns (GetExecutionResponse);
+  // Start a workflow execution for an issue.
   rpc StartExecution(StartExecutionRequest) returns (StartExecutionResponse);
+  // Cancel a running execution.
   rpc CancelExecution(CancelExecutionRequest) returns (CancelExecutionResponse);
 }
 
 message ListExecutionsRequest {
+  // Paginate execution results. Pass JSON matching PageRequest.
   PageRequest page = 1;
+  // Filter executions by issue id.
   string issue_id = 2;
+  // Filter executions by status.
   ExecutionStatus status = 3;
 }
 
@@ -25,6 +33,7 @@ message ListExecutionsResponse {
 }
 
 message GetExecutionRequest {
+  // Execution identifier.
   string id = 1;
 }
 
@@ -33,9 +42,13 @@ message GetExecutionResponse {
 }
 
 message StartExecutionRequest {
+  // Issue identifier.
   string issue_id = 1;
+  // Workflow identifier.
   string workflow_id = 2;
+  // Actor requesting the execution.
   string requested_by = 3;
+  // Execution input values. Pass a JSON object.
   map<string, string> inputs = 4;
 }
 
@@ -44,7 +57,9 @@ message StartExecutionResponse {
 }
 
 message CancelExecutionRequest {
+  // Execution identifier.
   string id = 1;
+  // Human-readable cancellation reason.
   string reason = 2;
 }
 

--- a/proto/rein/v1/issue.proto
+++ b/proto/rein/v1/issue.proto
@@ -6,18 +6,28 @@ option go_package = "github.com/earchibald/rein/gen/go/rein/v1;reinv1";
 
 import "rein/v1/types.proto";
 
+// IssueService manages issues stored by the daemon.
 service IssueService {
+  // List issues stored in the daemon.
   rpc ListIssues(ListIssuesRequest) returns (ListIssuesResponse);
+  // Get a single issue by id.
   rpc GetIssue(GetIssueRequest) returns (GetIssueResponse);
+  // Create an issue record.
   rpc CreateIssue(CreateIssueRequest) returns (CreateIssueResponse);
+  // Update an issue record.
   rpc UpdateIssue(UpdateIssueRequest) returns (UpdateIssueResponse);
 }
 
 message ListIssuesRequest {
+  // Paginate issue results. Pass JSON matching PageRequest.
   PageRequest page = 1;
+  // Filter issues by project id.
   string project_id = 2;
+  // Filter issues by status.
   IssueStatus status = 3;
+  // Filter issues by assignee.
   string assignee = 4;
+  // Match issue id, title, summary, workflow id, or assignee.
   string query = 5;
 }
 
@@ -27,6 +37,7 @@ message ListIssuesResponse {
 }
 
 message GetIssueRequest {
+  // Issue identifier.
   string id = 1;
 }
 
@@ -35,6 +46,7 @@ message GetIssueResponse {
 }
 
 message CreateIssueRequest {
+  // Issue payload. Pass JSON matching Issue.
   Issue issue = 1;
 }
 
@@ -43,6 +55,7 @@ message CreateIssueResponse {
 }
 
 message UpdateIssueRequest {
+  // Replacement issue payload. Pass JSON matching Issue.
   Issue issue = 1;
 }
 

--- a/proto/rein/v1/project.proto
+++ b/proto/rein/v1/project.proto
@@ -6,16 +6,24 @@ option go_package = "github.com/earchibald/rein/gen/go/rein/v1;reinv1";
 
 import "rein/v1/types.proto";
 
+// ProjectService manages projects stored by the daemon.
 service ProjectService {
+  // List projects stored in the daemon.
   rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse);
+  // Get a single project by id.
   rpc GetProject(GetProjectRequest) returns (GetProjectResponse);
+  // Create a project record.
   rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse);
+  // Update a project record.
   rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse);
 }
 
 message ListProjectsRequest {
+  // Paginate project results. Pass JSON matching PageRequest.
   PageRequest page = 1;
+  // Filter projects by status.
   ProjectStatus status = 2;
+  // Match project id, slug, display name, or summary.
   string query = 3;
 }
 
@@ -25,6 +33,7 @@ message ListProjectsResponse {
 }
 
 message GetProjectRequest {
+  // Project identifier.
   string id = 1;
 }
 
@@ -33,6 +42,7 @@ message GetProjectResponse {
 }
 
 message CreateProjectRequest {
+  // Project payload. Pass JSON matching Project.
   Project project = 1;
 }
 
@@ -41,6 +51,7 @@ message CreateProjectResponse {
 }
 
 message UpdateProjectRequest {
+  // Replacement project payload. Pass JSON matching Project.
   Project project = 1;
 }
 

--- a/proto/rein/v1/workflow.proto
+++ b/proto/rein/v1/workflow.proto
@@ -6,14 +6,20 @@ option go_package = "github.com/earchibald/rein/gen/go/rein/v1;reinv1";
 
 import "rein/v1/types.proto";
 
+// WorkflowService manages workflows stored by the daemon.
 service WorkflowService {
+  // List workflows stored in the daemon.
   rpc ListWorkflows(ListWorkflowsRequest) returns (ListWorkflowsResponse);
+  // Get a single workflow by id.
   rpc GetWorkflow(GetWorkflowRequest) returns (GetWorkflowResponse);
+  // Validate a workflow payload without storing it.
   rpc ValidateWorkflow(ValidateWorkflowRequest) returns (ValidateWorkflowResponse);
 }
 
 message ListWorkflowsRequest {
+  // Paginate workflow results. Pass JSON matching PageRequest.
   PageRequest page = 1;
+  // Match workflow id, name, description, or version.
   string query = 2;
 }
 
@@ -23,6 +29,7 @@ message ListWorkflowsResponse {
 }
 
 message GetWorkflowRequest {
+  // Workflow identifier.
   string id = 1;
 }
 
@@ -31,6 +38,7 @@ message GetWorkflowResponse {
 }
 
 message ValidateWorkflowRequest {
+  // Workflow payload. Pass JSON matching Workflow.
   Workflow workflow = 1;
 }
 


### PR DESCRIPTION
## Summary
- turn `rein` into the canonical descriptor-driven gRPC client CLI and move daemon startup to `rein daemon serve`
- back the daemon with managed services for the CLI surface, including list/update RPC coverage and registry-backed adapter catalog wiring
- add proto comments, CLI/help tests, managed service tests, and updated contract expectations

## Testing
- just proto
- go test ./cmd/rein ./internal/service ./internal/server
- just ci
- manual CLI smoke test against `rein daemon serve` with worktree-local XDG_STATE_HOME