### PR TITLE
RN-20: add describe-as surface outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - `rein` is the canonical gRPC client CLI. By default it connects to the selected instance over that instance's unix socket.
 - Use `rein daemon serve` to start the daemon for the selected instance.
 - Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics.
+- Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface and reachable protobuf schemas.
+- Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.
 - Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
 - Request flags map 1:1 to top-level gRPC request fields. Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
 - Responses are emitted as JSON using protobuf field names.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 
 	"github.com/earchibald/rein/internal/adapter"
-	"github.com/earchibald/rein/internal/instance"
 	"github.com/earchibald/rein/internal/server"
 	"github.com/earchibald/rein/internal/service"
 	"github.com/earchibald/rein/internal/storage/sqlite"
@@ -91,7 +90,12 @@ func (a *app) run(args []string) error {
 		return a.runDaemon(root, remaining[1:])
 	case "doctor":
 		return a.runDoctor(root, remaining[1:])
+	case "describe-as":
+		return a.runDescribe(remaining)
 	default:
+		if strings.HasPrefix(remaining[0], "describe-as=") {
+			return a.runDescribe(remaining)
+		}
 		return a.runRPC(root, remaining)
 	}
 }
@@ -110,6 +114,24 @@ func (a *app) runDaemon(root rootConfig, args []string) error {
 		return err
 	}
 	return a.serveDaemon(serveConfig)
+}
+
+func (a *app) runDescribe(args []string) error {
+	format, showHelp, err := parseDescribeArgs(args)
+	if err != nil {
+		return err
+	}
+	if showHelp {
+		a.printDescribeHelp()
+		return flag.ErrHelp
+	}
+
+	output, err := renderDescribeAs(format)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(a.stdout, output)
+	return err
 }
 
 func (a *app) serveDaemon(config daemonServeConfig) error {
@@ -415,13 +437,12 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr, "  rein [global flags] <service> <verb> [flags]")
 	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
 	fmt.Fprintln(a.stderr, "  rein [global flags] doctor")
+	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as=<format>")
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Global flags:")
-	fmt.Fprintf(a.stderr, "  --instance string\n    Select the daemon instance (default %q or %s)\n", instance.DefaultName, instance.EnvVar)
-	fmt.Fprintln(a.stderr, "  --grpc-network string")
-	fmt.Fprintln(a.stderr, "    Override the daemon network for client connections.")
-	fmt.Fprintln(a.stderr, "  --grpc-address string")
-	fmt.Fprintln(a.stderr, "    Override the daemon address for client connections.")
+	for _, flag := range globalFlagDescriptions() {
+		fmt.Fprintf(a.stderr, "  --%s %s\n    %s\n", flag.Name, flag.Type, flag.Description)
+	}
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Commands:")
 
@@ -445,6 +466,7 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "  daemon serve\tStart the daemon and expose the canonical gRPC surface.")
 	fmt.Fprintln(a.stderr, "  doctor\tEmit JSON diagnostics for daemon health and local instance readiness.")
+	fmt.Fprintln(a.stderr, "  describe-as=<format>\tEmit a stable machine-consumable surface description.")
 }
 
 func (a *app) printDaemonHelp() {
@@ -452,10 +474,20 @@ func (a *app) printDaemonHelp() {
 	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Flags:")
-	fmt.Fprintf(a.stderr, "  --grpc-network string\n    Listener network: tcp or unix (default %q)\n", server.DefaultListenerNetwork())
-	fmt.Fprintln(a.stderr, "  --grpc-address string")
-	fmt.Fprintln(a.stderr, "    Listener address or unix socket path.")
-	fmt.Fprintf(a.stderr, "  --grpc-require-peer-credentials bool\n    Require SO_PEERCRED same-UID authentication for unix sockets (default %t)\n", server.DefaultListenerConfig().RequirePeerCredentials)
+	for _, flag := range daemonServeFlagDescriptions() {
+		fmt.Fprintf(a.stderr, "  --%s %s\n    %s\n", flag.Name, flag.Type, flag.Description)
+	}
+}
+
+func (a *app) printDescribeHelp() {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as=<format>")
+	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as <format>")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Formats:")
+	for _, format := range supportedDescribeFormats() {
+		fmt.Fprintf(a.stderr, "  %s\n    %s\n", format.Name, format.Description)
+	}
 }
 
 func (a *app) printDoctorHelp() {
@@ -492,7 +524,7 @@ func fieldUsage(field protoreflect.FieldDescriptor) string {
 	if comment == "" {
 		comment = fmt.Sprintf("Set request field %s.", field.Name())
 	}
-	if field.IsList() || field.IsMap() || field.Kind() == protoreflect.MessageKind {
+	if (field.IsList() || field.IsMap() || field.Kind() == protoreflect.MessageKind) && !strings.Contains(strings.ToLower(comment), "json") {
 		return comment + " Pass JSON."
 	}
 	return comment
@@ -533,6 +565,38 @@ func cleanComment(value string) string {
 
 func isHelpToken(value string) bool {
 	return value == "-h" || value == "--help" || value == "help"
+}
+
+func parseDescribeArgs(args []string) (format string, showHelp bool, err error) {
+	if len(args) == 0 {
+		return "", false, fmt.Errorf("describe-as format is required")
+	}
+	if strings.HasPrefix(args[0], "describe-as=") {
+		format = strings.TrimPrefix(args[0], "describe-as=")
+		if format == "" {
+			return "", false, fmt.Errorf("describe-as format is required")
+		}
+		if len(args) == 1 {
+			return format, false, nil
+		}
+		if len(args) == 2 && isHelpToken(args[1]) {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("unexpected arguments: %v", args[1:])
+	}
+	if args[0] != "describe-as" {
+		return "", false, fmt.Errorf("unknown describe command %q", args[0])
+	}
+	if len(args) == 1 {
+		return "", true, nil
+	}
+	if isHelpToken(args[1]) {
+		return "", true, nil
+	}
+	if len(args) != 2 {
+		return "", false, fmt.Errorf("unexpected arguments: %v", args[2:])
+	}
+	return args[1], false, nil
 }
 
 func sliceMin(a, b int) int {

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -190,7 +190,7 @@ func TestAppCommandHelpUsesProtoComments(t *testing.T) {
 	}
 }
 
-func TestRootHelpListsDoctorCommand(t *testing.T) {
+func TestRootHelpListsDoctorAndDescribeCommands(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -204,8 +204,118 @@ func TestRootHelpListsDoctorCommand(t *testing.T) {
 	if err != flag.ErrHelp {
 		t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
 	}
-
-	if got := stderr.String(); !strings.Contains(got, "doctor\tEmit JSON diagnostics") {
-		t.Fatalf("root help missing doctor command:\n%s", got)
+	output := stderr.String()
+	for _, want := range []string{
+		"doctor\tEmit JSON diagnostics",
+		"rein [global flags] describe-as=<format>",
+		"describe-as=<format>\tEmit a stable machine-consumable surface description.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q\n%s", want, output)
+		}
 	}
+}
+
+func TestAppDescribeCLIOutput(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	if err := app.run([]string{"describe-as=cli"}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"REIN SURFACE v1",
+		"COMMAND project list",
+		"full_method: /rein.v1.ProjectService/ListProjects",
+		"schema: rein.v1.PageRequest",
+		"GATEWAY STUB",
+		"MESSAGE rein.v1.ListProjectsRequest",
+		"ENUM rein.v1.ProjectStatus",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("describe-as=cli output missing %q\n%s", want, output)
+		}
+	}
+}
+
+func TestAppDescribeMCPOutput(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	if err := app.run([]string{"describe-as=mcp"}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"surface: \"rein\"",
+		"- name: \"project_list\"",
+		"full_method: \"/rein.v1.ProjectService/ListProjects\"",
+		"path: \"/v2/projects\"",
+		"- name: \"rein.v1.ListProjectsRequest\"",
+		"- name: \"rein.v1.ProjectStatus\"",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("describe-as=mcp output missing %q\n%s", want, output)
+		}
+	}
+}
+
+func TestAppDescribeHelpAndInvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("help", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+			return "/Users/tester", nil
+		}, func() (string, error) {
+			return "/repo", nil
+		})
+
+		err := app.run([]string{"describe-as", "--help"})
+		if err != flag.ErrHelp {
+			t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+		}
+		output := stderr.String()
+		for _, want := range []string{"Formats:", "cli", "mcp"} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("describe help missing %q\n%s", want, output)
+			}
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+			return "/Users/tester", nil
+		}, func() (string, error) {
+			return "/repo", nil
+		})
+
+		err := app.run([]string{"describe-as=bogus"})
+		if err == nil {
+			t.Fatal("run() error = nil, want non-nil")
+		}
+		if !strings.Contains(err.Error(), "supported: cli, mcp") {
+			t.Fatalf("run() error = %v, want supported formats", err)
+		}
+	})
 }

--- a/cmd/rein/describe.go
+++ b/cmd/rein/describe.go
@@ -218,6 +218,8 @@ func describeField(field protoreflect.FieldDescriptor) fieldDescription {
 			schemaRef = string(field.Message().FullName())
 		case protoreflect.EnumKind:
 			schemaRef = string(field.Enum().FullName())
+		default:
+			// Scalar fields do not reference nested schemas.
 		}
 	}
 

--- a/cmd/rein/describe.go
+++ b/cmd/rein/describe.go
@@ -1,0 +1,707 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/earchibald/rein/internal/gateway"
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/server"
+)
+
+const (
+	describeFormatCLI = "cli"
+	describeFormatMCP = "mcp"
+)
+
+type describeSurface struct {
+	Title       string
+	Summary     string
+	Conventions []string
+	Usage       []string
+	Formats     []describeFormatDescription
+	GlobalFlags []staticFlagDescription
+	Commands    []commandDescription
+	Daemon      daemonCommandDescription
+	Gateway     gatewayDescription
+	Messages    []messageSchemaDescription
+	Enums       []enumSchemaDescription
+}
+
+type describeFormatDescription struct {
+	Name        string
+	Description string
+}
+
+type staticFlagDescription struct {
+	Name        string
+	Type        string
+	Description string
+}
+
+type daemonCommandDescription struct {
+	Name    string
+	CLI     string
+	Summary string
+	Flags   []staticFlagDescription
+}
+
+type commandDescription struct {
+	Name           string
+	CLI            string
+	Noun           string
+	Verb           string
+	Service        string
+	ServiceSummary string
+	Method         string
+	Summary        string
+	FullMethod     string
+	RequestType    string
+	ResponseType   string
+	Flags          []fieldDescription
+}
+
+type fieldDescription struct {
+	Name        string
+	Type        string
+	ProtoType   string
+	SchemaRef   string
+	Description string
+	AcceptsJSON bool
+	Repeated    bool
+	Map         bool
+	EnumValues  []enumValueDescription
+}
+
+type gatewayDescription struct {
+	Routes  []gateway.Route
+	Streams []gateway.Stream
+}
+
+type messageSchemaDescription struct {
+	Name        string
+	Description string
+	Fields      []fieldDescription
+}
+
+type enumSchemaDescription struct {
+	Name        string
+	Description string
+	Values      []enumValueDescription
+}
+
+type enumValueDescription struct {
+	Name        string
+	Number      int32
+	Description string
+}
+
+func supportedDescribeFormats() []describeFormatDescription {
+	return []describeFormatDescription{
+		{Name: describeFormatCLI, Description: "Manual-style description of the descriptor-driven CLI, daemon command, and reachable protobuf schemas."},
+		{Name: describeFormatMCP, Description: "YAML reference for wrapper and skill tooling, including CLI commands, gateway stub routes, and protobuf schemas."},
+	}
+}
+
+func rootUsageLines() []string {
+	return []string{
+		"rein [global flags] <service> <verb> [flags]",
+		"rein [global flags] daemon serve [flags]",
+		"rein [global flags] describe-as=<format>",
+	}
+}
+
+func rootConventions() []string {
+	return []string{
+		"Request flags map 1:1 to top-level gRPC request fields.",
+		"Scalar fields take plain values; message, repeated, and map fields take JSON blobs.",
+		"Responses are emitted as JSON using protobuf field names.",
+	}
+}
+
+func globalFlagDescriptions() []staticFlagDescription {
+	return []staticFlagDescription{
+		{Name: "instance", Type: "string", Description: fmt.Sprintf("Select the daemon instance (default %q or %s).", instance.DefaultName, instance.EnvVar)},
+		{Name: "grpc-network", Type: "string", Description: "Override the daemon network for client connections."},
+		{Name: "grpc-address", Type: "string", Description: "Override the daemon address for client connections."},
+	}
+}
+
+func daemonServeFlagDescriptions() []staticFlagDescription {
+	defaults := server.DefaultListenerConfig()
+	return []staticFlagDescription{
+		{Name: "grpc-network", Type: "string", Description: fmt.Sprintf("Listener network: tcp or unix (default %q).", defaults.Network)},
+		{Name: "grpc-address", Type: "string", Description: "Listener address or unix socket path."},
+		{Name: "grpc-require-peer-credentials", Type: "bool", Description: fmt.Sprintf("Require SO_PEERCRED same-UID authentication for unix sockets (default %t).", defaults.RequirePeerCredentials)},
+	}
+}
+
+func buildDescribeSurface() (describeSurface, error) {
+	commandsByKey, err := loadRPCCommands()
+	if err != nil {
+		return describeSurface{}, err
+	}
+
+	collector := newSchemaCollector()
+	commands := make([]commandDescription, 0, len(commandsByKey))
+	for _, command := range commandsByKey {
+		commands = append(commands, describeCommand(command))
+		collector.addMessage(command.input)
+		collector.addMessage(command.output)
+	}
+	sort.Slice(commands, func(i, j int) bool {
+		if commands[i].Noun != commands[j].Noun {
+			return commands[i].Noun < commands[j].Noun
+		}
+		return commands[i].Verb < commands[j].Verb
+	})
+
+	gatewayStub := gateway.NewV2Stub()
+	return describeSurface{
+		Title:       "rein",
+		Summary:     "Descriptor-driven reference for the rein CLI, gRPC services, and v2 gateway stub.",
+		Conventions: rootConventions(),
+		Usage:       rootUsageLines(),
+		Formats:     supportedDescribeFormats(),
+		GlobalFlags: globalFlagDescriptions(),
+		Commands:    commands,
+		Daemon: daemonCommandDescription{
+			Name:    "daemon_serve",
+			CLI:     "rein [global flags] daemon serve [flags]",
+			Summary: "Start the daemon and expose the canonical gRPC surface.",
+			Flags:   daemonServeFlagDescriptions(),
+		},
+		Gateway:  gatewayDescription{Routes: gatewayStub.Routes(), Streams: gatewayStub.Streams()},
+		Messages: collector.messageSchemas(),
+		Enums:    collector.enumSchemas(),
+	}, nil
+}
+
+func describeCommand(command rpcCommand) commandDescription {
+	flags := make([]fieldDescription, 0, command.input.Fields().Len())
+	for i := 0; i < command.input.Fields().Len(); i++ {
+		flags = append(flags, describeField(command.input.Fields().Get(i)))
+	}
+	return commandDescription{
+		Name:           command.noun + "_" + command.verb,
+		CLI:            fmt.Sprintf("rein [global flags] %s %s [flags]", command.noun, command.verb),
+		Noun:           command.noun,
+		Verb:           command.verb,
+		Service:        string(command.service.FullName()),
+		ServiceSummary: cleanComment(commentText(command.service)),
+		Method:         string(command.method.Name()),
+		Summary:        cleanComment(commentText(command.method)),
+		FullMethod:     command.fullMethod,
+		RequestType:    string(command.input.FullName()),
+		ResponseType:   string(command.output.FullName()),
+		Flags:          flags,
+	}
+}
+
+func describeField(field protoreflect.FieldDescriptor) fieldDescription {
+	description := fieldUsage(field)
+	schemaRef := ""
+	if field.IsMap() {
+		if field.MapValue().Kind() == protoreflect.MessageKind {
+			schemaRef = string(field.MapValue().Message().FullName())
+		} else if field.MapValue().Kind() == protoreflect.EnumKind {
+			schemaRef = string(field.MapValue().Enum().FullName())
+		}
+	} else {
+		switch field.Kind() {
+		case protoreflect.MessageKind:
+			schemaRef = string(field.Message().FullName())
+		case protoreflect.EnumKind:
+			schemaRef = string(field.Enum().FullName())
+		}
+	}
+
+	var enumValues []enumValueDescription
+	if field.IsMap() {
+		if field.MapValue().Kind() == protoreflect.EnumKind {
+			enumValues = describeEnumValues(field.MapValue().Enum())
+		}
+	} else if field.Kind() == protoreflect.EnumKind {
+		enumValues = describeEnumValues(field.Enum())
+	}
+
+	return fieldDescription{
+		Name:        string(field.Name()),
+		Type:        fieldTypeLabel(field),
+		ProtoType:   protoTypeLabel(field),
+		SchemaRef:   schemaRef,
+		Description: description,
+		AcceptsJSON: field.IsList() || field.IsMap() || field.Kind() == protoreflect.MessageKind,
+		Repeated:    field.IsList(),
+		Map:         field.IsMap(),
+		EnumValues:  enumValues,
+	}
+}
+
+func protoTypeLabel(field protoreflect.FieldDescriptor) string {
+	if field.IsMap() {
+		return fmt.Sprintf("map<%s, %s>", scalarKindLabel(field.MapKey().Kind()), nestedFieldBaseType(field.MapValue()))
+	}
+	base := nestedFieldBaseType(field)
+	if field.IsList() {
+		return "repeated " + base
+	}
+	return base
+}
+
+func nestedFieldBaseType(field protoreflect.FieldDescriptor) string {
+	switch field.Kind() {
+	case protoreflect.MessageKind:
+		return string(field.Message().FullName())
+	case protoreflect.EnumKind:
+		return string(field.Enum().FullName())
+	default:
+		return scalarKindLabel(field.Kind())
+	}
+}
+
+func scalarKindLabel(kind protoreflect.Kind) string {
+	switch kind {
+	case protoreflect.BoolKind:
+		return "bool"
+	case protoreflect.StringKind:
+		return "string"
+	case protoreflect.BytesKind:
+		return "bytes"
+	case protoreflect.Int32Kind:
+		return "int32"
+	case protoreflect.Sint32Kind:
+		return "sint32"
+	case protoreflect.Sfixed32Kind:
+		return "sfixed32"
+	case protoreflect.Int64Kind:
+		return "int64"
+	case protoreflect.Sint64Kind:
+		return "sint64"
+	case protoreflect.Sfixed64Kind:
+		return "sfixed64"
+	case protoreflect.Uint32Kind:
+		return "uint32"
+	case protoreflect.Fixed32Kind:
+		return "fixed32"
+	case protoreflect.Uint64Kind:
+		return "uint64"
+	case protoreflect.Fixed64Kind:
+		return "fixed64"
+	case protoreflect.FloatKind:
+		return "float"
+	case protoreflect.DoubleKind:
+		return "double"
+	default:
+		return strings.ToLower(kind.String())
+	}
+}
+
+func describeEnumValues(enum protoreflect.EnumDescriptor) []enumValueDescription {
+	values := make([]enumValueDescription, 0, enum.Values().Len())
+	for i := 0; i < enum.Values().Len(); i++ {
+		value := enum.Values().Get(i)
+		values = append(values, enumValueDescription{
+			Name:        string(value.Name()),
+			Number:      int32(value.Number()),
+			Description: cleanComment(commentText(value)),
+		})
+	}
+	return values
+}
+
+type schemaCollector struct {
+	messages map[protoreflect.FullName]protoreflect.MessageDescriptor
+	enums    map[protoreflect.FullName]protoreflect.EnumDescriptor
+}
+
+func newSchemaCollector() *schemaCollector {
+	return &schemaCollector{
+		messages: map[protoreflect.FullName]protoreflect.MessageDescriptor{},
+		enums:    map[protoreflect.FullName]protoreflect.EnumDescriptor{},
+	}
+}
+
+func (c *schemaCollector) addMessage(message protoreflect.MessageDescriptor) {
+	if message == nil || !strings.HasPrefix(string(message.FullName()), "rein.v1.") {
+		return
+	}
+	if _, exists := c.messages[message.FullName()]; exists {
+		return
+	}
+	c.messages[message.FullName()] = message
+	for i := 0; i < message.Fields().Len(); i++ {
+		field := message.Fields().Get(i)
+		if field.IsMap() {
+			if field.MapValue().Kind() == protoreflect.MessageKind {
+				c.addMessage(field.MapValue().Message())
+			}
+			if field.MapValue().Kind() == protoreflect.EnumKind {
+				c.addEnum(field.MapValue().Enum())
+			}
+			continue
+		}
+		if field.Kind() == protoreflect.MessageKind {
+			c.addMessage(field.Message())
+		}
+		if field.Kind() == protoreflect.EnumKind {
+			c.addEnum(field.Enum())
+		}
+	}
+}
+
+func (c *schemaCollector) addEnum(enum protoreflect.EnumDescriptor) {
+	if enum == nil || !strings.HasPrefix(string(enum.FullName()), "rein.v1.") {
+		return
+	}
+	if _, exists := c.enums[enum.FullName()]; exists {
+		return
+	}
+	c.enums[enum.FullName()] = enum
+}
+
+func (c *schemaCollector) messageSchemas() []messageSchemaDescription {
+	names := make([]string, 0, len(c.messages))
+	for name := range c.messages {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+
+	messages := make([]messageSchemaDescription, 0, len(names))
+	for _, name := range names {
+		message := c.messages[protoreflect.FullName(name)]
+		fields := make([]fieldDescription, 0, message.Fields().Len())
+		for i := 0; i < message.Fields().Len(); i++ {
+			fields = append(fields, describeField(message.Fields().Get(i)))
+		}
+		messages = append(messages, messageSchemaDescription{
+			Name:        name,
+			Description: cleanComment(commentText(message)),
+			Fields:      fields,
+		})
+	}
+	return messages
+}
+
+func (c *schemaCollector) enumSchemas() []enumSchemaDescription {
+	names := make([]string, 0, len(c.enums))
+	for name := range c.enums {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+
+	enums := make([]enumSchemaDescription, 0, len(names))
+	for _, name := range names {
+		enum := c.enums[protoreflect.FullName(name)]
+		enums = append(enums, enumSchemaDescription{
+			Name:        name,
+			Description: cleanComment(commentText(enum)),
+			Values:      describeEnumValues(enum),
+		})
+	}
+	return enums
+}
+
+func renderDescribeAs(format string) (string, error) {
+	surface, err := buildDescribeSurface()
+	if err != nil {
+		return "", err
+	}
+	switch format {
+	case describeFormatCLI:
+		return renderDescribeCLI(surface), nil
+	case describeFormatMCP:
+		return renderDescribeMCP(surface), nil
+	default:
+		return "", fmt.Errorf("unsupported describe-as format %q (supported: %s)", format, supportedDescribeFormatNames())
+	}
+}
+
+func supportedDescribeFormatNames() string {
+	names := make([]string, 0, len(supportedDescribeFormats()))
+	for _, format := range supportedDescribeFormats() {
+		names = append(names, format.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func renderDescribeCLI(surface describeSurface) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s SURFACE v1\n\n", strings.ToUpper(surface.Title))
+	fmt.Fprintln(&buf, "NAME")
+	fmt.Fprintf(&buf, "  %s\n", surface.Title)
+	fmt.Fprintf(&buf, "    %s\n\n", surface.Summary)
+
+	fmt.Fprintln(&buf, "USAGE")
+	for _, line := range surface.Usage {
+		fmt.Fprintf(&buf, "  %s\n", line)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "CONVENTIONS")
+	for _, line := range surface.Conventions {
+		fmt.Fprintf(&buf, "  - %s\n", line)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "GLOBAL FLAGS")
+	for _, flag := range surface.GlobalFlags {
+		fmt.Fprintf(&buf, "  --%s %s\n", flag.Name, flag.Type)
+		fmt.Fprintf(&buf, "    %s\n", flag.Description)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "DESCRIBE FORMATS")
+	for _, format := range surface.Formats {
+		fmt.Fprintf(&buf, "  %s\n", format.Name)
+		fmt.Fprintf(&buf, "    %s\n", format.Description)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "COMMAND GROUPS")
+	currentNoun := ""
+	for _, command := range surface.Commands {
+		if command.Noun != currentNoun {
+			currentNoun = command.Noun
+			fmt.Fprintf(&buf, "  %s\n", currentNoun)
+			if command.ServiceSummary != "" {
+				fmt.Fprintf(&buf, "    %s\n", command.ServiceSummary)
+			}
+			buf.WriteString("\n")
+		}
+		fmt.Fprintf(&buf, "    COMMAND %s %s\n", command.Noun, command.Verb)
+		fmt.Fprintf(&buf, "      summary: %s\n", command.Summary)
+		fmt.Fprintf(&buf, "      grpc_service: %s\n", command.Service)
+		fmt.Fprintf(&buf, "      grpc_method: %s\n", command.Method)
+		fmt.Fprintf(&buf, "      full_method: %s\n", command.FullMethod)
+		fmt.Fprintf(&buf, "      request: %s\n", command.RequestType)
+		fmt.Fprintf(&buf, "      response: %s\n", command.ResponseType)
+		fmt.Fprintf(&buf, "      cli: %s\n", command.CLI)
+		fmt.Fprintf(&buf, "      flags:\n")
+		for _, flag := range command.Flags {
+			fmt.Fprintf(&buf, "        --%s %s\n", flag.Name, flag.Type)
+			fmt.Fprintf(&buf, "          proto: %s\n", flag.ProtoType)
+			fmt.Fprintf(&buf, "          description: %s\n", flag.Description)
+			fmt.Fprintf(&buf, "          accepts_json: %t\n", flag.AcceptsJSON)
+			if flag.SchemaRef != "" {
+				fmt.Fprintf(&buf, "          schema: %s\n", flag.SchemaRef)
+			}
+			if len(flag.EnumValues) > 0 {
+				fmt.Fprintf(&buf, "          enum_values:\n")
+				for _, value := range flag.EnumValues {
+					fmt.Fprintf(&buf, "            - %s = %d\n", value.Name, value.Number)
+				}
+			}
+		}
+		buf.WriteString("\n")
+	}
+
+	fmt.Fprintln(&buf, "DAEMON COMMANDS")
+	fmt.Fprintf(&buf, "  daemon serve\n")
+	fmt.Fprintf(&buf, "    summary: %s\n", surface.Daemon.Summary)
+	fmt.Fprintf(&buf, "    cli: %s\n", surface.Daemon.CLI)
+	fmt.Fprintln(&buf, "    flags:")
+	for _, flag := range surface.Daemon.Flags {
+		fmt.Fprintf(&buf, "      --%s %s\n", flag.Name, flag.Type)
+		fmt.Fprintf(&buf, "        %s\n", flag.Description)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "GATEWAY STUB")
+	fmt.Fprintln(&buf, "  routes:")
+	for _, route := range surface.Gateway.Routes {
+		fmt.Fprintf(&buf, "    %s %s\n", route.Method, route.Path)
+		fmt.Fprintf(&buf, "      purpose: %s\n", route.Purpose)
+	}
+	fmt.Fprintln(&buf, "  streams:")
+	for _, stream := range surface.Gateway.Streams {
+		fmt.Fprintf(&buf, "    %s\n", stream.Path)
+		fmt.Fprintf(&buf, "      event: %s\n", stream.Event)
+		fmt.Fprintf(&buf, "      purpose: %s\n", stream.Purpose)
+	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "SCHEMAS")
+	for _, message := range surface.Messages {
+		fmt.Fprintf(&buf, "  MESSAGE %s\n", message.Name)
+		if message.Description != "" {
+			fmt.Fprintf(&buf, "    summary: %s\n", message.Description)
+		}
+		fmt.Fprintln(&buf, "    fields:")
+		for _, field := range message.Fields {
+			fmt.Fprintf(&buf, "      %s %s\n", field.Name, field.Type)
+			fmt.Fprintf(&buf, "        proto: %s\n", field.ProtoType)
+			fmt.Fprintf(&buf, "        description: %s\n", field.Description)
+			fmt.Fprintf(&buf, "        accepts_json: %t\n", field.AcceptsJSON)
+			if field.SchemaRef != "" {
+				fmt.Fprintf(&buf, "        schema: %s\n", field.SchemaRef)
+			}
+			if len(field.EnumValues) > 0 {
+				fmt.Fprintln(&buf, "        enum_values:")
+				for _, value := range field.EnumValues {
+					fmt.Fprintf(&buf, "          - %s = %d\n", value.Name, value.Number)
+				}
+			}
+		}
+		buf.WriteString("\n")
+	}
+	for _, enum := range surface.Enums {
+		fmt.Fprintf(&buf, "  ENUM %s\n", enum.Name)
+		if enum.Description != "" {
+			fmt.Fprintf(&buf, "    summary: %s\n", enum.Description)
+		}
+		for _, value := range enum.Values {
+			fmt.Fprintf(&buf, "    %s = %d\n", value.Name, value.Number)
+			if value.Description != "" {
+				fmt.Fprintf(&buf, "      %s\n", value.Description)
+			}
+		}
+		buf.WriteString("\n")
+	}
+	return buf.String()
+}
+
+func renderDescribeMCP(surface describeSurface) string {
+	var buf bytes.Buffer
+	writeYAMLString(&buf, "version", "1")
+	writeYAMLString(&buf, "surface", surface.Title)
+	writeYAMLString(&buf, "description", surface.Summary)
+	writeYAMLString(&buf, "describe_command", "rein [global flags] describe-as=<format>")
+	buf.WriteString("conventions:\n")
+	for _, convention := range surface.Conventions {
+		fmt.Fprintf(&buf, "  - %s\n", yamlString(convention))
+	}
+	buf.WriteString("formats:\n")
+	for _, format := range surface.Formats {
+		buf.WriteString("  - name: ")
+		buf.WriteString(yamlString(format.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "    description: %s\n", yamlString(format.Description))
+	}
+	buf.WriteString("root_usage:\n")
+	for _, line := range surface.Usage {
+		fmt.Fprintf(&buf, "  - %s\n", yamlString(line))
+	}
+	buf.WriteString("global_flags:\n")
+	for _, flag := range surface.GlobalFlags {
+		buf.WriteString("  - name: ")
+		buf.WriteString(yamlString(flag.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "    type: %s\n", yamlString(flag.Type))
+		fmt.Fprintf(&buf, "    description: %s\n", yamlString(flag.Description))
+	}
+	buf.WriteString("commands:\n")
+	for _, command := range surface.Commands {
+		buf.WriteString("  - name: ")
+		buf.WriteString(yamlString(command.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "    cli: %s\n", yamlString(command.CLI))
+		fmt.Fprintf(&buf, "    noun: %s\n", yamlString(command.Noun))
+		fmt.Fprintf(&buf, "    verb: %s\n", yamlString(command.Verb))
+		fmt.Fprintf(&buf, "    service: %s\n", yamlString(command.Service))
+		fmt.Fprintf(&buf, "    service_summary: %s\n", yamlString(command.ServiceSummary))
+		fmt.Fprintf(&buf, "    grpc_method: %s\n", yamlString(command.Method))
+		fmt.Fprintf(&buf, "    full_method: %s\n", yamlString(command.FullMethod))
+		fmt.Fprintf(&buf, "    summary: %s\n", yamlString(command.Summary))
+		fmt.Fprintf(&buf, "    request_type: %s\n", yamlString(command.RequestType))
+		fmt.Fprintf(&buf, "    response_type: %s\n", yamlString(command.ResponseType))
+		buf.WriteString("    flags:\n")
+		for _, flag := range command.Flags {
+			writeYAMLField(&buf, "      ", flag)
+		}
+	}
+	buf.WriteString("daemon:\n")
+	buf.WriteString("  - name: ")
+	buf.WriteString(yamlString(surface.Daemon.Name))
+	buf.WriteString("\n")
+	fmt.Fprintf(&buf, "    cli: %s\n", yamlString(surface.Daemon.CLI))
+	fmt.Fprintf(&buf, "    summary: %s\n", yamlString(surface.Daemon.Summary))
+	buf.WriteString("    flags:\n")
+	for _, flag := range surface.Daemon.Flags {
+		buf.WriteString("      - name: ")
+		buf.WriteString(yamlString(flag.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "        type: %s\n", yamlString(flag.Type))
+		fmt.Fprintf(&buf, "        description: %s\n", yamlString(flag.Description))
+	}
+	buf.WriteString("gateway:\n")
+	buf.WriteString("  routes:\n")
+	for _, route := range surface.Gateway.Routes {
+		buf.WriteString("    - method: ")
+		buf.WriteString(yamlString(route.Method))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "      path: %s\n", yamlString(route.Path))
+		fmt.Fprintf(&buf, "      purpose: %s\n", yamlString(route.Purpose))
+	}
+	buf.WriteString("  streams:\n")
+	for _, stream := range surface.Gateway.Streams {
+		buf.WriteString("    - path: ")
+		buf.WriteString(yamlString(stream.Path))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "      event: %s\n", yamlString(stream.Event))
+		fmt.Fprintf(&buf, "      purpose: %s\n", yamlString(stream.Purpose))
+	}
+	buf.WriteString("schemas:\n")
+	buf.WriteString("  messages:\n")
+	for _, message := range surface.Messages {
+		buf.WriteString("    - name: ")
+		buf.WriteString(yamlString(message.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "      description: %s\n", yamlString(message.Description))
+		buf.WriteString("      fields:\n")
+		for _, field := range message.Fields {
+			writeYAMLField(&buf, "        ", field)
+		}
+	}
+	buf.WriteString("  enums:\n")
+	for _, enum := range surface.Enums {
+		buf.WriteString("    - name: ")
+		buf.WriteString(yamlString(enum.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "      description: %s\n", yamlString(enum.Description))
+		buf.WriteString("      values:\n")
+		for _, value := range enum.Values {
+			buf.WriteString("        - name: ")
+			buf.WriteString(yamlString(value.Name))
+			buf.WriteString("\n")
+			fmt.Fprintf(&buf, "          number: %d\n", value.Number)
+			fmt.Fprintf(&buf, "          description: %s\n", yamlString(value.Description))
+		}
+	}
+	return buf.String()
+}
+
+func writeYAMLField(buf *bytes.Buffer, indent string, field fieldDescription) {
+	fmt.Fprintf(buf, "%s- name: %s\n", indent, yamlString(field.Name))
+	fmt.Fprintf(buf, "%s  type: %s\n", indent, yamlString(field.Type))
+	fmt.Fprintf(buf, "%s  proto_type: %s\n", indent, yamlString(field.ProtoType))
+	fmt.Fprintf(buf, "%s  description: %s\n", indent, yamlString(field.Description))
+	fmt.Fprintf(buf, "%s  accepts_json: %t\n", indent, field.AcceptsJSON)
+	fmt.Fprintf(buf, "%s  repeated: %t\n", indent, field.Repeated)
+	fmt.Fprintf(buf, "%s  map: %t\n", indent, field.Map)
+	fmt.Fprintf(buf, "%s  schema_ref: %s\n", indent, yamlString(field.SchemaRef))
+	if len(field.EnumValues) == 0 {
+		fmt.Fprintf(buf, "%s  enum_values: []\n", indent)
+		return
+	}
+	buf.WriteString(indent)
+	buf.WriteString("  enum_values:\n")
+	for _, value := range field.EnumValues {
+		fmt.Fprintf(buf, "%s    - name: %s\n", indent, yamlString(value.Name))
+		fmt.Fprintf(buf, "%s      number: %d\n", indent, value.Number)
+		fmt.Fprintf(buf, "%s      description: %s\n", indent, yamlString(value.Description))
+	}
+}
+
+func yamlString(value string) string {
+	return strconv.Quote(value)
+}
+
+func writeYAMLString(buf *bytes.Buffer, key, value string) {
+	fmt.Fprintf(buf, "%s: %s\n", key, yamlString(value))
+}


### PR DESCRIPTION
## Summary
- add descriptor-driven `rein describe-as` output for `cli` and `mcp` formats
- document the new surface in help text and README
- add command tests covering help and both describe outputs

## Validation
- just build
- just test
- just vet
- go run ./cmd/rein describe-as=cli >/dev/null
- go run ./cmd/rein describe-as=mcp | ruby -e 'require "yaml"; YAML.safe_load(ARGF.read); puts "yaml ok"'