### PR TITLE
RN-23: bootstrap Claude Code adapter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "rein",
+  "plugins": [
+    {
+      "capabilities": {
+        "patch.apply": "true",
+        "pull_request": "true",
+        "shell.exec": "true"
+      },
+      "category": "codingAgent",
+      "daemonApiVersion": "rein.v1",
+      "description": "Claude Code coding-agent adapter bootstrap (separate repo).",
+      "name": "coding-claude-code",
+      "source": {
+        "ref": "main",
+        "repo": "earchibald/rein-adapter-claude-code",
+        "source": "github"
+      },
+      "version": "0.1.0"
+    }
+  ],
+  "signature": {
+    "algorithm": "ed25519",
+    "keyId": "rn23-marketplace-bootstrap",
+    "value": "FV/LN1bWx05WT6etZTMsJvhy1Esdgki9tHhXqwTXn5e95VcQzLKfRolxrqYTfdO9bdjlXxI0RRlGkoWbMu4EDQ=="
+  }
+}

--- a/.claude-plugin/trusted-keys.json
+++ b/.claude-plugin/trusted-keys.json
@@ -1,0 +1,9 @@
+{
+  "keys": [
+    {
+      "algorithm": "ed25519",
+      "id": "rn23-marketplace-bootstrap",
+      "publicKey": "FdtQ9oa/ZwmeNpmOH5tTsgOx4PD2xoL/sxwrHPIorQo="
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - Execution drilldown includes workflow steps, side effects, execution metadata, and looking-glass status for any adapter that advertises `capabilities.tail=true`.
 - Looking-glass tailing is capability-gated: when adapters advertise tail support but the daemon cannot stream it yet, the TUI shows that state instead of assuming live tail availability.
 
+## Marketplace bootstrap
+
+- Rein discovers adapters from `.claude-plugin/marketplace.json` at the repository root.
+- Repository-local signing keys live in `.claude-plugin/trusted-keys.json`; the daemon and `rein doctor` load them automatically before verifying the marketplace signature.
+- RN-23 boots the Claude Code coding-agent adapter as a remote GitHub marketplace entry (`earchibald/rein-adapter-claude-code`) instead of a local plugin checkout.
+- The registry and adapter APIs now surface that remote entry immediately; managed execution still reports an explicit “not wired yet” stub until the external adapter bridge lands.
+
 ## Development
 
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.

--- a/internal/adapter/diagnostics.go
+++ b/internal/adapter/diagnostics.go
@@ -39,12 +39,18 @@ type AdapterDiagnostic struct {
 }
 
 func Diagnose(root string, options DiscoveryOptions) Diagnostic {
-	options = options.withDefaults()
-
 	diagnostic := Diagnostic{
 		Root:            root,
 		MarketplacePath: filepath.Join(root, ".claude-plugin", "marketplace.json"),
 		RegistryReady:   true,
+	}
+
+	var err error
+	options, err = options.withRootDefaults(root)
+	if err != nil {
+		diagnostic.RegistryReady = false
+		diagnostic.Error = fmt.Sprintf("load trusted keys: %v", err)
+		return diagnostic
 	}
 
 	raw, err := os.ReadFile(diagnostic.MarketplacePath)

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -131,7 +131,11 @@ type pluginRecord struct {
 }
 
 func Load(root string, options DiscoveryOptions) (*Registry, error) {
-	options = options.withDefaults()
+	var err error
+	options, err = options.withRootDefaults(root)
+	if err != nil {
+		return nil, fmt.Errorf("load trusted keys: %w", err)
+	}
 
 	marketplacePath := filepath.Join(root, ".claude-plugin", "marketplace.json")
 	raw, err := os.ReadFile(marketplacePath)

--- a/internal/adapter/repository_marketplace_test.go
+++ b/internal/adapter/repository_marketplace_test.go
@@ -1,0 +1,57 @@
+package adapter
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/earchibald/rein/adaptertest"
+)
+
+type repositoryCodingAgentContract interface {
+	Run(context.Context, string) error
+}
+
+type repositoryCodingAgentStub struct{}
+
+func (*repositoryCodingAgentStub) Run(context.Context, string) error {
+	return nil
+}
+
+func TestRepositoryMarketplaceIncludesClaudeCodeBootstrap(t *testing.T) {
+	t.Parallel()
+
+	registry, err := Load(repositoryRoot(t), DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("Load(repositoryRoot) error = %v", err)
+	}
+
+	entry, ok := registry.Entry("coding-claude-code")
+	if !ok {
+		t.Fatal(`Entry("coding-claude-code") = !ok`)
+	}
+	if entry.Source.Kind != SourceGitHub {
+		t.Fatalf("source kind = %q, want %q", entry.Source.Kind, SourceGitHub)
+	}
+	if got, want := entry.Source.Repo, "earchibald/rein-adapter-claude-code"; got != want {
+		t.Fatalf("source repo = %q, want %q", got, want)
+	}
+
+	adaptertest.RunCodingAgent(t, adaptertest.Spec{
+		Descriptor:           entry.Descriptor,
+		Implementation:       &repositoryCodingAgentStub{},
+		Contract:             (*repositoryCodingAgentContract)(nil),
+		RequiredCapabilities: []string{"patch.apply", "pull_request", "shell.exec"},
+	})
+}
+
+func repositoryRoot(t testing.TB) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() = !ok")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/internal/adapter/trusted_keys.go
+++ b/internal/adapter/trusted_keys.go
@@ -1,0 +1,91 @@
+package adapter
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const trustedKeysPath = ".claude-plugin/trusted-keys.json"
+
+type trustedKeysDocument struct {
+	Keys []trustedKeyRecord `json:"keys"`
+}
+
+type trustedKeyRecord struct {
+	ID        string `json:"id"`
+	Algorithm string `json:"algorithm"`
+	PublicKey string `json:"publicKey"`
+}
+
+func (o DiscoveryOptions) withRootDefaults(root string) (DiscoveryOptions, error) {
+	options := o.withDefaults()
+
+	trustedKeys, err := loadTrustedKeys(root)
+	if err != nil {
+		return DiscoveryOptions{}, err
+	}
+	if len(trustedKeys) == 0 {
+		return options, nil
+	}
+
+	if len(options.TrustedKeys) == 0 {
+		options.TrustedKeys = trustedKeys
+		return options, nil
+	}
+
+	merged := make(map[string]ed25519.PublicKey, len(trustedKeys)+len(options.TrustedKeys))
+	for keyID, publicKey := range trustedKeys {
+		merged[keyID] = publicKey
+	}
+	for keyID, publicKey := range options.TrustedKeys {
+		merged[keyID] = publicKey
+	}
+	options.TrustedKeys = merged
+	return options, nil
+}
+
+func loadTrustedKeys(root string) (map[string]ed25519.PublicKey, error) {
+	raw, err := os.ReadFile(filepath.Join(root, trustedKeysPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read trusted keys: %w", err)
+	}
+
+	var document trustedKeysDocument
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return nil, fmt.Errorf("decode trusted keys: %w", err)
+	}
+
+	keys := make(map[string]ed25519.PublicKey, len(document.Keys))
+	for i, record := range document.Keys {
+		keyID := strings.TrimSpace(record.ID)
+		if keyID == "" {
+			return nil, fmt.Errorf("trusted keys[%d].id is required", i)
+		}
+		if record.Algorithm != "ed25519" {
+			return nil, fmt.Errorf("trusted key %q uses unsupported algorithm %q", keyID, record.Algorithm)
+		}
+		if _, exists := keys[keyID]; exists {
+			return nil, fmt.Errorf("trusted key %q is duplicated", keyID)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(record.PublicKey))
+		if err != nil {
+			return nil, fmt.Errorf("decode trusted key %q: %w", keyID, err)
+		}
+		if len(decoded) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("trusted key %q must decode to %d bytes", keyID, ed25519.PublicKeySize)
+		}
+		keys[keyID] = ed25519.PublicKey(decoded)
+	}
+
+	return keys, nil
+}

--- a/internal/adapter/trusted_keys_test.go
+++ b/internal/adapter/trusted_keys_test.go
@@ -1,0 +1,60 @@
+package adapter
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTrustedKeys(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	publicKey := privateKey().Public().(ed25519.PublicKey)
+	document := `{
+  "keys": [
+    {
+      "id": "fixture-key",
+      "algorithm": "ed25519",
+      "publicKey": "` + base64.StdEncoding.EncodeToString(publicKey) + `"
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(root, trustedKeysPath), []byte(document), 0o644); err != nil {
+		t.Fatalf("WriteFile(trusted-keys.json) error = %v", err)
+	}
+
+	keys, err := loadTrustedKeys(root)
+	if err != nil {
+		t.Fatalf("loadTrustedKeys() error = %v", err)
+	}
+	if got, want := len(keys), 1; got != want {
+		t.Fatalf("len(loadTrustedKeys()) = %d, want %d", got, want)
+	}
+	if got := base64.StdEncoding.EncodeToString(keys["fixture-key"]); got != base64.StdEncoding.EncodeToString(publicKey) {
+		t.Fatalf("fixture-key = %q, want %q", got, base64.StdEncoding.EncodeToString(publicKey))
+	}
+}
+
+func TestLoadTrustedKeysRejectsInvalidDocuments(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, trustedKeysPath), []byte(`{"keys":[{"id":"broken","algorithm":"rsa","publicKey":"Zm9v"}]}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(trusted-keys.json) error = %v", err)
+	}
+
+	_, err := loadTrustedKeys(root)
+	if err == nil || err.Error() != `trusted key "broken" uses unsupported algorithm "rsa"` {
+		t.Fatalf("loadTrustedKeys() error = %v, want unsupported algorithm error", err)
+	}
+}

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 
@@ -39,15 +40,16 @@ func (c *registryManagedCatalog) Lookup(id string) (ManagedAdapter, bool) {
 		return nil, false
 	}
 
-	descriptor, ok := c.registry.Get(id)
+	entry, ok := c.registry.Entry(id)
 	if !ok {
 		return nil, false
 	}
-	return &registryManagedAdapter{descriptor: descriptor}, true
+	return &registryManagedAdapter{descriptor: entry.Descriptor, source: entry.Source}, true
 }
 
 type registryManagedAdapter struct {
 	descriptor *reinv1.Adapter
+	source     adapter.Source
 }
 
 func (a *registryManagedAdapter) Descriptor() *reinv1.Adapter {
@@ -60,6 +62,12 @@ func (a *registryManagedAdapter) Descriptor() *reinv1.Adapter {
 func (a *registryManagedAdapter) Run(context.Context, *workflow.RuntimeState, workflow.Phase, workflow.Direction, *workflow.SideEffect) error {
 	if a == nil || a.descriptor == nil {
 		return fmt.Errorf("adapter execution is not configured")
+	}
+	if repo := strings.TrimSpace(a.source.Repo); a.source.Kind == adapter.SourceGitHub && repo != "" {
+		return fmt.Errorf("adapter %q is registered from GitHub repo %q, but remote managed execution is not wired into the daemon yet", a.descriptor.GetId(), repo)
+	}
+	if url := strings.TrimSpace(a.source.URL); (a.source.Kind == adapter.SourceURL || a.source.Kind == adapter.SourceGitSubdir) && url != "" {
+		return fmt.Errorf("adapter %q is registered from remote source %q, but remote managed execution is not wired into the daemon yet", a.descriptor.GetId(), url)
 	}
 	return fmt.Errorf("adapter %q does not support managed execution yet", a.descriptor.GetId())
 }

--- a/internal/service/managed_catalog_test.go
+++ b/internal/service/managed_catalog_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+func TestManagedCatalogRemoteAdapterReportsSourceRepo(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	document := map[string]any{
+		"name": "managed-catalog-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             "coding-claude-code",
+				"source":           map[string]any{"source": "github", "repo": "earchibald/rein-adapter-claude-code", "ref": "main"},
+				"version":          "0.1.0",
+				"description":      "Claude Code coding-agent bootstrap",
+				"category":         "codingAgent",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+				"capabilities": map[string]string{
+					"patch.apply":  "true",
+					"pull_request": "true",
+					"shell.exec":   "true",
+				},
+			},
+		},
+	}
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+
+	registry, err := adapter.Load(root, adapter.DiscoveryOptions{AllowUnsignedIndex: true})
+	if err != nil {
+		t.Fatalf("adapter.Load() error = %v", err)
+	}
+	managedAdapter, ok := NewManagedCatalog(registry).Lookup("coding-claude-code")
+	if !ok {
+		t.Fatal(`Lookup("coding-claude-code") = !ok`)
+	}
+
+	err = managedAdapter.Run(context.Background(), &workflow.RuntimeState{}, workflow.Phase{}, workflow.Direction(""), nil)
+	want := `adapter "coding-claude-code" is registered from GitHub repo "earchibald/rein-adapter-claude-code", but remote managed execution is not wired into the daemon yet`
+	if err == nil || err.Error() != want {
+		t.Fatalf("Run() error = %v, want %q", err, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a signed root marketplace entry and trusted-key discovery for the Claude Code coding-agent bootstrap
- make marketplace-backed managed adapters report explicit remote-source stub errors and cover the new seam with tests
- document the marketplace bootstrap and point the entry at the new external repo bootstrap

## Testing
- just lint
- just build
- just test
- just vet