### PR TITLE
RN-21: add bundled muxiterm mux adapter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,11 +25,19 @@
       "name": "messaging-null",
       "source": "./plugins/messaging-null",
       "version": "0.1.0"
+    },
+    {
+      "category": "mux",
+      "daemonApiVersion": "rein.v1",
+      "description": "First-party mux adapter backed by the muxiterm JSON CLI.",
+      "name": "muxiterm",
+      "source": "./plugins/muxiterm",
+      "version": "0.9.0"
     }
   ],
   "signature": {
     "algorithm": "ed25519",
-    "keyId": "rein-marketplace-phase4",
-    "value": "IniJumkkqBHuZ+e+R4FGpF2aG2a0HlGPOWMp+1TyQdGFWbn0AOR0OYoX2FixmOQeUM6yGVsO6timE7ckklmOBw=="
+    "keyId": "rein-marketplace-phase4b",
+    "value": "HJk3K9IYNJk3WKTu43FIjbF61JmH9yiWFmLAnBEbryF1Nw0NpgPgXeydl3TE3r9eYqeAkn+UQt3Nq0eR+QPRAw=="
   }
 }

--- a/.claude-plugin/trusted-keys.json
+++ b/.claude-plugin/trusted-keys.json
@@ -2,8 +2,8 @@
   "keys": [
     {
       "algorithm": "ed25519",
-      "id": "rein-marketplace-phase4",
-      "publicKey": "3NA0UhCPZCVOB1Wz8VW9CGTbmkn1tmgHhtUaUbRylqE="
+      "id": "rein-marketplace-phase4b",
+      "publicKey": "Wks1syNv/haTCWXu53mXFa0zm470mwPu16RXPOPZl4U="
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 
 ## Adapter registry
 
-- The repo ships an unsigned local marketplace index at `.claude-plugin/marketplace.json` for built-in adapter discovery during local daemon and doctor runs.
+- The repo ships a signed marketplace index at `.claude-plugin/marketplace.json` for built-in and remote adapter discovery.
+- Repository-local trusted public keys live at `.claude-plugin/trusted-keys.json`; the daemon and `rein doctor` load them automatically before verifying marketplace signatures.
 - `messaging-null` is a no-op notification adapter that advertises `messaging.post` so workflows can stay launchable until Slack and Discord adapters land.
+- The in-tree `muxiterm` multiplexer adapter manifest lives at `plugins/muxiterm/.claude-plugin/plugin.json` and advertises the bundled mux capability surface.
 
 ## TUI
 
@@ -37,7 +39,6 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 ## Marketplace bootstrap
 
 - Rein discovers adapters from `.claude-plugin/marketplace.json` at the repository root.
-- Repository-local signing keys live in `.claude-plugin/trusted-keys.json`; the daemon and `rein doctor` load them automatically before verifying the marketplace signature.
 - RN-23 boots the Claude Code coding-agent adapter as a remote GitHub marketplace entry (`earchibald/rein-adapter-claude-code`) instead of a local plugin checkout.
 - The registry and adapter APIs now surface that remote entry immediately; managed execution still reports an explicit “not wired yet” stub until the external adapter bridge lands.
 

--- a/internal/adapter/muxiterm/adapter.go
+++ b/internal/adapter/muxiterm/adapter.go
@@ -1,0 +1,384 @@
+package muxiterm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+const (
+	AdapterID = "muxiterm"
+
+	inputArgv = "argv"
+	inputCWD  = "cwd"
+	inputEnv  = "env"
+)
+
+var workflowReservedInputs = map[string]struct{}{
+	workflow.InputLane:              {},
+	workflow.InputLaneAttach:        {},
+	workflow.InputOperation:         {},
+	workflow.InputBail:              {},
+	workflow.InputOnCancel:          {},
+	workflow.InputBackwardOperation: {},
+	workflow.InputBackwardTo:        {},
+}
+
+type Command struct {
+	Path string
+	Args []string
+	Dir  string
+	Env  []string
+}
+
+type Result struct {
+	Stdout string
+	Stderr string
+}
+
+type Executor interface {
+	Run(context.Context, Command) (Result, error)
+}
+
+type Adapter struct {
+	descriptor *reinv1.Adapter
+	binary     string
+	executor   Executor
+}
+
+func DefaultDescriptor() *reinv1.Adapter {
+	return &reinv1.Adapter{
+		Id:          AdapterID,
+		Name:        "muxiterm",
+		Category:    reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER,
+		Description: "First-party mux adapter that wraps the muxiterm JSON CLI.",
+		Version:     "0.9.0",
+		Enabled:     true,
+		Capabilities: map[string]string{
+			"session.attach": "true",
+			"pane.split":     "true",
+			"input.send":     "true",
+			"tail":           "true",
+		},
+	}
+}
+
+func New() *Adapter {
+	return NewWithExecutor("muxiterm", osExecutor{})
+}
+
+func NewWithExecutor(binary string, executor Executor) *Adapter {
+	if strings.TrimSpace(binary) == "" {
+		binary = "muxiterm"
+	}
+	if executor == nil {
+		executor = osExecutor{}
+	}
+	return &Adapter{
+		descriptor: DefaultDescriptor(),
+		binary:     binary,
+		executor:   executor,
+	}
+}
+
+func (a *Adapter) WithDescriptor(descriptor *reinv1.Adapter) *Adapter {
+	cloned := *a
+	if descriptor == nil {
+		cloned.descriptor = DefaultDescriptor()
+		return &cloned
+	}
+	cloned.descriptor = proto.Clone(descriptor).(*reinv1.Adapter)
+	return &cloned
+}
+
+func (a *Adapter) Descriptor() *reinv1.Adapter {
+	if a == nil || a.descriptor == nil {
+		return DefaultDescriptor()
+	}
+	return proto.Clone(a.descriptor).(*reinv1.Adapter)
+}
+
+func (a *Adapter) Run(ctx context.Context, state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, effect *workflow.SideEffect) error {
+	if effect == nil {
+		return errors.New("muxiterm side effect is required")
+	}
+
+	operation, err := operationForDirection(phase, direction)
+	if err != nil {
+		return err
+	}
+
+	command, err := a.buildCommand(state, phase, direction, operation)
+	if err != nil {
+		return err
+	}
+
+	result, execErr := a.executor.Run(ctx, command)
+	outputs, envelopeErr := parseOutputs(command, result.Stdout, result.Stderr)
+	if envelopeErr == nil {
+		effect.Outputs = outputs
+	}
+
+	if execErr != nil {
+		if envelopeErr == nil {
+			return failureFromOutputs(operation, outputs, execErr)
+		}
+		return fmt.Errorf("muxiterm %s: %w", operation, execErr)
+	}
+	if envelopeErr != nil {
+		return fmt.Errorf("muxiterm %s: %w", operation, envelopeErr)
+	}
+	if outputs["ok"] == "false" {
+		return failureFromOutputs(operation, outputs, nil)
+	}
+
+	effect.Outputs = outputs
+	return nil
+}
+
+func (a *Adapter) buildCommand(state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, operation string) (Command, error) {
+	inputs := phase.Inputs
+	positionals, err := parseJSONArray(inputs[inputArgv])
+	if err != nil {
+		return Command{}, fmt.Errorf("muxiterm argv: %w", err)
+	}
+	envValues, err := parseJSONObject(inputs[inputEnv])
+	if err != nil {
+		return Command{}, fmt.Errorf("muxiterm env: %w", err)
+	}
+
+	args := append([]string(nil), strings.Fields(operation)...)
+	args = append(args, positionals...)
+
+	flagKeys := make([]string, 0, len(inputs))
+	for key := range inputs {
+		switch key {
+		case inputArgv, inputCWD, inputEnv:
+			continue
+		}
+		if _, reserved := workflowReservedInputs[key]; reserved {
+			continue
+		}
+		flagKeys = append(flagKeys, key)
+	}
+	sort.Strings(flagKeys)
+	for _, key := range flagKeys {
+		value := strings.TrimSpace(inputs[key])
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			if parsed {
+				args = append(args, "--"+key)
+			}
+			continue
+		}
+		args = append(args, "--"+key, value)
+	}
+
+	envKeys := make([]string, 0, len(envValues)+7)
+	for key := range envValues {
+		envKeys = append(envKeys, key)
+	}
+	addRuntimeEnv(envValues, state, phase, direction, operation)
+	envKeys = envKeys[:0]
+	for key := range envValues {
+		envKeys = append(envKeys, key)
+	}
+	sort.Strings(envKeys)
+
+	env := make([]string, 0, len(envKeys))
+	for _, key := range envKeys {
+		env = append(env, key+"="+envValues[key])
+	}
+
+	return Command{
+		Path: a.binary,
+		Args: args,
+		Dir:  strings.TrimSpace(inputs[inputCWD]),
+		Env:  env,
+	}, nil
+}
+
+func operationForDirection(phase workflow.Phase, direction workflow.Direction) (string, error) {
+	if direction == workflow.DirectionBackward {
+		if operation := strings.TrimSpace(phase.BackwardOperation); operation != "" {
+			return operation, nil
+		}
+	}
+	if operation := strings.TrimSpace(phase.Operation); operation != "" {
+		return operation, nil
+	}
+	return "", errors.New("muxiterm operation is required")
+}
+
+func addRuntimeEnv(env map[string]string, state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, operation string) {
+	env["REIN_ADAPTER_ID"] = AdapterID
+	env["REIN_PHASE_ID"] = phase.ID
+	env["REIN_DIRECTION"] = string(direction)
+	env["REIN_OPERATION"] = operation
+	if state == nil {
+		return
+	}
+	if state.Execution != nil {
+		env["REIN_EXECUTION_ID"] = state.Execution.GetId()
+	}
+	if state.Issue != nil {
+		env["REIN_ISSUE_ID"] = state.Issue.GetId()
+	}
+	if state.Workflow != nil {
+		env["REIN_WORKFLOW_ID"] = state.Workflow.GetId()
+	}
+}
+
+func parseJSONArray(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, errors.New("must be a JSON array of strings")
+	}
+	return values, nil
+}
+
+func parseJSONObject(raw string) (map[string]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]string{}, nil
+	}
+	var values map[string]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, errors.New("must be a JSON object of string values")
+	}
+	return values, nil
+}
+
+func parseOutputs(command Command, stdout, stderr string) (map[string]string, error) {
+	outputs := map[string]string{
+		"command": strings.Join(append([]string{command.Path}, command.Args...), " "),
+	}
+	if command.Dir != "" {
+		outputs["cwd"] = command.Dir
+	}
+	if strings.TrimSpace(stderr) != "" {
+		outputs["stderr"] = strings.TrimSpace(stderr)
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return outputs, nil
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		return nil, fmt.Errorf("decode muxiterm response: %w", err)
+	}
+
+	outputs["json"] = strings.TrimSpace(stdout)
+	for key, value := range envelope {
+		switch key {
+		case "error":
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return nil, fmt.Errorf("encode muxiterm error payload: %w", err)
+			}
+			outputs[key] = string(encoded)
+		default:
+			outputs[key] = stringify(value)
+		}
+	}
+	return outputs, nil
+}
+
+func stringify(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		return strconv.FormatBool(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprint(typed)
+		}
+		return string(encoded)
+	}
+}
+
+func failureFromOutputs(operation string, outputs map[string]string, fallback error) error {
+	code, message, hint := "", "", ""
+	if raw := strings.TrimSpace(outputs["error"]); raw != "" {
+		var payload struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Hint    string `json:"hint"`
+		}
+		if err := json.Unmarshal([]byte(raw), &payload); err == nil {
+			code = payload.Code
+			message = payload.Message
+			hint = payload.Hint
+		}
+	}
+	if message == "" && fallback != nil {
+		message = fallback.Error()
+	}
+	if message == "" {
+		message = "command failed"
+	}
+
+	var builder strings.Builder
+	builder.WriteString("muxiterm ")
+	builder.WriteString(operation)
+	builder.WriteString(": ")
+	if code != "" {
+		builder.WriteString(code)
+		builder.WriteString(": ")
+	}
+	builder.WriteString(message)
+	if hint != "" {
+		builder.WriteString(" (")
+		builder.WriteString(hint)
+		builder.WriteString(")")
+	}
+	return errors.New(builder.String())
+}
+
+type osExecutor struct{}
+
+func (osExecutor) Run(ctx context.Context, command Command) (Result, error) {
+	const binary = "muxiterm"
+	if path := strings.TrimSpace(command.Path); path != "" && path != binary {
+		return Result{}, fmt.Errorf("unsupported muxiterm binary %q", command.Path)
+	}
+
+	//nolint:gosec // The adapter's job is to translate workflow inputs into the fixed muxiterm CLI surface.
+	cmd := exec.CommandContext(ctx, binary, command.Args...)
+	if command.Dir != "" {
+		cmd.Dir = command.Dir
+	}
+	if len(command.Env) > 0 {
+		cmd.Env = append(os.Environ(), command.Env...)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return Result{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}, err
+}

--- a/internal/adapter/muxiterm/adapter_test.go
+++ b/internal/adapter/muxiterm/adapter_test.go
@@ -1,0 +1,147 @@
+package muxiterm
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/earchibald/rein/adaptertest"
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+type multiplexerContract interface {
+	Descriptor() *reinv1.Adapter
+	Run(context.Context, *workflow.RuntimeState, workflow.Phase, workflow.Direction, *workflow.SideEffect) error
+}
+
+func TestAdapterConformance(t *testing.T) {
+	t.Parallel()
+
+	adaptertest.RunMultiplexer(t, adaptertest.Spec{
+		Descriptor:           DefaultDescriptor(),
+		Implementation:       NewWithExecutor("muxiterm", &fakeExecutor{}),
+		Contract:             (*multiplexerContract)(nil),
+		RequiredCapabilities: []string{"session.attach", "pane.split", "input.send", "tail"},
+	})
+}
+
+func TestRunExecutesMuxitermAndCapturesOutputs(t *testing.T) {
+	t.Parallel()
+
+	executor := &fakeExecutor{
+		result: Result{
+			Stdout: `{"ok":true,"session":"dev","focused":true,"panes":["left","right"]}`,
+			Stderr: "debug trace",
+		},
+	}
+	adapter := NewWithExecutor("muxiterm", executor)
+	effect := &workflow.SideEffect{}
+
+	err := adapter.Run(context.Background(), &workflow.RuntimeState{
+		Workflow:  &reinv1.Workflow{Id: "wf-1"},
+		Issue:     &reinv1.Issue{Id: "RN-21"},
+		Execution: &reinv1.Execution{Id: "exec-rn-21-001"},
+	}, workflow.Phase{
+		ID:        "mux-step",
+		Operation: "tmux detect",
+		Inputs: map[string]string{
+			"argv":             `["workspace-a"]`,
+			"backend":          "tmux",
+			"debug":            "true",
+			"cwd":              "/repo/worktree",
+			"env":              `{"MUXITERM_BACKEND":"tmux"}`,
+			workflow.InputBail: "true",
+		},
+	}, workflow.DirectionForward, effect)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if got, want := executor.command.Path, "muxiterm"; got != want {
+		t.Fatalf("command.Path = %q, want %q", got, want)
+	}
+	if got, want := executor.command.Args, []string{"tmux", "detect", "workspace-a", "--backend", "tmux", "--debug"}; !slices.Equal(got, want) {
+		t.Fatalf("command.Args = %v, want %v", got, want)
+	}
+	if got, want := executor.command.Dir, "/repo/worktree"; got != want {
+		t.Fatalf("command.Dir = %q, want %q", got, want)
+	}
+	if !slices.Contains(executor.command.Env, "MUXITERM_BACKEND=tmux") || !slices.Contains(executor.command.Env, "REIN_EXECUTION_ID=exec-rn-21-001") {
+		t.Fatalf("command.Env = %v, want muxiterm and rein context", executor.command.Env)
+	}
+	if got := effect.Outputs["session"]; got != "dev" {
+		t.Fatalf("effect.Outputs[session] = %q, want %q", got, "dev")
+	}
+	if got := effect.Outputs["focused"]; got != "true" {
+		t.Fatalf("effect.Outputs[focused] = %q, want %q", got, "true")
+	}
+	if got := effect.Outputs["panes"]; got != `["left","right"]` {
+		t.Fatalf("effect.Outputs[panes] = %q, want %q", got, `["left","right"]`)
+	}
+	if got := effect.Outputs["stderr"]; got != "debug trace" {
+		t.Fatalf("effect.Outputs[stderr] = %q, want %q", got, "debug trace")
+	}
+}
+
+func TestRunUsesBackwardOperation(t *testing.T) {
+	t.Parallel()
+
+	executor := &fakeExecutor{result: Result{Stdout: `{"ok":true}`}}
+	adapter := NewWithExecutor("muxiterm", executor)
+
+	err := adapter.Run(context.Background(), nil, workflow.Phase{
+		ID:                "mux-step",
+		Operation:         "tmux detect",
+		BackwardOperation: "registry release",
+	}, workflow.DirectionBackward, &workflow.SideEffect{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := executor.command.Args, []string{"registry", "release"}; !slices.Equal(got, want) {
+		t.Fatalf("command.Args = %v, want %v", got, want)
+	}
+}
+
+func TestRunReturnsMuxitermEnvelopeFailures(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewWithExecutor("muxiterm", &fakeExecutor{
+		result: Result{
+			Stdout: `{"ok":false,"error":{"code":"tmux-error","message":"tmux missing","hint":"install tmux"}}`,
+		},
+		err: errors.New("exit status 2"),
+	})
+
+	err := adapter.Run(context.Background(), nil, workflow.Phase{
+		ID:        "mux-step",
+		Operation: "tmux detect",
+	}, workflow.DirectionForward, &workflow.SideEffect{})
+	want := "muxiterm tmux detect: tmux-error: tmux missing (install tmux)"
+	if err == nil || err.Error() != want {
+		t.Fatalf("Run() error = %v, want %q", err, want)
+	}
+}
+
+func TestRunRejectsMissingOperation(t *testing.T) {
+	t.Parallel()
+
+	err := NewWithExecutor("muxiterm", &fakeExecutor{}).Run(context.Background(), nil, workflow.Phase{
+		ID: "mux-step",
+	}, workflow.DirectionForward, &workflow.SideEffect{})
+	if err == nil || err.Error() != "muxiterm operation is required" {
+		t.Fatalf("Run() error = %v, want %q", err, "muxiterm operation is required")
+	}
+}
+
+type fakeExecutor struct {
+	command Command
+	result  Result
+	err     error
+}
+
+func (f *fakeExecutor) Run(_ context.Context, command Command) (Result, error) {
+	f.command = command
+	return f.result, f.err
+}

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -299,9 +299,6 @@ func (o DiscoveryOptions) withDefaults() DiscoveryOptions {
 	if strings.TrimSpace(o.DaemonAPIVersion) == "" {
 		o.DaemonAPIVersion = CurrentDaemonAPIVersion
 	}
-	if o.TrustedKeys == nil {
-		o.TrustedKeys = map[string]ed25519.PublicKey{}
-	}
 	return o
 }
 

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -161,6 +162,30 @@ func TestNormalizeCategoryAliases(t *testing.T) {
 				t.Fatalf("NormalizeCategory() = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLoadRepositoryMarketplaceMuxitermEntry(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	registry, err := Load(root, DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("Load(repo root) error = %v", err)
+	}
+
+	entry, ok := registry.Entry("muxiterm")
+	if !ok {
+		t.Fatal(`Entry("muxiterm") = !ok`)
+	}
+	if entry.MarketplaceCategory != CategoryMux {
+		t.Fatalf("MarketplaceCategory = %q, want %q", entry.MarketplaceCategory, CategoryMux)
+	}
+	if got := entry.Descriptor.GetCategory(); got != reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER {
+		t.Fatalf("Descriptor.Category = %s, want %s", got, reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER)
+	}
+	if got := entry.Descriptor.GetCapabilities()["tail"]; got != "true" {
+		t.Fatalf(`Descriptor.Capabilities["tail"] = %q, want %q`, got, "true")
 	}
 }
 
@@ -343,4 +368,14 @@ func trustedKeys() map[string]ed25519.PublicKey {
 func privateKey() ed25519.PrivateKey {
 	seed := []byte("rein-rn11-marketplace-signing-se")
 	return ed25519.NewKeyFromSeed(seed)
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller() = !ok")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 }

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
 
 	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
 	"github.com/earchibald/rein/internal/adapter"
+	muxadapter "github.com/earchibald/rein/internal/adapter/muxiterm"
 	"github.com/earchibald/rein/internal/workflow"
 )
 
@@ -21,26 +23,66 @@ func NewManagedCatalogFromRoot(root string, options adapter.DiscoveryOptions) (M
 }
 
 func NewManagedCatalog(registry *adapter.Registry) ManagedCatalog {
-	return &registryManagedCatalog{registry: registry}
+	return &registryManagedCatalog{
+		registry: registry,
+		builtIns: map[string]func(*reinv1.Adapter) ManagedAdapter{
+			muxadapter.AdapterID: func(descriptor *reinv1.Adapter) ManagedAdapter {
+				managed := muxadapter.New()
+				if descriptor != nil {
+					return managed.WithDescriptor(descriptor)
+				}
+				return managed
+			},
+		},
+	}
 }
 
 type registryManagedCatalog struct {
 	registry *adapter.Registry
+	builtIns map[string]func(*reinv1.Adapter) ManagedAdapter
 }
 
 func (c *registryManagedCatalog) List() []*reinv1.Adapter {
-	if c == nil || c.registry == nil {
+	if c == nil {
 		return nil
 	}
-	return c.registry.List(reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED, false)
+
+	descriptors := map[string]*reinv1.Adapter{}
+	if c.registry != nil {
+		for _, descriptor := range c.registry.List(reinv1.AdapterCategory_ADAPTER_CATEGORY_UNSPECIFIED, false) {
+			descriptors[descriptor.GetId()] = descriptor
+		}
+	}
+	for id, factory := range c.builtIns {
+		descriptors[id] = factory(descriptors[id]).Descriptor()
+	}
+
+	ids := make([]string, 0, len(descriptors))
+	for id := range descriptors {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	list := make([]*reinv1.Adapter, 0, len(ids))
+	for _, id := range ids {
+		list = append(list, descriptors[id])
+	}
+	return list
 }
 
 func (c *registryManagedCatalog) Lookup(id string) (ManagedAdapter, bool) {
-	if c == nil || c.registry == nil {
+	if c == nil {
 		return nil, false
 	}
 
-	entry, ok := c.registry.Entry(id)
+	var entry adapter.Entry
+	var ok bool
+	if c.registry != nil {
+		entry, ok = c.registry.Entry(id)
+	}
+	if factory, builtIn := c.builtIns[id]; builtIn {
+		return factory(entry.Descriptor), true
+	}
 	if !ok {
 		return nil, false
 	}

--- a/internal/service/managed_catalog_test.go
+++ b/internal/service/managed_catalog_test.go
@@ -5,21 +5,147 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
 	"github.com/earchibald/rein/internal/adapter"
+	muxadapter "github.com/earchibald/rein/internal/adapter/muxiterm"
 	"github.com/earchibald/rein/internal/workflow"
 )
+
+func TestNewManagedCatalogUsesBuiltInMuxitermAdapter(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeManagedCatalogManifest(t, root, muxadapter.AdapterID, map[string]any{
+		"name":             muxadapter.AdapterID,
+		"version":          "0.9.0",
+		"description":      "Bundled muxiterm adapter",
+		"category":         "mux",
+		"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"session.attach": "true",
+			"pane.split":     "true",
+			"input.send":     "true",
+			"tail":           "true",
+		},
+	})
+	writeManagedCatalogMarketplace(t, root, map[string]any{
+		"name": "rein-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             muxadapter.AdapterID,
+				"source":           "./plugins/muxiterm",
+				"version":          "0.9.0",
+				"description":      "Bundled muxiterm adapter",
+				"category":         "mux",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+			},
+		},
+	})
+
+	registry, err := adapter.Load(root, adapter.DiscoveryOptions{AllowUnsignedIndex: true})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	catalog := NewManagedCatalog(registry)
+	managed, ok := catalog.Lookup(muxadapter.AdapterID)
+	if !ok {
+		t.Fatalf("Lookup(%q) = !ok", muxadapter.AdapterID)
+	}
+	if _, ok := managed.(*muxadapter.Adapter); !ok {
+		t.Fatalf("Lookup(%q) type = %T, want *muxiterm.Adapter", muxadapter.AdapterID, managed)
+	}
+	if got := managed.Descriptor().GetCategory(); got != reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER {
+		t.Fatalf("Descriptor().Category = %s, want %s", got, reinv1.AdapterCategory_ADAPTER_CATEGORY_MULTIPLEXER)
+	}
+
+	err = managed.Run(context.Background(), nil, workflow.Phase{ID: "mux-step"}, workflow.DirectionForward, &workflow.SideEffect{})
+	if err == nil || !strings.Contains(err.Error(), "muxiterm operation is required") {
+		t.Fatalf("Run() error = %v, want muxiterm operation error", err)
+	}
+
+	if got, want := managedCatalogIDs(catalog.List()), []string{muxadapter.AdapterID}; !slices.Equal(got, want) {
+		t.Fatalf("List() ids = %v, want %v", got, want)
+	}
+}
+
+func TestManagedWorkflowValidateAcceptsBuiltInMuxiterm(t *testing.T) {
+	t.Parallel()
+
+	server := &ManagedWorkflowServer{
+		catalog: NewManagedCatalog(nil),
+		engine:  workflow.New(nil),
+	}
+	resp, err := server.ValidateWorkflow(context.Background(), &reinv1.ValidateWorkflowRequest{
+		Workflow: &reinv1.Workflow{
+			Id:   "wf-mux",
+			Name: "Mux workflow",
+			Steps: []*reinv1.WorkflowStep{{
+				Id:        "mux-step",
+				Name:      "Probe mux",
+				AdapterId: muxadapter.AdapterID,
+				Inputs: map[string]string{
+					workflow.InputOperation: "doctor",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ValidateWorkflow() error = %v", err)
+	}
+	if !resp.GetValid() {
+		t.Fatalf("ValidateWorkflow() valid = false, messages = %+v", resp.GetMessages())
+	}
+}
+
+func managedCatalogIDs(adapters []*reinv1.Adapter) []string {
+	ids := make([]string, 0, len(adapters))
+	for _, descriptor := range adapters {
+		ids = append(ids, descriptor.GetId())
+	}
+	return ids
+}
+
+func writeManagedCatalogMarketplace(t *testing.T, root string, document map[string]any) {
+	t.Helper()
+
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(marketplace.json) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+}
+
+func writeManagedCatalogManifest(t *testing.T, root, name string, manifest map[string]any) {
+	t.Helper()
+
+	manifestDir := filepath.Join(root, "plugins", name, ".claude-plugin")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", manifestDir, err)
+	}
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(plugin.json) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json) error = %v", err)
+	}
+}
 
 func TestManagedCatalogRemoteAdapterReportsSourceRepo(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-
-	document := map[string]any{
+	writeManagedCatalogMarketplace(t, root, map[string]any{
 		"name": "managed-catalog-fixture",
 		"plugins": []any{
 			map[string]any{
@@ -36,14 +162,7 @@ func TestManagedCatalogRemoteAdapterReportsSourceRepo(t *testing.T) {
 				},
 			},
 		},
-	}
-	raw, err := json.MarshalIndent(document, "", "  ")
-	if err != nil {
-		t.Fatalf("json.MarshalIndent() error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
-		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
-	}
+	})
 
 	registry, err := adapter.Load(root, adapter.DiscoveryOptions{AllowUnsignedIndex: true})
 	if err != nil {

--- a/plugins/muxiterm/.claude-plugin/plugin.json
+++ b/plugins/muxiterm/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "muxiterm",
+  "version": "0.9.0",
+  "description": "First-party mux adapter backed by the muxiterm JSON CLI.",
+  "category": "mux",
+  "daemonApiVersion": "rein.v1",
+  "capabilities": {
+    "session.attach": "true",
+    "pane.split": "true",
+    "input.send": "true",
+    "tail": "true"
+  }
+}


### PR DESCRIPTION
## Summary
- add an in-tree managed muxiterm adapter that wraps the muxiterm JSON CLI and exposes the mux capability surface
- wire built-in managed adapters into the managed catalog while preserving registry-backed descriptors
- ship a signed first-party marketplace entry + plugin manifest for muxiterm and cover the new surfaces with focused tests

## Testing
- just ci