### PR TITLE
RN-24: add messaging null adapter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,11 +17,19 @@
         "source": "github"
       },
       "version": "0.1.0"
+    },
+    {
+      "category": "messaging",
+      "daemonApiVersion": "rein.v1",
+      "description": "No-op managed messaging adapter stub.",
+      "name": "messaging-null",
+      "source": "./plugins/messaging-null",
+      "version": "0.1.0"
     }
   ],
   "signature": {
     "algorithm": "ed25519",
-    "keyId": "rn23-marketplace-bootstrap",
-    "value": "FV/LN1bWx05WT6etZTMsJvhy1Esdgki9tHhXqwTXn5e95VcQzLKfRolxrqYTfdO9bdjlXxI0RRlGkoWbMu4EDQ=="
+    "keyId": "rein-marketplace-phase4",
+    "value": "IniJumkkqBHuZ+e+R4FGpF2aG2a0HlGPOWMp+1TyQdGFWbn0AOR0OYoX2FixmOQeUM6yGVsO6timE7ckklmOBw=="
   }
 }

--- a/.claude-plugin/trusted-keys.json
+++ b/.claude-plugin/trusted-keys.json
@@ -2,8 +2,8 @@
   "keys": [
     {
       "algorithm": "ed25519",
-      "id": "rn23-marketplace-bootstrap",
-      "publicKey": "FdtQ9oa/ZwmeNpmOH5tTsgOx4PD2xoL/sxwrHPIorQo="
+      "id": "rein-marketplace-phase4",
+      "publicKey": "3NA0UhCPZCVOB1Wz8VW9CGTbmkn1tmgHhtUaUbRylqE="
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - Request flags map 1:1 to top-level gRPC request fields. Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
 - Responses are emitted as JSON using protobuf field names.
 
+## Adapter registry
+
+- The repo ships an unsigned local marketplace index at `.claude-plugin/marketplace.json` for built-in adapter discovery during local daemon and doctor runs.
+- `messaging-null` is a no-op notification adapter that advertises `messaging.post` so workflows can stay launchable until Slack and Discord adapters land.
+
 ## TUI
 
 - `rein tui` reads projects, issues, executions, workflow drilldown, and adapter capability state over the canonical gRPC API.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -149,7 +149,7 @@ func (a *app) serveDaemon(config daemonServeConfig) error {
 	}
 	defer store.Close()
 
-	catalog, err := service.NewManagedCatalogFromRoot(".", adapter.DiscoveryOptions{})
+	catalog, err := service.NewManagedCatalogFromRoot(".", adapter.LocalDiscoveryOptions())
 	if err != nil {
 		return fmt.Errorf("load adapter registry: %w", err)
 	}

--- a/cmd/rein/doctor.go
+++ b/cmd/rein/doctor.go
@@ -276,7 +276,7 @@ func diagnoseSocket(path string) doctorSocketDiagnostic {
 }
 
 func diagnosePlugins(root string) doctorPluginDiagnostic {
-	diagnostic := adapter.Diagnose(root, adapter.DiscoveryOptions{})
+	diagnostic := adapter.Diagnose(root, adapter.LocalDiscoveryOptions())
 
 	adapters := make([]doctorAdapterDiagnostic, 0, len(diagnostic.Adapters))
 	availableCount := 0

--- a/internal/adapter/local.go
+++ b/internal/adapter/local.go
@@ -1,0 +1,5 @@
+package adapter
+
+func LocalDiscoveryOptions() DiscoveryOptions {
+	return DiscoveryOptions{AllowUnsignedIndex: true}
+}

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -44,7 +44,23 @@ func (c *registryManagedCatalog) Lookup(id string) (ManagedAdapter, bool) {
 	if !ok {
 		return nil, false
 	}
+	if adapter, ok := builtinManagedAdapter(entry.Descriptor); ok {
+		return adapter, true
+	}
 	return &registryManagedAdapter{descriptor: entry.Descriptor, source: entry.Source}, true
+}
+
+func builtinManagedAdapter(descriptor *reinv1.Adapter) (ManagedAdapter, bool) {
+	if descriptor == nil {
+		return nil, false
+	}
+
+	switch descriptor.GetId() {
+	case messagingNullAdapterID:
+		return newManagedMessagingAdapter(descriptor, nil), true
+	default:
+		return nil, false
+	}
 }
 
 type registryManagedAdapter struct {

--- a/internal/service/messaging_adapter.go
+++ b/internal/service/messaging_adapter.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+const messagingNullAdapterID = "messaging-null"
+
+// MessagingAdapter is the minimal managed messaging seam for future Slack and
+// Discord adapters.
+type MessagingAdapter interface {
+	Post(context.Context, MessagingPost) (*MessagingReceipt, error)
+}
+
+type MessagingPost struct {
+	WorkflowID  string
+	IssueID     string
+	ExecutionID string
+	PhaseID     string
+	AdapterID   string
+	Operation   string
+	Direction   workflow.Direction
+	Inputs      map[string]string
+}
+
+type MessagingReceipt struct {
+	Delivery string
+	Metadata map[string]string
+}
+
+type managedMessagingAdapter struct {
+	descriptor *reinv1.Adapter
+	poster     MessagingAdapter
+}
+
+func newManagedMessagingAdapter(descriptor *reinv1.Adapter, poster MessagingAdapter) *managedMessagingAdapter {
+	if descriptor == nil {
+		descriptor = managedMessagingNullDescriptor()
+	}
+	if poster == nil {
+		poster = nullMessagingAdapter{}
+	}
+	return &managedMessagingAdapter{
+		descriptor: proto.Clone(descriptor).(*reinv1.Adapter),
+		poster:     poster,
+	}
+}
+
+func managedMessagingNullDescriptor() *reinv1.Adapter {
+	return &reinv1.Adapter{
+		Id:          messagingNullAdapterID,
+		Name:        "Messaging Null",
+		Category:    reinv1.AdapterCategory_ADAPTER_CATEGORY_NOTIFICATION,
+		Description: "No-op managed messaging adapter stub for workflows until Slack and Discord adapters land.",
+		Version:     "0.1.0",
+		Enabled:     true,
+		Capabilities: map[string]string{
+			"messaging.post": "true",
+		},
+	}
+}
+
+func (a *managedMessagingAdapter) Descriptor() *reinv1.Adapter {
+	if a == nil || a.descriptor == nil {
+		return nil
+	}
+	return proto.Clone(a.descriptor).(*reinv1.Adapter)
+}
+
+func (a *managedMessagingAdapter) Post(ctx context.Context, post MessagingPost) (*MessagingReceipt, error) {
+	if a == nil || a.descriptor == nil {
+		return nil, fmt.Errorf("adapter execution is not configured")
+	}
+	if a.poster == nil {
+		return nil, fmt.Errorf("messaging adapter %q does not support posting", a.descriptor.GetId())
+	}
+	return a.poster.Post(ctx, post)
+}
+
+func (a *managedMessagingAdapter) Run(ctx context.Context, state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, effect *workflow.SideEffect) error {
+	receipt, err := a.Post(ctx, newMessagingPost(state, phase, direction, effect))
+	if err != nil || receipt == nil || effect == nil {
+		return err
+	}
+
+	if effect.Outputs == nil {
+		effect.Outputs = map[string]string{}
+	}
+	if receipt.Delivery != "" {
+		effect.Outputs["delivery"] = receipt.Delivery
+	}
+	for key, value := range receipt.Metadata {
+		effect.Outputs[key] = value
+	}
+	return nil
+}
+
+func newMessagingPost(state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, effect *workflow.SideEffect) MessagingPost {
+	post := MessagingPost{
+		PhaseID:   phase.ID,
+		AdapterID: phase.AdapterID,
+		Operation: phase.Operation,
+		Direction: direction,
+		Inputs:    cloneMap(phase.Inputs),
+	}
+	if state != nil {
+		if state.Workflow != nil {
+			post.WorkflowID = state.Workflow.GetId()
+		}
+		if state.Issue != nil {
+			post.IssueID = state.Issue.GetId()
+		}
+		if state.Execution != nil {
+			post.ExecutionID = state.Execution.GetId()
+		}
+	}
+	if effect == nil {
+		return post
+	}
+	if effect.WorkflowID != "" {
+		post.WorkflowID = effect.WorkflowID
+	}
+	if effect.IssueID != "" {
+		post.IssueID = effect.IssueID
+	}
+	if effect.ExecutionID != "" {
+		post.ExecutionID = effect.ExecutionID
+	}
+	if effect.Operation != "" {
+		post.Operation = effect.Operation
+	}
+	if len(effect.Inputs) > 0 {
+		post.Inputs = cloneMap(effect.Inputs)
+	}
+	return post
+}
+
+type nullMessagingAdapter struct{}
+
+func (nullMessagingAdapter) Post(context.Context, MessagingPost) (*MessagingReceipt, error) {
+	return &MessagingReceipt{Delivery: "noop"}, nil
+}

--- a/internal/service/messaging_adapter_test.go
+++ b/internal/service/messaging_adapter_test.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+	"github.com/earchibald/rein/internal/workflow"
+
+	"github.com/earchibald/rein/adaptertest"
+)
+
+func TestManagedMessagingNullAdapterConformance(t *testing.T) {
+	t.Parallel()
+
+	messaging := newManagedMessagingAdapter(managedMessagingNullDescriptor(), nil)
+	adaptertest.RunNotification(t, adaptertest.Spec{
+		Descriptor:           messaging.Descriptor(),
+		Implementation:       messaging,
+		Contract:             (*MessagingAdapter)(nil),
+		RequiredCapabilities: []string{"messaging.post"},
+		Validate: func(tb testing.TB, _ *reinv1.Adapter, implementation any) {
+			tb.Helper()
+
+			adapter, ok := implementation.(MessagingAdapter)
+			if !ok {
+				tb.Fatalf("implementation type = %T, want MessagingAdapter", implementation)
+			}
+			receipt, err := adapter.Post(context.Background(), MessagingPost{Operation: "post"})
+			if err != nil {
+				tb.Fatalf("Post() error = %v", err)
+			}
+			if got, want := receipt.Delivery, "noop"; got != want {
+				tb.Fatalf("Post() delivery = %q, want %q", got, want)
+			}
+		},
+	})
+}
+
+func TestManagedMessagingAdapterRunUsesMessagingSeam(t *testing.T) {
+	t.Parallel()
+
+	poster := &capturingMessagingAdapter{
+		receipt: &MessagingReceipt{
+			Delivery: "queued",
+			Metadata: map[string]string{"target": "release-room"},
+		},
+	}
+	messaging := newManagedMessagingAdapter(managedMessagingNullDescriptor(), poster)
+	state := &workflow.RuntimeState{
+		Workflow:  &reinv1.Workflow{Id: "workflow-release"},
+		Issue:     &reinv1.Issue{Id: "RN-24"},
+		Execution: &reinv1.Execution{Id: "exec-rn-24-001"},
+	}
+	phase := workflow.Phase{
+		ID:        "notify",
+		AdapterID: messagingNullAdapterID,
+		Operation: "post",
+		Inputs:    map[string]string{"channel": "release-room", "text": "ready"},
+	}
+	effect := &workflow.SideEffect{
+		WorkflowID:  state.Workflow.GetId(),
+		IssueID:     state.Issue.GetId(),
+		ExecutionID: state.Execution.GetId(),
+		Operation:   "post",
+		Inputs:      map[string]string{"channel": "release-room", "text": "ready"},
+	}
+
+	if err := messaging.Run(context.Background(), state, phase, workflow.DirectionForward, effect); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := poster.post.WorkflowID, state.Workflow.GetId(); got != want {
+		t.Fatalf("Post() workflow_id = %q, want %q", got, want)
+	}
+	if got, want := poster.post.Operation, "post"; got != want {
+		t.Fatalf("Post() operation = %q, want %q", got, want)
+	}
+	if got, want := poster.post.Inputs["channel"], "release-room"; got != want {
+		t.Fatalf("Post() channel = %q, want %q", got, want)
+	}
+	if got, want := effect.Outputs["delivery"], "queued"; got != want {
+		t.Fatalf("effect output delivery = %q, want %q", got, want)
+	}
+	if got, want := effect.Outputs["target"], "release-room"; got != want {
+		t.Fatalf("effect output target = %q, want %q", got, want)
+	}
+}
+
+func TestManagedExecutionServerStartsWorkflowWithMessagingNullAdapter(t *testing.T) {
+	t.Parallel()
+
+	root := writeManagedMessagingFixture(t)
+	catalog, err := NewManagedCatalogFromRoot(root, adapter.LocalDiscoveryOptions())
+	if err != nil {
+		t.Fatalf("NewManagedCatalogFromRoot() error = %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := sqlite.OpenInMemoryAndMigrate(ctx, t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	})
+
+	issue := &reinv1.Issue{
+		Id:         "RN-24",
+		ProjectId:  "rein",
+		Title:      "Messaging stub",
+		WorkflowId: "workflow-messaging-null",
+	}
+	definition := &reinv1.Workflow{
+		Id:      "workflow-messaging-null",
+		Name:    "Messaging null workflow",
+		Version: "v1",
+		Steps: []*reinv1.WorkflowStep{
+			{
+				Id:        "notify",
+				Name:      "Notify",
+				AdapterId: messagingNullAdapterID,
+				Inputs: map[string]string{
+					workflow.InputOperation: "post",
+					"channel":               "release-room",
+				},
+			},
+		},
+	}
+	if _, err := createStoredProto(ctx, store, sqlite.IssueKind, issue.GetId(), issue); err != nil {
+		t.Fatalf("createStoredProto(issue) error = %v", err)
+	}
+	if _, err := createStoredProto(ctx, store, sqlite.WorkflowKind, definition.GetId(), definition); err != nil {
+		t.Fatalf("createStoredProto(workflow) error = %v", err)
+	}
+
+	server := &ManagedExecutionServer{
+		catalog: catalog,
+		engine:  workflow.New(store),
+		store:   store,
+	}
+	resp, err := server.StartExecution(ctx, &reinv1.StartExecutionRequest{
+		IssueId:     issue.GetId(),
+		WorkflowId:  definition.GetId(),
+		RequestedBy: "copilot",
+	})
+	if err != nil {
+		t.Fatalf("StartExecution() error = %v", err)
+	}
+	if got, want := resp.GetExecution().GetStatus(), reinv1.ExecutionStatus_EXECUTION_STATUS_SUCCEEDED; got != want {
+		t.Fatalf("StartExecution() status = %s, want %s", got, want)
+	}
+
+	effects, err := server.engine.ListSideEffects(ctx, resp.GetExecution().GetId())
+	if err != nil {
+		t.Fatalf("ListSideEffects() error = %v", err)
+	}
+	if len(effects) != 1 {
+		t.Fatalf("ListSideEffects() len = %d, want 1", len(effects))
+	}
+	if got, want := effects[0].Outputs["delivery"], "noop"; got != want {
+		t.Fatalf("side effect delivery = %q, want %q", got, want)
+	}
+}
+
+type capturingMessagingAdapter struct {
+	post    MessagingPost
+	receipt *MessagingReceipt
+	err     error
+}
+
+func (a *capturingMessagingAdapter) Post(_ context.Context, post MessagingPost) (*MessagingReceipt, error) {
+	a.post = post
+	return a.receipt, a.err
+}
+
+func writeManagedMessagingFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	mustServiceMkdirAll(t, filepath.Join(root, ".claude-plugin"))
+	writeServiceManifest(t, root, messagingNullAdapterID, map[string]any{
+		"name":             messagingNullAdapterID,
+		"version":          "0.1.0",
+		"description":      "No-op managed messaging adapter stub.",
+		"category":         "messaging",
+		"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"messaging.post": "true",
+		},
+	})
+
+	document := map[string]any{
+		"name": "rein-managed-messaging-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             messagingNullAdapterID,
+				"source":           "./plugins/messaging-null",
+				"version":          "0.1.0",
+				"description":      "No-op managed messaging adapter stub.",
+				"category":         "messaging",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+			},
+		},
+	}
+
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+	return root
+}

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -16,7 +16,7 @@ type Set struct {
 }
 
 func NewSet() Set {
-	adapterServer, _ := NewAdapterServerFromRoot(".", adapter.DiscoveryOptions{})
+	adapterServer, _ := NewAdapterServerFromRoot(".", adapter.LocalDiscoveryOptions())
 	return Set{
 		Adapter:   adapterServer,
 		Execution: ExecutionServer{},
@@ -39,7 +39,7 @@ func NewSetFromRoot(root string, options adapter.DiscoveryOptions) (Set, error) 
 
 func (s Set) WithDefaults() Set {
 	if s.Adapter == nil {
-		adapterServer, _ := NewAdapterServerFromRoot(".", adapter.DiscoveryOptions{})
+		adapterServer, _ := NewAdapterServerFromRoot(".", adapter.LocalDiscoveryOptions())
 		s.Adapter = adapterServer
 	}
 	if s.Execution == nil {

--- a/plugins/messaging-null/.claude-plugin/plugin.json
+++ b/plugins/messaging-null/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "messaging-null",
+  "version": "0.1.0",
+  "description": "No-op managed messaging adapter stub.",
+  "category": "messaging",
+  "daemonApiVersion": "rein.v1",
+  "capabilities": {
+    "messaging.post": "true"
+  }
+}


### PR DESCRIPTION
## Summary
- add a built-in managed messaging null adapter with a minimal post seam for future Slack/Discord work
- register the adapter via local marketplace/manifest metadata and allow local unsigned discovery for daemon/doctor flows
- add focused messaging adapter tests and execution coverage

## Testing
- just ci
- go run ./cmd/rein doctor | python3 -c 'import json,sys; data=json.load(sys.stdin); print(json.dumps(data["plugins"], indent=2))'