### PR TITLE
RN-19: add rein doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - The current reserved layout is:
   - `grpc.sock` — default unix gRPC listener socket for that instance.
   - `rein.db` — canonical SQLite path reserved for that instance's persisted state.
-- `rein doctor` will validate that commands and on-disk state follow this canonical layout in a future issue.
+- `rein doctor` emits JSON diagnostics for daemon reachability, canonical instance layout, adapter registry compatibility, credential provider readiness, and SQLite migration state.
 
 ## CLI surface
 
 - `rein` is the canonical gRPC client CLI. By default it connects to the selected instance over that instance's unix socket.
 - Use `rein daemon serve` to start the daemon for the selected instance.
+- Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics.
 - Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
 - Request flags map 1:1 to top-level gRPC request fields. Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
 - Responses are emitted as JSON using protobuf field names.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -39,6 +39,7 @@ type app struct {
 	stderr      io.Writer
 	lookupEnv   func(string) (string, bool)
 	userHomeDir func() (string, error)
+	getwd       func() (string, error)
 }
 
 type rpcCommand struct {
@@ -57,12 +58,16 @@ type fieldBinding struct {
 	set   bool
 }
 
-func newApp(stdout, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error)) *app {
+func newApp(stdout, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error), getwd func() (string, error)) *app {
+	if getwd == nil {
+		getwd = os.Getwd
+	}
 	return &app{
 		stdout:      stdout,
 		stderr:      stderr,
 		lookupEnv:   lookupEnv,
 		userHomeDir: userHomeDir,
+		getwd:       getwd,
 	}
 }
 
@@ -84,6 +89,8 @@ func (a *app) run(args []string) error {
 	switch remaining[0] {
 	case "daemon":
 		return a.runDaemon(root, remaining[1:])
+	case "doctor":
+		return a.runDoctor(root, remaining[1:])
 	default:
 		return a.runRPC(root, remaining)
 	}
@@ -407,6 +414,7 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr, "Usage:")
 	fmt.Fprintln(a.stderr, "  rein [global flags] <service> <verb> [flags]")
 	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
+	fmt.Fprintln(a.stderr, "  rein [global flags] doctor")
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Global flags:")
 	fmt.Fprintf(a.stderr, "  --instance string\n    Select the daemon instance (default %q or %s)\n", instance.DefaultName, instance.EnvVar)
@@ -436,6 +444,7 @@ func (a *app) printRootHelp() {
 	}
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "  daemon serve\tStart the daemon and expose the canonical gRPC surface.")
+	fmt.Fprintln(a.stderr, "  doctor\tEmit JSON diagnostics for daemon health and local instance readiness.")
 }
 
 func (a *app) printDaemonHelp() {
@@ -447,6 +456,15 @@ func (a *app) printDaemonHelp() {
 	fmt.Fprintln(a.stderr, "  --grpc-address string")
 	fmt.Fprintln(a.stderr, "    Listener address or unix socket path.")
 	fmt.Fprintf(a.stderr, "  --grpc-require-peer-credentials bool\n    Require SO_PEERCRED same-UID authentication for unix sockets (default %t)\n", server.DefaultListenerConfig().RequirePeerCredentials)
+}
+
+func (a *app) printDoctorHelp() {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] doctor")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Emit machine-parseable JSON diagnostics covering daemon reachability,")
+	fmt.Fprintln(a.stderr, "instance layout, adapter registry compatibility, credential readiness,")
+	fmt.Fprintln(a.stderr, "and SQLite migration state for the selected instance.")
 }
 
 func (a *app) printCommandHelp(command rpcCommand) {

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -58,7 +58,7 @@ type fieldBinding struct {
 	set   bool
 }
 
-func newApp(stdout, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir func() (string, error), getwd func() (string, error)) *app {
+func newApp(stdout, stderr io.Writer, lookupEnv func(string) (string, bool), userHomeDir, getwd func() (string, error)) *app {
 	if getwd == nil {
 		getwd = os.Getwd
 	}

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -169,6 +169,8 @@ func TestAppCommandHelpUsesProtoComments(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
 		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
 	})
 
 	err := app.run([]string{"project", "list", "--help"})
@@ -185,5 +187,25 @@ func TestAppCommandHelpUsesProtoComments(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q\n%s", want, output)
 		}
+	}
+}
+
+func TestRootHelpListsDoctorCommand(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	err := app.run([]string{"--help"})
+	if err != flag.ErrHelp {
+		t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+	}
+
+	if got := stderr.String(); !strings.Contains(got, "doctor\tEmit JSON diagnostics") {
+		t.Fatalf("root help missing doctor command:\n%s", got)
 	}
 }

--- a/cmd/rein/doctor.go
+++ b/cmd/rein/doctor.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sort"
+	"time"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/credentials"
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+type doctorOutput struct {
+	OK          bool                       `json:"ok"`
+	GeneratedAt time.Time                  `json:"generatedAt"`
+	Instance    doctorInstanceDiagnostic   `json:"instance"`
+	Daemon      doctorDaemonDiagnostic     `json:"daemon"`
+	Plugins     doctorPluginDiagnostic     `json:"plugins"`
+	Credentials doctorCredentialDiagnostic `json:"credentials"`
+	Storage     doctorStorageDiagnostic    `json:"storage"`
+}
+
+type doctorInstanceDiagnostic struct {
+	Name         string                 `json:"name"`
+	StateHome    string                 `json:"stateHome"`
+	RootDir      string                 `json:"rootDir"`
+	SocketPath   string                 `json:"socketPath"`
+	DatabasePath string                 `json:"databasePath"`
+	AutoStart    bool                   `json:"autoStart"`
+	Layout       doctorLayoutDiagnostic `json:"layout"`
+}
+
+type doctorLayoutDiagnostic struct {
+	Canonical      bool     `json:"canonical"`
+	RootExists     bool     `json:"rootExists"`
+	RootMode       string   `json:"rootMode,omitempty"`
+	SocketExists   bool     `json:"socketExists"`
+	SocketMode     string   `json:"socketMode,omitempty"`
+	SocketIsSocket bool     `json:"socketIsSocket"`
+	DatabaseExists bool     `json:"databaseExists"`
+	DatabaseMode   string   `json:"databaseMode,omitempty"`
+	Entries        []string `json:"entries,omitempty"`
+	Error          string   `json:"error,omitempty"`
+}
+
+type doctorDaemonDiagnostic struct {
+	Network   string                 `json:"network"`
+	Address   string                 `json:"address"`
+	Reachable bool                   `json:"reachable"`
+	RPC       doctorRPCDiagnostic    `json:"rpc"`
+	Socket    doctorSocketDiagnostic `json:"socket"`
+}
+
+type doctorSocketDiagnostic struct {
+	Path        string `json:"path,omitempty"`
+	Exists      bool   `json:"exists"`
+	IsSocket    bool   `json:"isSocket"`
+	Mode        string `json:"mode,omitempty"`
+	Connectable bool   `json:"connectable"`
+	Error       string `json:"error,omitempty"`
+}
+
+type doctorRPCDiagnostic struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+type doctorPluginDiagnostic struct {
+	Root             string                      `json:"root"`
+	DaemonAPIVersion string                      `json:"daemonApiVersion"`
+	RegistryReady    bool                        `json:"registryReady"`
+	AvailableCount   int                         `json:"availableCount"`
+	ConfiguredCount  int                         `json:"configuredCount"`
+	Error            string                      `json:"error,omitempty"`
+	Marketplace      doctorMarketplaceDiagnostic `json:"marketplace"`
+	Adapters         []doctorAdapterDiagnostic   `json:"adapters"`
+}
+
+type doctorMarketplaceDiagnostic struct {
+	Path      string                    `json:"path"`
+	Name      string                    `json:"name,omitempty"`
+	Present   bool                      `json:"present"`
+	Signature doctorSignatureDiagnostic `json:"signature"`
+}
+
+type doctorSignatureDiagnostic struct {
+	Present   bool   `json:"present"`
+	Verified  bool   `json:"verified"`
+	Algorithm string `json:"algorithm,omitempty"`
+	KeyID     string `json:"keyId,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+type doctorAdapterDiagnostic struct {
+	Name                 string         `json:"name"`
+	Source               adapter.Source `json:"source"`
+	LocalManifestPath    string         `json:"localManifestPath,omitempty"`
+	LocalManifestFound   bool           `json:"localManifestFound"`
+	Version              string         `json:"version,omitempty"`
+	Category             string         `json:"category,omitempty"`
+	DaemonAPIVersion     string         `json:"daemonApiVersion,omitempty"`
+	CompatibleWithDaemon bool           `json:"compatibleWithDaemon"`
+	Error                string         `json:"error,omitempty"`
+}
+
+type doctorCredentialDiagnostic struct {
+	OK                     bool                            `json:"ok"`
+	ExecutionScopeRequired bool                            `json:"executionScopeRequired"`
+	Providers              []credentials.ProviderReadiness `json:"providers"`
+}
+
+type doctorStorageDiagnostic struct {
+	OK         bool                       `json:"ok"`
+	Database   doctorDatabaseDiagnostic   `json:"database"`
+	Migrations sqlite.MigrationDiagnostic `json:"migrations"`
+}
+
+type doctorDatabaseDiagnostic struct {
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (a *app) runDoctor(root rootConfig, args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		a.printDoctorHelp()
+		return flag.ErrHelp
+	}
+	if len(args) != 0 {
+		return fmt.Errorf("unexpected arguments: %v", args)
+	}
+
+	workingDir, err := a.getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	diagnostic := doctorOutput{
+		GeneratedAt: time.Now().UTC(),
+		Instance:    diagnoseInstance(root.instance),
+		Daemon:      a.diagnoseDaemon(root.client, root.instance.SocketPath),
+		Plugins:     diagnosePlugins(workingDir),
+		Credentials: diagnoseCredentials(),
+	}
+	diagnostic.Storage = diagnoseStorage(root.instance.DatabasePath)
+	diagnostic.OK = diagnostic.Instance.Layout.Canonical &&
+		diagnostic.Instance.Layout.RootExists &&
+		diagnostic.Daemon.RPC.OK &&
+		diagnostic.Plugins.RegistryReady &&
+		diagnostic.Storage.OK &&
+		diagnostic.Credentials.OK
+
+	return writeJSONObject(a.stdout, diagnostic)
+}
+
+func diagnoseInstance(layout instance.Layout) doctorInstanceDiagnostic {
+	diagnostic := doctorInstanceDiagnostic{
+		Name:         layout.Name,
+		StateHome:    layout.StateHome,
+		RootDir:      layout.RootDir,
+		SocketPath:   layout.SocketPath,
+		DatabasePath: layout.DatabasePath,
+		AutoStart:    layout.AutoStartEnabled(),
+	}
+
+	layoutDiagnostic := doctorLayoutDiagnostic{Canonical: true}
+	if err := layout.Validate(); err != nil {
+		layoutDiagnostic.Canonical = false
+		layoutDiagnostic.Error = err.Error()
+	}
+
+	if info, err := os.Stat(layout.RootDir); err == nil {
+		layoutDiagnostic.RootExists = true
+		layoutDiagnostic.RootMode = info.Mode().String()
+		entries, readErr := os.ReadDir(layout.RootDir)
+		if readErr != nil {
+			layoutDiagnostic.Error = joinErrors(layoutDiagnostic.Error, readErr.Error())
+		} else {
+			layoutDiagnostic.Entries = make([]string, 0, len(entries))
+			for _, entry := range entries {
+				layoutDiagnostic.Entries = append(layoutDiagnostic.Entries, entry.Name())
+			}
+			sort.Strings(layoutDiagnostic.Entries)
+		}
+	} else if !os.IsNotExist(err) {
+		layoutDiagnostic.Error = joinErrors(layoutDiagnostic.Error, err.Error())
+	}
+
+	if info, err := os.Lstat(layout.SocketPath); err == nil {
+		layoutDiagnostic.SocketExists = true
+		layoutDiagnostic.SocketMode = info.Mode().String()
+		layoutDiagnostic.SocketIsSocket = info.Mode()&os.ModeSocket != 0
+	} else if !os.IsNotExist(err) {
+		layoutDiagnostic.Error = joinErrors(layoutDiagnostic.Error, err.Error())
+	}
+
+	if info, err := os.Stat(layout.DatabasePath); err == nil {
+		layoutDiagnostic.DatabaseExists = true
+		layoutDiagnostic.DatabaseMode = info.Mode().String()
+	} else if !os.IsNotExist(err) {
+		layoutDiagnostic.Error = joinErrors(layoutDiagnostic.Error, err.Error())
+	}
+
+	diagnostic.Layout = layoutDiagnostic
+	return diagnostic
+}
+
+func (a *app) diagnoseDaemon(config clientConfig, socketPath string) doctorDaemonDiagnostic {
+	diagnostic := doctorDaemonDiagnostic{
+		Network: config.Network,
+		Address: config.Address,
+	}
+
+	if config.Network == "unix" {
+		diagnostic.Socket = diagnoseSocket(socketPath)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRPCTimeout)
+	defer cancel()
+
+	conn, err := dialGRPC(ctx, config)
+	if err != nil {
+		diagnostic.RPC.Error = err.Error()
+		return diagnostic
+	}
+	defer conn.Close()
+
+	client := reinv1.NewProjectServiceClient(conn)
+	if _, err := client.ListProjects(ctx, &reinv1.ListProjectsRequest{}); err != nil {
+		diagnostic.RPC.Error = err.Error()
+		return diagnostic
+	}
+
+	diagnostic.Reachable = true
+	diagnostic.RPC.OK = true
+	if config.Network == "unix" {
+		diagnostic.Socket.Connectable = diagnostic.Socket.Exists && diagnostic.Socket.IsSocket
+	}
+	return diagnostic
+}
+
+func diagnoseSocket(path string) doctorSocketDiagnostic {
+	diagnostic := doctorSocketDiagnostic{Path: path}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			diagnostic.Error = err.Error()
+		}
+		return diagnostic
+	}
+
+	diagnostic.Exists = true
+	diagnostic.Mode = info.Mode().String()
+	diagnostic.IsSocket = info.Mode()&os.ModeSocket != 0
+	if !diagnostic.IsSocket {
+		diagnostic.Error = fmt.Sprintf("%q is not a unix socket", path)
+		return diagnostic
+	}
+
+	conn, err := (&net.Dialer{Timeout: time.Second}).Dial("unix", path)
+	if err != nil {
+		diagnostic.Error = err.Error()
+		return diagnostic
+	}
+	diagnostic.Connectable = true
+	_ = conn.Close()
+	return diagnostic
+}
+
+func diagnosePlugins(root string) doctorPluginDiagnostic {
+	diagnostic := adapter.Diagnose(root, adapter.DiscoveryOptions{})
+
+	adapters := make([]doctorAdapterDiagnostic, 0, len(diagnostic.Adapters))
+	availableCount := 0
+	for _, item := range diagnostic.Adapters {
+		if item.Error == "" {
+			availableCount++
+		}
+		adapters = append(adapters, doctorAdapterDiagnostic{
+			Name:                 item.Name,
+			Source:               item.Source,
+			LocalManifestPath:    item.LocalManifestPath,
+			LocalManifestFound:   item.LocalManifestFound,
+			Version:              item.Version,
+			Category:             item.Category,
+			DaemonAPIVersion:     item.DaemonAPIVersion,
+			CompatibleWithDaemon: item.CompatibleWithDaemon,
+			Error:                item.Error,
+		})
+	}
+
+	return doctorPluginDiagnostic{
+		Root:             root,
+		DaemonAPIVersion: adapter.CurrentDaemonAPIVersion,
+		RegistryReady:    diagnostic.RegistryReady,
+		AvailableCount:   availableCount,
+		ConfiguredCount:  len(diagnostic.Adapters),
+		Error:            diagnostic.Error,
+		Marketplace: doctorMarketplaceDiagnostic{
+			Path:    diagnostic.MarketplacePath,
+			Name:    diagnostic.MarketplaceName,
+			Present: diagnostic.MarketplaceFound,
+			Signature: doctorSignatureDiagnostic{
+				Present:   diagnostic.Signature.Present,
+				Verified:  diagnostic.Signature.Verified,
+				Algorithm: diagnostic.Signature.Algorithm,
+				KeyID:     diagnostic.Signature.KeyID,
+				Error:     diagnostic.Signature.Error,
+			},
+		},
+		Adapters: adapters,
+	}
+}
+
+func diagnoseCredentials() doctorCredentialDiagnostic {
+	readiness := credentials.DiagnoseBuiltinReadiness()
+	ok := true
+	for _, provider := range readiness.Providers {
+		if provider.Supported && !provider.Available {
+			ok = false
+		}
+	}
+
+	return doctorCredentialDiagnostic{
+		OK:                     ok,
+		ExecutionScopeRequired: readiness.ExecutionScopeRequired,
+		Providers:              readiness.Providers,
+	}
+}
+
+func diagnoseStorage(databasePath string) doctorStorageDiagnostic {
+	migrations := sqlite.DiagnoseMigrations(context.Background(), sqlite.Config{Path: databasePath})
+	database := doctorDatabaseDiagnostic{
+		Path:   databasePath,
+		Exists: migrations.Exists,
+	}
+	if migrations.InspectionError != "" {
+		database.Error = migrations.InspectionError
+	} else if migrations.BlockedReason != "" {
+		database.Error = migrations.BlockedReason
+	}
+
+	return doctorStorageDiagnostic{
+		OK:         migrations.Ready,
+		Database:   database,
+		Migrations: migrations,
+	}
+}
+
+func writeJSONObject(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func joinErrors(current, next string) string {
+	if current == "" {
+		return next
+	}
+	if next == "" || current == next {
+		return current
+	}
+	return current + "; " + next
+}

--- a/cmd/rein/doctor_test.go
+++ b/cmd/rein/doctor_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/server"
+	"github.com/earchibald/rein/internal/service"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
+	t.Parallel()
+
+	stateHome := t.TempDir()
+	worktree := t.TempDir()
+
+	layout, err := instance.NewLayout(instance.DefaultName, stateHome)
+	if err != nil {
+		t.Fatalf("NewLayout() error = %v", err)
+	}
+	if err := layout.EnsureRootDir(); err != nil {
+		t.Fatalf("EnsureRootDir() error = %v", err)
+	}
+	if err := sqlite.MigrateUp(context.Background(), sqlite.Config{Path: layout.DatabasePath}); err != nil {
+		t.Fatalf("MigrateUp() error = %v", err)
+	}
+
+	store, err := sqlite.OpenAndMigrate(context.Background(), sqlite.Config{Path: filepath.Join(t.TempDir(), "daemon.db")})
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() daemon store error = %v", err)
+	}
+	defer store.Close()
+
+	listener, err := server.Listen(server.ListenerConfig{Network: "tcp", Address: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	runtime := server.New(server.Options{Services: service.NewManagedSet(store, nil)})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- runtime.Serve(ctx, listener)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		runtime.Stop()
+		select {
+		case err := <-serveDone:
+			if err != nil {
+				t.Fatalf("Serve() error = %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out stopping runtime")
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(key string) (string, bool) {
+		if key == "XDG_STATE_HOME" {
+			return stateHome, true
+		}
+		return "", false
+	}, nil, func() (string, error) {
+		return worktree, nil
+	})
+
+	address := listener.Addr().String()
+	if tcpAddr, ok := listener.Addr().(*net.TCPAddr); ok {
+		address = tcpAddr.String()
+	}
+	err = app.run([]string{"--grpc-network", "tcp", "--grpc-address", address, "doctor"})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload struct {
+		Instance struct {
+			Name   string `json:"name"`
+			Layout struct {
+				Canonical      bool `json:"canonical"`
+				RootExists     bool `json:"rootExists"`
+				DatabaseExists bool `json:"databaseExists"`
+			} `json:"layout"`
+		} `json:"instance"`
+		Daemon struct {
+			Reachable bool `json:"reachable"`
+			RPC       struct {
+				OK bool `json:"ok"`
+			} `json:"rpc"`
+		} `json:"daemon"`
+		Plugins struct {
+			Marketplace struct {
+				Present bool `json:"present"`
+			} `json:"marketplace"`
+			ConfiguredCount int `json:"configuredCount"`
+		} `json:"plugins"`
+		Credentials struct {
+			ExecutionScopeRequired bool `json:"executionScopeRequired"`
+			Providers              []struct {
+				Scheme string `json:"scheme"`
+			} `json:"providers"`
+		} `json:"credentials"`
+		Storage struct {
+			Migrations struct {
+				Ready          bool `json:"ready"`
+				CurrentVersion uint `json:"currentVersion"`
+				LatestVersion  uint `json:"latestVersion"`
+			} `json:"migrations"`
+		} `json:"storage"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+
+	if payload.Instance.Name != instance.DefaultName {
+		t.Fatalf("instance name = %q, want %q", payload.Instance.Name, instance.DefaultName)
+	}
+	if !payload.Instance.Layout.Canonical || !payload.Instance.Layout.RootExists || !payload.Instance.Layout.DatabaseExists {
+		t.Fatalf("instance layout = %+v, want canonical existing layout", payload.Instance.Layout)
+	}
+	if !payload.Daemon.Reachable || !payload.Daemon.RPC.OK {
+		t.Fatalf("daemon diagnostic = %+v, want reachable rpc ok", payload.Daemon)
+	}
+	if payload.Plugins.Marketplace.Present {
+		t.Fatalf("marketplace.present = true, want false")
+	}
+	if payload.Plugins.ConfiguredCount != 0 {
+		t.Fatalf("configuredCount = %d, want 0", payload.Plugins.ConfiguredCount)
+	}
+	if !payload.Credentials.ExecutionScopeRequired || len(payload.Credentials.Providers) < 2 {
+		t.Fatalf("credentials diagnostic = %+v", payload.Credentials)
+	}
+	if !payload.Storage.Migrations.Ready || payload.Storage.Migrations.CurrentVersion == 0 || payload.Storage.Migrations.LatestVersion == 0 {
+		t.Fatalf("migration diagnostic = %+v, want ready migrated database", payload.Storage.Migrations)
+	}
+}

--- a/cmd/rein/main.go
+++ b/cmd/rein/main.go
@@ -13,7 +13,7 @@ func main() {
 }
 
 func run() int {
-	app := newApp(os.Stdout, os.Stderr, os.LookupEnv, os.UserHomeDir)
+	app := newApp(os.Stdout, os.Stderr, os.LookupEnv, os.UserHomeDir, os.Getwd)
 	if err := app.run(os.Args[1:]); err != nil {
 		return parseErrorExitCode(err, os.Stderr)
 	}

--- a/internal/adapter/diagnostics.go
+++ b/internal/adapter/diagnostics.go
@@ -1,0 +1,187 @@
+package adapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Diagnostic struct {
+	Root             string
+	MarketplacePath  string
+	MarketplaceName  string
+	MarketplaceFound bool
+	RegistryReady    bool
+	Error            string
+	Signature        SignatureDiagnostic
+	Adapters         []AdapterDiagnostic
+}
+
+type SignatureDiagnostic struct {
+	Present   bool
+	Verified  bool
+	Algorithm string
+	KeyID     string
+	Error     string
+}
+
+type AdapterDiagnostic struct {
+	Name                 string
+	Source               Source
+	LocalManifestPath    string
+	LocalManifestFound   bool
+	Version              string
+	Category             string
+	DaemonAPIVersion     string
+	CompatibleWithDaemon bool
+	Error                string
+}
+
+func Diagnose(root string, options DiscoveryOptions) Diagnostic {
+	options = options.withDefaults()
+
+	diagnostic := Diagnostic{
+		Root:            root,
+		MarketplacePath: filepath.Join(root, ".claude-plugin", "marketplace.json"),
+		RegistryReady:   true,
+	}
+
+	raw, err := os.ReadFile(diagnostic.MarketplacePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return diagnostic
+		}
+		diagnostic.RegistryReady = false
+		diagnostic.Error = fmt.Sprintf("read marketplace index: %v", err)
+		return diagnostic
+	}
+	diagnostic.MarketplaceFound = true
+
+	diagnostic.Signature = diagnoseSignature(raw, options)
+	if diagnostic.Signature.Error != "" {
+		diagnostic.RegistryReady = false
+		diagnostic.Error = diagnostic.Signature.Error
+	}
+
+	var document marketplaceDocument
+	if err := json.Unmarshal(raw, &document); err != nil {
+		diagnostic.RegistryReady = false
+		diagnostic.Error = fmt.Sprintf("decode marketplace index: %v", err)
+		return diagnostic
+	}
+	diagnostic.MarketplaceName = document.Name
+	diagnostic.Adapters = make([]AdapterDiagnostic, 0, len(document.Plugins))
+	for _, plugin := range document.Plugins {
+		adapterDiagnostic := diagnosePlugin(root, plugin, options)
+		if adapterDiagnostic.Error != "" {
+			diagnostic.RegistryReady = false
+			if diagnostic.Error == "" {
+				diagnostic.Error = fmt.Sprintf("load plugin %q: %s", plugin.Name, adapterDiagnostic.Error)
+			}
+		}
+		diagnostic.Adapters = append(diagnostic.Adapters, adapterDiagnostic)
+	}
+
+	return diagnostic
+}
+
+func diagnoseSignature(raw []byte, options DiscoveryOptions) SignatureDiagnostic {
+	var diagnostic SignatureDiagnostic
+
+	var envelope map[string]any
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		diagnostic.Error = fmt.Sprintf("decode marketplace signature envelope: %v", err)
+		return diagnostic
+	}
+
+	value, ok := envelope["signature"]
+	if !ok {
+		if options.AllowUnsignedIndex {
+			return diagnostic
+		}
+		diagnostic.Error = "marketplace index signature is required"
+		return diagnostic
+	}
+	diagnostic.Present = true
+
+	signatureMap, ok := value.(map[string]any)
+	if !ok {
+		diagnostic.Error = "marketplace index signature must be an object"
+		return diagnostic
+	}
+	diagnostic.Algorithm, _ = signatureMap["algorithm"].(string)
+	diagnostic.KeyID, _ = signatureMap["keyId"].(string)
+
+	if err := verifyIndexSignature(raw, options); err != nil {
+		diagnostic.Error = err.Error()
+		return diagnostic
+	}
+
+	diagnostic.Verified = true
+	return diagnostic
+}
+
+func diagnosePlugin(root string, plugin marketplacePlugin, options DiscoveryOptions) AdapterDiagnostic {
+	diagnostic := AdapterDiagnostic{Name: plugin.Name}
+
+	source, sourceErr := parseSource(plugin.Source)
+	if sourceErr == nil {
+		diagnostic.Source = source
+		if source.Kind == SourceLocal {
+			diagnostic.LocalManifestPath = filepath.Join(root, filepath.Clean(source.Path), ".claude-plugin", "plugin.json")
+			if _, err := os.Stat(diagnostic.LocalManifestPath); err == nil {
+				diagnostic.LocalManifestFound = true
+			}
+		}
+	}
+
+	record := pluginRecord{
+		ID:               plugin.Name,
+		Description:      plugin.Description,
+		Version:          plugin.Version,
+		Category:         plugin.Category,
+		DaemonAPIVersion: plugin.DaemonAPIVersion,
+		Capabilities:     cloneCapabilities(plugin.Capabilities),
+		Tail:             cloneBool(plugin.Tail),
+		Requires:         append([]string(nil), plugin.Requires...),
+		Source:           source,
+	}
+
+	if sourceErr == nil && source.Kind == SourceLocal {
+		strict := true
+		if plugin.Strict != nil {
+			strict = *plugin.Strict
+		}
+		manifest, err := loadPluginManifest(root, plugin.Name, source.Path)
+		if err == nil && manifest != nil {
+			manifestRecord := pluginRecord{
+				ID:               plugin.Name,
+				Description:      manifest.Description,
+				Version:          manifest.Version,
+				Category:         manifest.Category,
+				DaemonAPIVersion: manifest.DaemonAPIVersion,
+				Capabilities:     cloneCapabilities(manifest.Capabilities),
+				Tail:             cloneBool(manifest.Tail),
+				Requires:         append([]string(nil), manifest.Requires...),
+				Source:           source,
+			}
+			if strict {
+				record = overlayRecord(record, manifestRecord)
+			} else {
+				record = overlayRecord(manifestRecord, record)
+			}
+		}
+	}
+
+	diagnostic.Version = record.Version
+	diagnostic.Category = record.Category
+	diagnostic.DaemonAPIVersion = record.DaemonAPIVersion
+	diagnostic.CompatibleWithDaemon = record.DaemonAPIVersion != "" && record.DaemonAPIVersion == options.DaemonAPIVersion
+
+	if _, err := loadPlugin(root, plugin, options); err != nil {
+		diagnostic.Error = err.Error()
+	}
+
+	return diagnostic
+}

--- a/internal/adapter/diagnostics_test.go
+++ b/internal/adapter/diagnostics_test.go
@@ -1,0 +1,34 @@
+package adapter
+
+import "testing"
+
+func TestDiagnoseReportsPluginCompatibilityFailures(t *testing.T) {
+	t.Parallel()
+
+	root := writeMarketplaceFixture(t, fixtureOptions{Signed: true, MismatchDaemonVersion: true})
+	diagnostic := Diagnose(root, DiscoveryOptions{TrustedKeys: trustedKeys()})
+
+	if diagnostic.RegistryReady {
+		t.Fatal("RegistryReady = true, want false")
+	}
+	if len(diagnostic.Adapters) == 0 {
+		t.Fatal("Adapters = empty, want entries")
+	}
+
+	var mismatch *AdapterDiagnostic
+	for i := range diagnostic.Adapters {
+		if diagnostic.Adapters[i].Name == "projection-local" {
+			mismatch = &diagnostic.Adapters[i]
+			break
+		}
+	}
+	if mismatch == nil {
+		t.Fatal("projection-local diagnostic missing")
+	}
+	if mismatch.CompatibleWithDaemon {
+		t.Fatalf("CompatibleWithDaemon = true, want false: %+v", *mismatch)
+	}
+	if mismatch.Error == "" {
+		t.Fatalf("Error = empty, want mismatch diagnostic: %+v", *mismatch)
+	}
+}

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -70,15 +70,15 @@ const (
 )
 
 type Source struct {
-	Kind     SourceKind
-	Path     string
-	Repo     string
-	URL      string
-	Ref      string
-	SHA      string
-	Package  string
-	Version  string
-	Registry string
+	Kind     SourceKind `json:"kind"`
+	Path     string     `json:"path,omitempty"`
+	Repo     string     `json:"repo,omitempty"`
+	URL      string     `json:"url,omitempty"`
+	Ref      string     `json:"ref,omitempty"`
+	SHA      string     `json:"sha,omitempty"`
+	Package  string     `json:"package,omitempty"`
+	Version  string     `json:"version,omitempty"`
+	Registry string     `json:"registry,omitempty"`
 }
 
 type marketplaceDocument struct {

--- a/internal/credentials/diagnostics.go
+++ b/internal/credentials/diagnostics.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+)
+
+type BuiltinReadiness struct {
+	ExecutionScopeRequired bool                `json:"executionScopeRequired"`
+	Providers              []ProviderReadiness `json:"providers"`
+}
+
+type ProviderReadiness struct {
+	Scheme      string `json:"scheme"`
+	Supported   bool   `json:"supported"`
+	Available   bool   `json:"available"`
+	Command     string `json:"command,omitempty"`
+	CommandPath string `json:"commandPath,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+func DiagnoseBuiltinReadiness() BuiltinReadiness {
+	return diagnoseBuiltinReadiness(runtime.GOOS, exec.LookPath)
+}
+
+func diagnoseBuiltinReadiness(goos string, lookPath func(string) (string, error)) BuiltinReadiness {
+	readiness := BuiltinReadiness{
+		ExecutionScopeRequired: true,
+		Providers: []ProviderReadiness{
+			{Scheme: "env", Supported: true, Available: true},
+			{Scheme: "file", Supported: true, Available: true},
+		},
+	}
+
+	readiness.Providers = append(readiness.Providers, commandProviderReadiness(goos == "darwin", "keychain", "security", lookPath))
+	readiness.Providers = append(readiness.Providers, commandProviderReadiness(goos == "linux", "libsecret", "secret-tool", lookPath))
+
+	return readiness
+}
+
+func commandProviderReadiness(supported bool, scheme, command string, lookPath func(string) (string, error)) ProviderReadiness {
+	readiness := ProviderReadiness{
+		Scheme:    scheme,
+		Supported: supported,
+		Command:   command,
+	}
+	if !supported {
+		return readiness
+	}
+
+	path, err := lookPath(command)
+	if err == nil {
+		readiness.Available = true
+		readiness.CommandPath = path
+		return readiness
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		readiness.Error = err.Error()
+		return readiness
+	}
+
+	readiness.Error = err.Error()
+	return readiness
+}

--- a/internal/credentials/diagnostics_test.go
+++ b/internal/credentials/diagnostics_test.go
@@ -1,0 +1,26 @@
+package credentials
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestDiagnoseBuiltinReadinessMarksMissingCommandUnavailable(t *testing.T) {
+	t.Parallel()
+
+	readiness := diagnoseBuiltinReadiness("darwin", func(string) (string, error) {
+		return "", exec.ErrNotFound
+	})
+
+	if len(readiness.Providers) != 4 {
+		t.Fatalf("len(Providers) = %d, want 4", len(readiness.Providers))
+	}
+	if !readiness.ExecutionScopeRequired {
+		t.Fatal("ExecutionScopeRequired = false, want true")
+	}
+
+	keychain := readiness.Providers[2]
+	if keychain.Scheme != "keychain" || !keychain.Supported || keychain.Available || keychain.Error == "" {
+		t.Fatalf("keychain readiness = %+v", keychain)
+	}
+}

--- a/internal/storage/sqlite/diagnostics.go
+++ b/internal/storage/sqlite/diagnostics.go
@@ -97,13 +97,8 @@ func DiagnoseMigrations(ctx context.Context, cfg Config) MigrationDiagnostic {
 	return diagnostic
 }
 
-func readMigrationVersion(ctx context.Context, db *sql.DB, migrationsTable string) (uint, bool, error) {
-	var (
-		version uint
-		dirty   bool
-	)
-
-	err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT version, dirty FROM %s LIMIT 1`, migrationsTable)).Scan(&version, &dirty)
+func readMigrationVersion(ctx context.Context, db *sql.DB, migrationsTable string) (version uint, dirty bool, err error) {
+	err = db.QueryRowContext(ctx, fmt.Sprintf(`SELECT version, dirty FROM %s LIMIT 1`, migrationsTable)).Scan(&version, &dirty)
 	if err == nil {
 		return version, dirty, nil
 	}

--- a/internal/storage/sqlite/diagnostics.go
+++ b/internal/storage/sqlite/diagnostics.go
@@ -1,0 +1,168 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+type MigrationDiagnostic struct {
+	Path            string `json:"path"`
+	Exists          bool   `json:"exists"`
+	Ready           bool   `json:"ready"`
+	CurrentVersion  uint   `json:"currentVersion"`
+	LatestVersion   uint   `json:"latestVersion"`
+	Dirty           bool   `json:"dirty"`
+	Outstanding     []uint `json:"outstanding"`
+	Blocked         bool   `json:"blocked"`
+	BlockedReason   string `json:"blockedReason,omitempty"`
+	InspectionError string `json:"inspectionError,omitempty"`
+	MigrationsTable string `json:"migrationsTable"`
+}
+
+func DiagnoseMigrations(ctx context.Context, cfg Config) MigrationDiagnostic {
+	normalized, err := cfg.normalize()
+	if err != nil {
+		return MigrationDiagnostic{
+			Path:            cfg.Path,
+			InspectionError: err.Error(),
+		}
+	}
+
+	versions := embeddedMigrationVersions()
+	diagnostic := MigrationDiagnostic{
+		Path:            normalized.Path,
+		MigrationsTable: normalized.MigrationsTable,
+		LatestVersion:   latestMigrationVersion(versions),
+	}
+
+	info, err := os.Stat(normalized.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			diagnostic.Outstanding = append([]uint(nil), versions...)
+			return diagnostic
+		}
+		diagnostic.InspectionError = err.Error()
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+	if info.IsDir() {
+		diagnostic.Exists = true
+		diagnostic.InspectionError = fmt.Sprintf("sqlite path %q is a directory", normalized.Path)
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+	diagnostic.Exists = true
+
+	db, err := openDB(ctx, normalized)
+	if err != nil {
+		diagnostic.InspectionError = err.Error()
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+	defer db.Close()
+
+	if err := validateLegacySettingsUpgrade(ctx, db, normalized.MigrationsTable); err != nil {
+		diagnostic.Blocked = true
+		diagnostic.BlockedReason = err.Error()
+	}
+
+	tableExists, err := sqliteTableExists(ctx, db, normalized.MigrationsTable)
+	if err != nil {
+		diagnostic.InspectionError = err.Error()
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+	if !tableExists {
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+
+	version, dirty, err := readMigrationVersion(ctx, db, normalized.MigrationsTable)
+	if err != nil {
+		diagnostic.InspectionError = err.Error()
+		diagnostic.Outstanding = append([]uint(nil), versions...)
+		return diagnostic
+	}
+	diagnostic.CurrentVersion = version
+	diagnostic.Dirty = dirty
+	diagnostic.Outstanding = outstandingMigrations(versions, version, dirty)
+	diagnostic.Ready = !diagnostic.Blocked && diagnostic.InspectionError == "" && !diagnostic.Dirty && len(diagnostic.Outstanding) == 0
+
+	return diagnostic
+}
+
+func readMigrationVersion(ctx context.Context, db *sql.DB, migrationsTable string) (uint, bool, error) {
+	var (
+		version uint
+		dirty   bool
+	)
+
+	err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT version, dirty FROM %s LIMIT 1`, migrationsTable)).Scan(&version, &dirty)
+	if err == nil {
+		return version, dirty, nil
+	}
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	return 0, false, fmt.Errorf("sqlite: inspect migration state: %w", err)
+}
+
+func embeddedMigrationVersions() []uint {
+	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	if err != nil {
+		return nil
+	}
+
+	versions := make([]uint, 0, len(entries))
+	seen := map[uint]struct{}{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".up.sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(entry.Name(), "_")
+		if !ok {
+			continue
+		}
+		value, err := strconv.ParseUint(prefix, 10, 64)
+		if err != nil {
+			continue
+		}
+		version := uint(value)
+		if _, exists := seen[version]; exists {
+			continue
+		}
+		seen[version] = struct{}{}
+		versions = append(versions, version)
+	}
+	slices.Sort(versions)
+	return versions
+}
+
+func latestMigrationVersion(versions []uint) uint {
+	if len(versions) == 0 {
+		return 0
+	}
+	return versions[len(versions)-1]
+}
+
+func outstandingMigrations(versions []uint, current uint, dirty bool) []uint {
+	outstanding := make([]uint, 0, len(versions))
+	for _, version := range versions {
+		if dirty {
+			if version >= current {
+				outstanding = append(outstanding, version)
+			}
+			continue
+		}
+		if version > current {
+			outstanding = append(outstanding, version)
+		}
+	}
+	return outstanding
+}

--- a/internal/storage/sqlite/diagnostics_test.go
+++ b/internal/storage/sqlite/diagnostics_test.go
@@ -1,0 +1,24 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDiagnoseMigrationsReportsMissingDatabaseAsOutstanding(t *testing.T) {
+	t.Parallel()
+
+	diagnostic := DiagnoseMigrations(context.Background(), Config{Path: filepath.Join(t.TempDir(), "missing.db")})
+
+	if diagnostic.Exists {
+		t.Fatal("Exists = true, want false")
+	}
+	if diagnostic.Ready {
+		t.Fatal("Ready = true, want false")
+	}
+	if got, want := diagnostic.Outstanding, []uint{1, 2, 3}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Outstanding = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add `rein doctor` with machine-parseable JSON diagnostics for daemon reachability, instance layout, plugin compatibility, credential readiness, and SQLite migration state
- add reusable adapter/credential/sqlite diagnostic helpers and focused tests
- update CLI help and README for the new command

Closes #19