### PR TITLE
RN-22: add in-tree GitHub tracker adapter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,11 +33,27 @@
       "name": "muxiterm",
       "source": "./plugins/muxiterm",
       "version": "0.9.0"
+    },
+    {
+      "capabilities": {
+        "branch.prepare": "true",
+        "issue.sync": "true",
+        "merge": "true",
+        "pull_request": "true",
+        "pull_request_review.poll": "true",
+        "worktree.create": "true"
+      },
+      "category": "tracker",
+      "daemonApiVersion": "rein.v1",
+      "description": "First-party GitHub issue and pull-request tracker adapter",
+      "name": "tracker-github",
+      "source": "./plugins/tracker-github",
+      "version": "0.1.0"
     }
   ],
   "signature": {
     "algorithm": "ed25519",
-    "keyId": "rein-marketplace-phase4b",
-    "value": "HJk3K9IYNJk3WKTu43FIjbF61JmH9yiWFmLAnBEbryF1Nw0NpgPgXeydl3TE3r9eYqeAkn+UQt3Nq0eR+QPRAw=="
+    "keyId": "rein-marketplace-phase4c",
+    "value": "Hyz66N9T/BLG/xyTqm/SfWOn9d8HgDw+8Lg0wSvZMvg8xXbylBfWJcLNq5HG1tXv8Z+2Xes3oXBTQYsabNxsAw=="
   }
 }

--- a/.claude-plugin/trusted-keys.json
+++ b/.claude-plugin/trusted-keys.json
@@ -2,8 +2,8 @@
   "keys": [
     {
       "algorithm": "ed25519",
-      "id": "rein-marketplace-phase4b",
-      "publicKey": "Wks1syNv/haTCWXu53mXFa0zm470mwPu16RXPOPZl4U="
+      "id": "rein-marketplace-phase4c",
+      "publicKey": "Hlow+tdE53olu7i3SUsabahjVwoQwM0b7N0oRi1vGGo="
     }
   ]
 }

--- a/internal/server/managed_flow_harness_test.go
+++ b/internal/server/managed_flow_harness_test.go
@@ -838,11 +838,12 @@ func newManagedFlowAdapterCatalog(tb testing.TB) *managedFlowAdapterCatalog {
 			Version:     "0.1.0",
 			Enabled:     true,
 			Capabilities: map[string]string{
-				"issue.sync":      "true",
-				"branch.prepare":  "true",
-				"worktree.create": "true",
-				"pull_request":    "true",
-				"merge":           "true",
+				"issue.sync":               "true",
+				"branch.prepare":           "true",
+				"worktree.create":          "true",
+				"pull_request":             "true",
+				"pull_request_review.poll": "true",
+				"merge":                    "true",
 			},
 		},
 	}
@@ -850,7 +851,7 @@ func newManagedFlowAdapterCatalog(tb testing.TB) *managedFlowAdapterCatalog {
 		Descriptor:           tracker.Descriptor(),
 		Implementation:       tracker,
 		Contract:             (*managedFlowTrackerContract)(nil),
-		RequiredCapabilities: []string{"issue.sync", "branch.prepare", "worktree.create", "pull_request", "merge"},
+		RequiredCapabilities: []string{"issue.sync", "branch.prepare", "worktree.create", "pull_request", "pull_request_review.poll", "merge"},
 	})
 
 	coding := &managedFlowCodingAdapter{

--- a/internal/service/github_tracker_adapter.go
+++ b/internal/service/github_tracker_adapter.go
@@ -1,0 +1,787 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/credentials"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+const githubTrackerAdapterID = "tracker-github"
+
+var (
+	managedAdapterFactories = map[string]func(string, *reinv1.Adapter) ManagedAdapter{
+		githubTrackerAdapterID: newGitHubTrackerManagedAdapter,
+	}
+
+	githubIssueNumberPattern = regexp.MustCompile(`(\d+)$`)
+)
+
+type githubTrackerAdapter struct {
+	descriptor         *reinv1.Adapter
+	root               string
+	httpClient         *http.Client
+	credentialRegistry *credentials.Registry
+	lookupEnv          func(string) (string, bool)
+	commandRunner      commandRunner
+}
+
+type commandRunner interface {
+	CombinedOutput(context.Context, string, ...string) ([]byte, error)
+}
+
+type exitCoder interface {
+	ExitCode() int
+}
+
+type execCommandRunner struct{}
+
+type githubTrackerConfig struct {
+	repository  string
+	owner       string
+	repo        string
+	token       string
+	authMode    string
+	apiBaseURL  string
+	webBaseURL  string
+	issueNumber int
+}
+
+type githubIssue struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+}
+
+type githubPullRequest struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+	Merged  bool   `json:"merged"`
+}
+
+type githubReview struct {
+	State string `json:"state"`
+	User  struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type githubMergeResult struct {
+	SHA     string `json:"sha"`
+	Merged  bool   `json:"merged"`
+	Message string `json:"message"`
+}
+
+func (execCommandRunner) CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func newGitHubTrackerManagedAdapter(root string, descriptor *reinv1.Adapter) ManagedAdapter {
+	if descriptor == nil {
+		descriptor = defaultGitHubTrackerDescriptor()
+	}
+	return &githubTrackerAdapter{
+		descriptor:         proto.Clone(descriptor).(*reinv1.Adapter),
+		root:               root,
+		httpClient:         http.DefaultClient,
+		credentialRegistry: credentials.NewBuiltinRegistry(credentials.BuiltinOptions{}),
+		lookupEnv:          os.LookupEnv,
+		commandRunner:      execCommandRunner{},
+	}
+}
+
+func defaultGitHubTrackerDescriptor() *reinv1.Adapter {
+	return &reinv1.Adapter{
+		Id:          githubTrackerAdapterID,
+		Name:        "GitHub Tracker",
+		Category:    reinv1.AdapterCategory_ADAPTER_CATEGORY_TRACKER,
+		Description: "First-party GitHub issue and pull-request tracker adapter",
+		Version:     "0.1.0",
+		Enabled:     true,
+		Capabilities: map[string]string{
+			"issue.sync":               "true",
+			"branch.prepare":           "true",
+			"worktree.create":          "true",
+			"pull_request":             "true",
+			"pull_request_review.poll": "true",
+			"merge":                    "true",
+		},
+	}
+}
+
+func (a *githubTrackerAdapter) Descriptor() *reinv1.Adapter {
+	if a == nil || a.descriptor == nil {
+		return nil
+	}
+	return proto.Clone(a.descriptor).(*reinv1.Adapter)
+}
+
+func (a *githubTrackerAdapter) Run(ctx context.Context, state *workflow.RuntimeState, phase workflow.Phase, direction workflow.Direction, effect *workflow.SideEffect) error {
+	if state == nil || state.Issue == nil || state.Execution == nil {
+		return errors.New("github tracker adapter requires issue and execution state")
+	}
+	if state.Execution.Metadata == nil {
+		state.Execution.Metadata = map[string]string{}
+	}
+	if state.Issue.Labels == nil {
+		state.Issue.Labels = map[string]string{}
+	}
+
+	config, err := a.resolveConfig(ctx, state)
+	if err != nil {
+		return err
+	}
+	state.Execution.Metadata["auth_mode"] = config.authMode
+	state.Execution.Metadata["github.repository"] = config.repository
+
+	switch direction {
+	case workflow.DirectionForward:
+		return a.runForward(ctx, config, state, phase, effect)
+	case workflow.DirectionBackward:
+		return a.runBackward(ctx, config, state, phase, effect)
+	default:
+		return fmt.Errorf("unsupported workflow direction %q", direction)
+	}
+}
+
+func (a *githubTrackerAdapter) runForward(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, phase workflow.Phase, effect *workflow.SideEffect) error {
+	switch strings.TrimSpace(phase.Operation) {
+	case "prepare":
+		return a.prepareIssue(ctx, config, state, effect)
+	case "open-pr", "pull-request", "pull_request":
+		return a.openPullRequest(ctx, config, state, effect)
+	case "poll-review", "review", "review-poll":
+		return a.pollPullRequestReview(ctx, config, state, effect)
+	case "merge":
+		return a.mergePullRequest(ctx, config, state, effect)
+	default:
+		return fmt.Errorf("unsupported GitHub tracker operation %q", phase.Operation)
+	}
+}
+
+func (a *githubTrackerAdapter) runBackward(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, phase workflow.Phase, effect *workflow.SideEffect) error {
+	switch strings.TrimSpace(phase.BackwardOperation) {
+	case "":
+		return nil
+	case "cleanup-branch":
+		return a.cleanupBranch(ctx, state, effect)
+	case "close-pr":
+		return a.closePullRequest(ctx, config, state, effect)
+	case "dismiss-review":
+		state.Execution.Metadata["review_state"] = "DISMISSED"
+		state.Issue.Labels["review_state"] = "DISMISSED"
+		setEffectOutput(effect, "review_state", "DISMISSED")
+		return nil
+	case "reopen-merge":
+		state.Execution.Metadata["result"] = "reopened"
+		setEffectOutput(effect, "result", "reopened")
+		return nil
+	default:
+		return fmt.Errorf("unsupported GitHub tracker backward operation %q", phase.BackwardOperation)
+	}
+}
+
+func (a *githubTrackerAdapter) prepareIssue(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	var issue githubIssue
+	if err := a.doJSON(ctx, http.MethodGet, config, path.Join("repos", config.owner, config.repo, "issues", strconv.Itoa(config.issueNumber)), nil, &issue); err != nil {
+		return err
+	}
+
+	title := strings.TrimSpace(state.Issue.GetTitle())
+	if title == "" {
+		title = strings.TrimSpace(issue.Title)
+		state.Issue.Title = title
+	}
+	if strings.TrimSpace(state.Issue.GetSummary()) == "" {
+		state.Issue.Summary = strings.TrimSpace(issue.Body)
+	}
+
+	branch := strings.TrimSpace(state.Execution.Metadata["branch"])
+	if branch == "" {
+		branch = issueBranchName(state.Issue.GetId(), title)
+	}
+	worktreePath := strings.TrimSpace(state.Execution.Metadata["worktree"])
+	if worktreePath == "" {
+		worktreePath = a.defaultWorktreePath(state.Issue.GetId())
+	}
+	if err := a.ensureWorktree(ctx, branch, worktreePath, state.Execution.Metadata["base_branch"]); err != nil {
+		return err
+	}
+
+	state.Execution.Metadata["issue_url"] = issue.HTMLURL
+	state.Execution.Metadata["branch"] = branch
+	state.Execution.Metadata["worktree"] = worktreePath
+	state.Issue.Labels["branch"] = branch
+	state.Issue.Labels["worktree"] = worktreePath
+	setEffectOutput(effect, "issue_url", issue.HTMLURL)
+	setEffectOutput(effect, "branch", branch)
+	setEffectOutput(effect, "worktree", worktreePath)
+	return nil
+}
+
+func (a *githubTrackerAdapter) openPullRequest(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	branch := strings.TrimSpace(state.Execution.Metadata["branch"])
+	if branch == "" {
+		return errors.New("branch metadata is required before opening a pull request")
+	}
+	baseBranch := strings.TrimSpace(state.Execution.Metadata["base_branch"])
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+
+	request := map[string]any{
+		"title": state.Issue.GetTitle(),
+		"head":  branch,
+		"base":  baseBranch,
+		"body":  pullRequestBody(state, config.issueNumber),
+	}
+	var pullRequest githubPullRequest
+	if err := a.doJSON(ctx, http.MethodPost, config, path.Join("repos", config.owner, config.repo, "pulls"), request, &pullRequest); err != nil {
+		return err
+	}
+
+	state.Execution.Metadata["pr_url"] = pullRequest.HTMLURL
+	state.Execution.Metadata["pr_state"] = normalizePullRequestState(pullRequest)
+	state.Execution.Metadata["github.pull_number"] = strconv.Itoa(pullRequest.Number)
+	state.Issue.Labels["pr_url"] = pullRequest.HTMLURL
+	setEffectOutput(effect, "pr_url", pullRequest.HTMLURL)
+	setEffectOutput(effect, "pr_state", state.Execution.Metadata["pr_state"])
+	return nil
+}
+
+func (a *githubTrackerAdapter) pollPullRequestReview(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	pullNumber, err := resolvePullRequestNumber(state)
+	if err != nil {
+		return err
+	}
+
+	var pullRequest githubPullRequest
+	if err := a.doJSON(ctx, http.MethodGet, config, path.Join("repos", config.owner, config.repo, "pulls", strconv.Itoa(pullNumber)), nil, &pullRequest); err != nil {
+		return err
+	}
+	state.Execution.Metadata["pr_url"] = firstNonEmpty(pullRequest.HTMLURL, state.Execution.Metadata["pr_url"])
+	state.Execution.Metadata["pr_state"] = normalizePullRequestState(pullRequest)
+	state.Execution.Metadata["github.pull_number"] = strconv.Itoa(pullNumber)
+
+	var reviews []githubReview
+	if err := a.doJSON(ctx, http.MethodGet, config, path.Join("repos", config.owner, config.repo, "pulls", strconv.Itoa(pullNumber), "reviews"), nil, &reviews); err != nil {
+		return err
+	}
+
+	reviewState, reviewers := aggregateReviewState(reviews)
+	state.Execution.Metadata["review_state"] = reviewState
+	if len(reviewers) > 0 {
+		state.Execution.Metadata["reviewed_by"] = strings.Join(reviewers, ",")
+		setEffectOutput(effect, "reviewed_by", state.Execution.Metadata["reviewed_by"])
+	} else {
+		delete(state.Execution.Metadata, "reviewed_by")
+	}
+	state.Issue.Labels["review_state"] = reviewState
+	setEffectOutput(effect, "pr_state", state.Execution.Metadata["pr_state"])
+	setEffectOutput(effect, "review_state", reviewState)
+	return nil
+}
+
+func (a *githubTrackerAdapter) mergePullRequest(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	if state.Execution.Metadata["review_state"] != "APPROVED" {
+		return errors.New("review approval is required before merge")
+	}
+	pullNumber, err := resolvePullRequestNumber(state)
+	if err != nil {
+		return err
+	}
+	baseBranch := strings.TrimSpace(state.Execution.Metadata["base_branch"])
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+
+	request := map[string]string{"merge_method": "merge"}
+	var result githubMergeResult
+	if err := a.doJSON(ctx, http.MethodPut, config, path.Join("repos", config.owner, config.repo, "pulls", strconv.Itoa(pullNumber), "merge"), request, &result); err != nil {
+		return err
+	}
+	if !result.Merged || strings.TrimSpace(result.SHA) == "" {
+		return fmt.Errorf("github merge did not complete: %s", strings.TrimSpace(result.Message))
+	}
+
+	state.Execution.Metadata["merge_commit"] = result.SHA
+	state.Execution.Metadata["integration_branch"] = baseBranch
+	state.Execution.Metadata["result"] = "merged"
+	state.Execution.Metadata["pr_state"] = "MERGED"
+	state.Issue.Labels["merge_commit"] = result.SHA
+	setEffectOutput(effect, "merge_commit", result.SHA)
+	setEffectOutput(effect, "integration_branch", baseBranch)
+	setEffectOutput(effect, "result", "merged")
+	return nil
+}
+
+func (a *githubTrackerAdapter) cleanupBranch(ctx context.Context, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	worktreePath := strings.TrimSpace(state.Execution.Metadata["worktree"])
+	if worktreePath == "" {
+		return nil
+	}
+	if strings.TrimSpace(a.root) == "" {
+		return errors.New("git root is required to clean up worktrees")
+	}
+	if _, err := a.commandRunner.CombinedOutput(ctx, "git", "-C", a.root, "worktree", "remove", "--force", worktreePath); err != nil {
+		return fmt.Errorf("remove worktree %q: %w", worktreePath, err)
+	}
+	state.Execution.Metadata["branch_cleanup"] = "true"
+	setEffectOutput(effect, "branch_cleanup", "true")
+	return nil
+}
+
+func (a *githubTrackerAdapter) closePullRequest(ctx context.Context, config githubTrackerConfig, state *workflow.RuntimeState, effect *workflow.SideEffect) error {
+	pullNumber, err := resolvePullRequestNumber(state)
+	if err != nil {
+		return err
+	}
+	var pullRequest githubPullRequest
+	if err := a.doJSON(ctx, http.MethodPatch, config, path.Join("repos", config.owner, config.repo, "pulls", strconv.Itoa(pullNumber)), map[string]string{"state": "closed"}, &pullRequest); err != nil {
+		return err
+	}
+	state.Execution.Metadata["pr_state"] = normalizePullRequestState(pullRequest)
+	setEffectOutput(effect, "pr_state", state.Execution.Metadata["pr_state"])
+	return nil
+}
+
+func (a *githubTrackerAdapter) ensureWorktree(ctx context.Context, branch, worktreePath, baseBranch string) error {
+	if strings.TrimSpace(a.root) == "" {
+		return errors.New("git root is required to prepare a worktree")
+	}
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+		return fmt.Errorf("create worktree parent for %q: %w", worktreePath, err)
+	}
+	if _, err := os.Stat(worktreePath); err == nil {
+		if gitWorktreePathExists(worktreePath) {
+			return nil
+		}
+		return fmt.Errorf("worktree path %q already exists but is not a git worktree", worktreePath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect worktree %q: %w", worktreePath, err)
+	}
+
+	if branchExists, err := a.branchExists(ctx, branch); err != nil {
+		return err
+	} else if branchExists {
+		if _, err := a.commandRunner.CombinedOutput(ctx, "git", "-C", a.root, "worktree", "add", worktreePath, branch); err != nil {
+			return fmt.Errorf("create worktree %q for branch %q: %w", worktreePath, branch, err)
+		}
+		return nil
+	}
+
+	if _, err := a.commandRunner.CombinedOutput(ctx, "git", "-C", a.root, "worktree", "add", "-b", branch, worktreePath, baseBranch); err != nil {
+		return fmt.Errorf("create worktree %q for new branch %q: %w", worktreePath, branch, err)
+	}
+	return nil
+}
+
+func (a *githubTrackerAdapter) branchExists(ctx context.Context, branch string) (bool, error) {
+	output, err := a.commandRunner.CombinedOutput(ctx, "git", "-C", a.root, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	if err == nil {
+		return true, nil
+	}
+	if exitError, ok := err.(exitCoder); ok && exitError.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, fmt.Errorf("check git branch %q: %w%s", branch, err, commandOutputSuffix(output))
+}
+
+func (a *githubTrackerAdapter) resolveConfig(ctx context.Context, state *workflow.RuntimeState) (githubTrackerConfig, error) {
+	token, authMode, err := a.resolveToken(ctx, state)
+	if err != nil {
+		return githubTrackerConfig{}, err
+	}
+
+	repository := firstNonEmpty(
+		state.Execution.Metadata["github.repository"],
+		state.Execution.Metadata["github_repository"],
+		state.Execution.Metadata["repository"],
+		state.Issue.Labels["github.repository"],
+	)
+	if repository == "" {
+		repository, err = a.repositoryFromGitRemote(ctx)
+		if err != nil {
+			return githubTrackerConfig{}, err
+		}
+	}
+	owner, repo, err := splitRepository(repository)
+	if err != nil {
+		return githubTrackerConfig{}, err
+	}
+
+	issueNumber, err := resolveIssueNumber(state)
+	if err != nil {
+		return githubTrackerConfig{}, err
+	}
+
+	apiBaseURL := firstNonEmpty(state.Execution.Metadata["github.api_base_url"], state.Execution.Metadata["github_api_base_url"])
+	if apiBaseURL == "" {
+		apiBaseURL = "https://api.github.com"
+	}
+	webBaseURL := firstNonEmpty(state.Execution.Metadata["github.web_base_url"], state.Execution.Metadata["github_web_base_url"])
+	if webBaseURL == "" {
+		webBaseURL = deriveGitHubWebBaseURL(apiBaseURL)
+	}
+
+	return githubTrackerConfig{
+		repository:  repository,
+		owner:       owner,
+		repo:        repo,
+		token:       token,
+		authMode:    authMode,
+		apiBaseURL:  strings.TrimRight(apiBaseURL, "/"),
+		webBaseURL:  strings.TrimRight(webBaseURL, "/"),
+		issueNumber: issueNumber,
+	}, nil
+}
+
+func (a *githubTrackerAdapter) resolveToken(ctx context.Context, state *workflow.RuntimeState) (token, authMode string, err error) {
+	if reference := strings.TrimSpace(state.Execution.Metadata["credential_ref.github_token"]); reference != "" {
+		registry := a.credentialRegistry
+		if registry == nil {
+			registry = credentials.NewBuiltinRegistry(credentials.BuiltinOptions{})
+		}
+		value, err := registry.Resolve(ctx, reference, credentials.ExecutionScope{
+			ProjectID:   state.Issue.GetProjectId(),
+			WorkflowID:  state.Workflow.GetId(),
+			ExecutionID: state.Execution.GetId(),
+			LookupEnv:   a.lookupEnv,
+		})
+		if err != nil {
+			return "", "", err
+		}
+		return value, "credential", nil
+	}
+	if token := strings.TrimSpace(firstNonEmpty(state.Execution.Metadata["github_token"], state.Execution.Metadata["github.token"])); token != "" {
+		return token, "token", nil
+	}
+	return "", "", errors.New("github token is required via credential_ref.github_token or github_token")
+}
+
+func (a *githubTrackerAdapter) repositoryFromGitRemote(ctx context.Context) (string, error) {
+	if strings.TrimSpace(a.root) == "" {
+		return "", errors.New("github.repository is required when git root is unavailable")
+	}
+	output, err := a.commandRunner.CombinedOutput(ctx, "git", "-C", a.root, "config", "--get", "remote.origin.url")
+	if err != nil {
+		return "", fmt.Errorf("resolve repository from git remote: %w%s", err, commandOutputSuffix(output))
+	}
+	repository, parseErr := repositoryFromRemoteURL(strings.TrimSpace(string(output)))
+	if parseErr != nil {
+		return "", parseErr
+	}
+	return repository, nil
+}
+
+func (a *githubTrackerAdapter) defaultWorktreePath(issueID string) string {
+	root := strings.TrimSpace(a.root)
+	if root == "" {
+		return filepath.Join("worktrees", strings.ToLower(issueID))
+	}
+	return filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", strings.ToLower(issueID))
+}
+
+func (a *githubTrackerAdapter) doJSON(ctx context.Context, method string, config githubTrackerConfig, route string, requestBody, responseBody any) error {
+	body, err := encodeJSON(requestBody)
+	if err != nil {
+		return err
+	}
+	endpoint, err := url.JoinPath(config.apiBaseURL, route)
+	if err != nil {
+		return fmt.Errorf("build GitHub API URL for %q: %w", route, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("create GitHub %s %q request: %w", method, route, err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+config.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if requestBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := a.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GitHub %s %q request: %w", method, route, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var failure struct {
+			Message string `json:"message"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&failure)
+		message := strings.TrimSpace(failure.Message)
+		if message == "" {
+			message = resp.Status
+		}
+		return fmt.Errorf("GitHub %s %q: %s", method, route, message)
+	}
+	if responseBody == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("decode GitHub %s %q response: %w", method, route, err)
+	}
+	return nil
+}
+
+func pullRequestBody(state *workflow.RuntimeState, issueNumber int) string {
+	summary := strings.TrimSpace(state.Issue.GetSummary())
+	if summary == "" {
+		return fmt.Sprintf("Closes #%d", issueNumber)
+	}
+	return summary + "\n\nCloses #" + strconv.Itoa(issueNumber)
+}
+
+func issueBranchName(issueID, title string) string {
+	slug := slugify(title)
+	if slug == "" {
+		return "issues/" + strings.ToLower(strings.TrimSpace(issueID))
+	}
+	return "issues/" + strings.ToLower(strings.TrimSpace(issueID)) + "-" + slug
+}
+
+func slugify(value string) string {
+	var builder strings.Builder
+	lastHyphen := false
+	for _, r := range strings.ToLower(value) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			builder.WriteRune(r)
+			lastHyphen = false
+		case !lastHyphen:
+			builder.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func splitRepository(repository string) (owner, repo string, err error) {
+	segments := strings.Split(strings.Trim(repository, "/"), "/")
+	if len(segments) != 2 || segments[0] == "" || segments[1] == "" {
+		return "", "", fmt.Errorf("github.repository %q must use owner/repo format", repository)
+	}
+	return segments[0], segments[1], nil
+}
+
+func resolveIssueNumber(state *workflow.RuntimeState) (int, error) {
+	for _, raw := range []string{
+		state.Execution.Metadata["github.issue_number"],
+		state.Execution.Metadata["github_issue_number"],
+		state.Issue.Labels["github.issue_number"],
+	} {
+		if number, ok := parseOptionalPositiveInt(raw); ok {
+			return number, nil
+		}
+	}
+	match := githubIssueNumberPattern.FindStringSubmatch(strings.TrimSpace(state.Issue.GetId()))
+	if len(match) != 2 {
+		return 0, fmt.Errorf("cannot infer GitHub issue number from issue id %q", state.Issue.GetId())
+	}
+	number, _ := strconv.Atoi(match[1])
+	return number, nil
+}
+
+func resolvePullRequestNumber(state *workflow.RuntimeState) (int, error) {
+	for _, raw := range []string{
+		state.Execution.Metadata["github.pull_number"],
+		state.Execution.Metadata["github_pull_number"],
+	} {
+		if number, ok := parseOptionalPositiveInt(raw); ok {
+			return number, nil
+		}
+	}
+	prURL := strings.TrimSpace(state.Execution.Metadata["pr_url"])
+	if prURL == "" {
+		return 0, errors.New("pull request number is required before polling or merging")
+	}
+	parsed, err := url.Parse(prURL)
+	if err != nil {
+		return 0, fmt.Errorf("parse pull request URL %q: %w", prURL, err)
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) == 0 {
+		return 0, fmt.Errorf("parse pull request URL %q: missing path segments", prURL)
+	}
+	number, ok := parseOptionalPositiveInt(segments[len(segments)-1])
+	if !ok {
+		return 0, fmt.Errorf("parse pull request URL %q: missing numeric pull request id", prURL)
+	}
+	return number, nil
+}
+
+func parseOptionalPositiveInt(raw string) (int, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	number, err := strconv.Atoi(raw)
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
+}
+
+func normalizePullRequestState(pullRequest githubPullRequest) string {
+	if pullRequest.Merged {
+		return "MERGED"
+	}
+	state := strings.ToUpper(strings.TrimSpace(pullRequest.State))
+	if state == "" {
+		return "OPEN"
+	}
+	return state
+}
+
+func aggregateReviewState(reviews []githubReview) (state string, reviewers []string) {
+	latestByReviewer := map[string]string{}
+	for _, review := range reviews {
+		login := strings.TrimSpace(review.User.Login)
+		reviewState := strings.ToUpper(strings.TrimSpace(review.State))
+		if login == "" || reviewState == "" {
+			continue
+		}
+		switch reviewState {
+		case "COMMENTED", "PENDING":
+			continue
+		default:
+			latestByReviewer[login] = reviewState
+		}
+	}
+
+	var changesRequested []string
+	var approved []string
+	for reviewer, reviewState := range latestByReviewer {
+		switch reviewState {
+		case "CHANGES_REQUESTED":
+			changesRequested = append(changesRequested, reviewer)
+		case "APPROVED":
+			approved = append(approved, reviewer)
+		}
+	}
+	sort.Strings(changesRequested)
+	sort.Strings(approved)
+	if len(changesRequested) > 0 {
+		return "CHANGES_REQUESTED", changesRequested
+	}
+	if len(approved) > 0 {
+		return "APPROVED", approved
+	}
+	return "PENDING", nil
+}
+
+func repositoryFromRemoteURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("git remote origin URL is empty")
+	}
+	if strings.Contains(raw, "://") {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return "", fmt.Errorf("parse git remote URL %q: %w", raw, err)
+		}
+		return repositoryFromPath(parsed.Path)
+	}
+	if prefix, rest, ok := strings.Cut(raw, ":"); ok && strings.Contains(prefix, "@") {
+		return repositoryFromPath(rest)
+	}
+	return repositoryFromPath(raw)
+}
+
+func repositoryFromPath(raw string) (string, error) {
+	trimmed := strings.Trim(strings.TrimSuffix(strings.TrimSpace(raw), ".git"), "/")
+	segments := strings.Split(trimmed, "/")
+	if len(segments) < 2 {
+		return "", fmt.Errorf("cannot infer owner/repo from git remote %q", raw)
+	}
+	return strings.Join(segments[len(segments)-2:], "/"), nil
+}
+
+func deriveGitHubWebBaseURL(apiBaseURL string) string {
+	apiBaseURL = strings.TrimRight(strings.TrimSpace(apiBaseURL), "/")
+	switch {
+	case apiBaseURL == "https://api.github.com":
+		return "https://github.com"
+	case strings.HasSuffix(apiBaseURL, "/api/v3"):
+		return strings.TrimSuffix(apiBaseURL, "/api/v3")
+	case strings.HasSuffix(apiBaseURL, "/api"):
+		return strings.TrimSuffix(apiBaseURL, "/api")
+	default:
+		return apiBaseURL
+	}
+}
+
+func gitWorktreePathExists(worktreePath string) bool {
+	_, err := os.Stat(filepath.Join(worktreePath, ".git"))
+	return err == nil
+}
+
+func encodeJSON(value any) (*bytes.Reader, error) {
+	if value == nil {
+		return bytes.NewReader(nil), nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode GitHub request: %w", err)
+	}
+	return bytes.NewReader(payload), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func setEffectOutput(effect *workflow.SideEffect, key, value string) {
+	if effect == nil || strings.TrimSpace(value) == "" {
+		return
+	}
+	if effect.Outputs == nil {
+		effect.Outputs = map[string]string{}
+	}
+	effect.Outputs[key] = value
+}
+
+func commandOutputSuffix(output []byte) string {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
+}

--- a/internal/service/github_tracker_adapter_test.go
+++ b/internal/service/github_tracker_adapter_test.go
@@ -1,0 +1,454 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/earchibald/rein/adaptertest"
+	reinv1 "github.com/earchibald/rein/gen/go/rein/v1"
+	"github.com/earchibald/rein/internal/workflow"
+)
+
+func TestGitHubTrackerAdapterConformance(t *testing.T) {
+	t.Parallel()
+
+	adapter := newGitHubTrackerManagedAdapter("/repo", nil)
+	adaptertest.RunTracker(t, adaptertest.Spec{
+		Descriptor:           adapter.Descriptor(),
+		Implementation:       adapter,
+		Contract:             (*ManagedAdapter)(nil),
+		RequiredCapabilities: []string{"issue.sync", "branch.prepare", "worktree.create", "pull_request", "pull_request_review.poll", "merge"},
+	})
+}
+
+func TestGitHubTrackerAdapterPrepareOpenReviewAndMerge(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu               sync.Mutex
+		requests         []string
+		authHeaders      []string
+		pullRequestTitle string
+		pullRequestHead  string
+		pullRequestBase  string
+	)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		writeJSON := func(value any) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(value); err != nil {
+				t.Fatalf("Encode() error = %v", err)
+			}
+		}
+
+		switch r.Method + " " + r.URL.Path {
+		case "GET /repos/earchibald/rein/issues/22":
+			writeJSON(map[string]any{
+				"number":   22,
+				"html_url": server.URL + "/earchibald/rein/issues/22",
+				"title":    "GitHub tracker adapter",
+				"body":     "Implement the first-party tracker adapter.",
+				"state":    "open",
+			})
+		case "POST /repos/earchibald/rein/pulls":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("Decode() error = %v", err)
+			}
+			pullRequestTitle, _ = body["title"].(string)
+			pullRequestHead, _ = body["head"].(string)
+			pullRequestBase, _ = body["base"].(string)
+			writeJSON(map[string]any{
+				"number":   101,
+				"html_url": server.URL + "/earchibald/rein/pull/101",
+				"state":    "open",
+			})
+		case "GET /repos/earchibald/rein/pulls/101":
+			writeJSON(map[string]any{
+				"number":   101,
+				"html_url": server.URL + "/earchibald/rein/pull/101",
+				"state":    "open",
+				"merged":   false,
+			})
+		case "GET /repos/earchibald/rein/pulls/101/reviews":
+			writeJSON([]map[string]any{
+				{"state": "COMMENTED", "user": map[string]any{"login": "octocat"}},
+				{"state": "APPROVED", "user": map[string]any{"login": "hubot"}},
+			})
+		case "PUT /repos/earchibald/rein/pulls/101/merge":
+			writeJSON(map[string]any{
+				"sha":     "merge-rn-22-001",
+				"merged":  true,
+				"message": "Pull Request successfully merged",
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	root := filepath.Join(t.TempDir(), "rein")
+	runner := &recordingRunner{branchExists: false}
+	adapter := &githubTrackerAdapter{
+		descriptor:         defaultGitHubTrackerDescriptor(),
+		root:               root,
+		httpClient:         server.Client(),
+		lookupEnv:          func(name string) (string, bool) { return "super-secret-token", name == "RN22_GITHUB_TOKEN" },
+		credentialRegistry: nil,
+		commandRunner:      runner,
+	}
+
+	state := &workflow.RuntimeState{
+		Workflow: &reinv1.Workflow{Id: "managed-issue-pr-review-merge"},
+		Issue: &reinv1.Issue{
+			Id:     "RN-22",
+			Title:  "GitHub tracker adapter",
+			Labels: map[string]string{},
+		},
+		Execution: &reinv1.Execution{
+			Id: "exec-rn-22-001",
+			Metadata: map[string]string{
+				"github.repository":           "earchibald/rein",
+				"github.api_base_url":         server.URL,
+				"github.web_base_url":         server.URL,
+				"base_branch":                 "main",
+				"credential_ref.github_token": "env://RN22_GITHUB_TOKEN",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	prepareEffect := &workflow.SideEffect{}
+	if err := adapter.Run(ctx, state, workflow.Phase{ID: "prepare-branch", Operation: "prepare"}, workflow.DirectionForward, prepareEffect); err != nil {
+		t.Fatalf("Run(prepare) error = %v", err)
+	}
+
+	wantBranch := "issues/rn-22-github-tracker-adapter"
+	wantWorktree := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", "rn-22")
+	if got := state.Execution.Metadata["issue_url"]; got != server.URL+"/earchibald/rein/issues/22" {
+		t.Fatalf("issue_url = %q, want %q", got, server.URL+"/earchibald/rein/issues/22")
+	}
+	if got := state.Execution.Metadata["branch"]; got != wantBranch {
+		t.Fatalf("branch = %q, want %q", got, wantBranch)
+	}
+	if got := state.Execution.Metadata["worktree"]; got != wantWorktree {
+		t.Fatalf("worktree = %q, want %q", got, wantWorktree)
+	}
+	if got := state.Execution.Metadata["auth_mode"]; got != "credential" {
+		t.Fatalf("auth_mode = %q, want credential", got)
+	}
+	if !reflect.DeepEqual(prepareEffect.Outputs, map[string]string{
+		"issue_url": server.URL + "/earchibald/rein/issues/22",
+		"branch":    wantBranch,
+		"worktree":  wantWorktree,
+	}) {
+		t.Fatalf("prepare outputs = %+v", prepareEffect.Outputs)
+	}
+
+	openPREffect := &workflow.SideEffect{}
+	if err := adapter.Run(ctx, state, workflow.Phase{ID: "open-pr", Operation: "open-pr"}, workflow.DirectionForward, openPREffect); err != nil {
+		t.Fatalf("Run(open-pr) error = %v", err)
+	}
+	if pullRequestTitle != "GitHub tracker adapter" || pullRequestHead != wantBranch || pullRequestBase != "main" {
+		t.Fatalf("pull request payload = title %q head %q base %q", pullRequestTitle, pullRequestHead, pullRequestBase)
+	}
+	if got := state.Execution.Metadata["pr_url"]; got != server.URL+"/earchibald/rein/pull/101" {
+		t.Fatalf("pr_url = %q, want %q", got, server.URL+"/earchibald/rein/pull/101")
+	}
+
+	reviewEffect := &workflow.SideEffect{}
+	if err := adapter.Run(ctx, state, workflow.Phase{ID: "poll-review", Operation: "poll-review"}, workflow.DirectionForward, reviewEffect); err != nil {
+		t.Fatalf("Run(poll-review) error = %v", err)
+	}
+	if got := state.Execution.Metadata["review_state"]; got != "APPROVED" {
+		t.Fatalf("review_state = %q, want APPROVED", got)
+	}
+	if got := state.Execution.Metadata["reviewed_by"]; got != "hubot" {
+		t.Fatalf("reviewed_by = %q, want hubot", got)
+	}
+
+	mergeEffect := &workflow.SideEffect{}
+	if err := adapter.Run(ctx, state, workflow.Phase{ID: "merge-pr", Operation: "merge"}, workflow.DirectionForward, mergeEffect); err != nil {
+		t.Fatalf("Run(merge) error = %v", err)
+	}
+	if got := state.Execution.Metadata["merge_commit"]; got != "merge-rn-22-001" {
+		t.Fatalf("merge_commit = %q, want merge-rn-22-001", got)
+	}
+	if got := state.Execution.Metadata["result"]; got != "merged" {
+		t.Fatalf("result = %q, want merged", got)
+	}
+	if got := state.Execution.Metadata["pr_state"]; got != "MERGED" {
+		t.Fatalf("pr_state = %q, want MERGED", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantRequests := []string{
+		"GET /repos/earchibald/rein/issues/22",
+		"POST /repos/earchibald/rein/pulls",
+		"GET /repos/earchibald/rein/pulls/101",
+		"GET /repos/earchibald/rein/pulls/101/reviews",
+		"PUT /repos/earchibald/rein/pulls/101/merge",
+	}
+	if !slices.Equal(requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	}
+	for _, header := range authHeaders {
+		if header != "Bearer super-secret-token" {
+			t.Fatalf("Authorization header = %q, want bearer token", header)
+		}
+	}
+
+	wantGit := []string{
+		"git -C " + root + " show-ref --verify --quiet refs/heads/" + wantBranch,
+		"git -C " + root + " worktree add -b " + wantBranch + " " + wantWorktree + " main",
+	}
+	if !slices.Equal(runner.calls, wantGit) {
+		t.Fatalf("git calls = %v, want %v", runner.calls, wantGit)
+	}
+}
+
+func TestGitHubTrackerAdapterAggregateReviewState(t *testing.T) {
+	t.Parallel()
+
+	state, reviewers := aggregateReviewState([]githubReview{
+		{State: "APPROVED", User: struct {
+			Login string `json:"login"`
+		}{Login: "hubot"}},
+		{State: "COMMENTED", User: struct {
+			Login string `json:"login"`
+		}{Login: "octocat"}},
+		{State: "CHANGES_REQUESTED", User: struct {
+			Login string `json:"login"`
+		}{Login: "dependabot"}},
+		{State: "APPROVED", User: struct {
+			Login string `json:"login"`
+		}{Login: "dependabot"}},
+	})
+	if state != "APPROVED" {
+		t.Fatalf("aggregateReviewState() state = %q, want APPROVED", state)
+	}
+	if !slices.Equal(reviewers, []string{"dependabot", "hubot"}) {
+		t.Fatalf("aggregateReviewState() reviewers = %v, want [dependabot hubot]", reviewers)
+	}
+}
+
+func TestGitHubTrackerAdapterPollReviewClearsReviewedByWhenPending(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /repos/earchibald/rein/pulls/101":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   101,
+				"html_url": server.URL + "/earchibald/rein/pull/101",
+				"state":    "open",
+				"merged":   false,
+			})
+		case "GET /repos/earchibald/rein/pulls/101/reviews":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"state": "COMMENTED", "user": map[string]any{"login": "octocat"}},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	adapter := &githubTrackerAdapter{
+		descriptor:    defaultGitHubTrackerDescriptor(),
+		root:          filepath.Join(t.TempDir(), "rein"),
+		httpClient:    server.Client(),
+		commandRunner: &recordingRunner{},
+	}
+	state := &workflow.RuntimeState{
+		Workflow: &reinv1.Workflow{Id: "wf"},
+		Issue:    &reinv1.Issue{Id: "RN-22", ProjectId: "project-rein", Labels: map[string]string{}},
+		Execution: &reinv1.Execution{
+			Id: "exec-rn-22-001",
+			Metadata: map[string]string{
+				"github.repository":   "earchibald/rein",
+				"github.api_base_url": server.URL,
+				"github.web_base_url": server.URL,
+				"github_token":        "token",
+				"pr_url":              server.URL + "/earchibald/rein/pull/101",
+				"reviewed_by":         "hubot",
+			},
+		},
+	}
+
+	if err := adapter.Run(context.Background(), state, workflow.Phase{Operation: "poll-review"}, workflow.DirectionForward, &workflow.SideEffect{}); err != nil {
+		t.Fatalf("Run(poll-review) error = %v", err)
+	}
+	if got := state.Execution.Metadata["review_state"]; got != "PENDING" {
+		t.Fatalf("review_state = %q, want PENDING", got)
+	}
+	if _, ok := state.Execution.Metadata["reviewed_by"]; ok {
+		t.Fatalf("reviewed_by = %q, want cleared", state.Execution.Metadata["reviewed_by"])
+	}
+}
+
+func TestGitHubTrackerAdapterPrepareRejectsExistingNonWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/earchibald/rein/issues/22" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":   22,
+			"html_url": server.URL + "/earchibald/rein/issues/22",
+			"title":    "GitHub tracker adapter",
+			"state":    "open",
+		})
+	}))
+	defer server.Close()
+
+	root := filepath.Join(t.TempDir(), "rein")
+	worktreePath := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", "rn-22")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", worktreePath, err)
+	}
+
+	adapter := &githubTrackerAdapter{
+		descriptor:    defaultGitHubTrackerDescriptor(),
+		root:          root,
+		httpClient:    server.Client(),
+		commandRunner: &recordingRunner{},
+	}
+	state := &workflow.RuntimeState{
+		Workflow: &reinv1.Workflow{Id: "wf"},
+		Issue: &reinv1.Issue{
+			Id:        "RN-22",
+			ProjectId: "project-rein",
+			Title:     "GitHub tracker adapter",
+			Labels:    map[string]string{},
+		},
+		Execution: &reinv1.Execution{
+			Id: "exec-rn-22-001",
+			Metadata: map[string]string{
+				"github.repository":   "earchibald/rein",
+				"github.api_base_url": server.URL,
+				"github.web_base_url": server.URL,
+				"github_token":        "token",
+			},
+		},
+	}
+
+	err := adapter.Run(context.Background(), state, workflow.Phase{Operation: "prepare"}, workflow.DirectionForward, &workflow.SideEffect{})
+	if err == nil || !strings.Contains(err.Error(), "is not a git worktree") {
+		t.Fatalf("Run(prepare) error = %v, want non-worktree error", err)
+	}
+}
+
+func TestRepositoryFromRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "https", raw: "https://github.com/earchibald/rein.git", want: "earchibald/rein"},
+		{name: "ssh scp", raw: "git@github.com:earchibald/rein.git", want: "earchibald/rein"},
+		{name: "ssh url", raw: "ssh://git@github.com/earchibald/rein.git", want: "earchibald/rein"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := repositoryFromRemoteURL(tt.raw)
+			if err != nil {
+				t.Fatalf("repositoryFromRemoteURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("repositoryFromRemoteURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type recordingRunner struct {
+	calls        []string
+	branchExists bool
+}
+
+func (r *recordingRunner) CombinedOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	command := strings.Join(append([]string{name}, args...), " ")
+	r.calls = append(r.calls, command)
+	if strings.Contains(command, "show-ref") {
+		if r.branchExists {
+			return nil, nil
+		}
+		return nil, &fakeExitError{}
+	}
+	return []byte(""), nil
+}
+
+type fakeExitError struct{}
+
+func (*fakeExitError) Error() string   { return "exit status 1" }
+func (*fakeExitError) ExitCode() int   { return 1 }
+func (*fakeExitError) Stderr() []byte  { return nil }
+func (*fakeExitError) String() string  { return "exit status 1" }
+func (*fakeExitError) Unwrap() error   { return nil }
+func (*fakeExitError) Timeout() bool   { return false }
+func (*fakeExitError) Temporary() bool { return false }
+
+func TestGitHubTrackerAdapterCleanupBranch(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "rein")
+	runner := &cleanupRunner{}
+	adapter := &githubTrackerAdapter{
+		descriptor:         defaultGitHubTrackerDescriptor(),
+		root:               root,
+		httpClient:         http.DefaultClient,
+		lookupEnv:          nil,
+		credentialRegistry: nil,
+		commandRunner:      runner,
+	}
+	state := &workflow.RuntimeState{
+		Workflow:  &reinv1.Workflow{Id: "wf"},
+		Issue:     &reinv1.Issue{Id: "RN-22", ProjectId: "project-rein", Labels: map[string]string{}},
+		Execution: &reinv1.Execution{Id: "exec-rn-22-001", Metadata: map[string]string{"github.repository": "earchibald/rein", "github_token": "token", "worktree": filepath.Join(filepath.Dir(root), filepath.Base(root)+"-worktrees", "rn-22")}},
+	}
+	effect := &workflow.SideEffect{}
+	if err := adapter.Run(context.Background(), state, workflow.Phase{BackwardOperation: "cleanup-branch"}, workflow.DirectionBackward, effect); err != nil {
+		t.Fatalf("Run(cleanup-branch) error = %v", err)
+	}
+	if got := state.Execution.Metadata["branch_cleanup"]; got != "true" {
+		t.Fatalf("branch_cleanup = %q, want true", got)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("cleanup calls = %v, want 1", runner.calls)
+	}
+}
+
+type cleanupRunner struct{ calls []string }
+
+func (r *cleanupRunner) CombinedOutput(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, strings.Join(append([]string{name}, args...), " "))
+	return nil, nil
+}

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -19,11 +19,16 @@ func NewManagedCatalogFromRoot(root string, options adapter.DiscoveryOptions) (M
 	if err != nil {
 		return nil, err
 	}
-	return NewManagedCatalog(registry), nil
+	return newManagedCatalog(root, registry), nil
 }
 
 func NewManagedCatalog(registry *adapter.Registry) ManagedCatalog {
+	return newManagedCatalog("", registry)
+}
+
+func newManagedCatalog(root string, registry *adapter.Registry) ManagedCatalog {
 	return &registryManagedCatalog{
+		root:     root,
 		registry: registry,
 		builtIns: map[string]func(*reinv1.Adapter) ManagedAdapter{
 			muxadapter.AdapterID: func(descriptor *reinv1.Adapter) ManagedAdapter {
@@ -38,6 +43,7 @@ func NewManagedCatalog(registry *adapter.Registry) ManagedCatalog {
 }
 
 type registryManagedCatalog struct {
+	root     string
 	registry *adapter.Registry
 	builtIns map[string]func(*reinv1.Adapter) ManagedAdapter
 }
@@ -86,8 +92,11 @@ func (c *registryManagedCatalog) Lookup(id string) (ManagedAdapter, bool) {
 	if !ok {
 		return nil, false
 	}
-	if adapter, ok := builtinManagedAdapter(entry.Descriptor); ok {
-		return adapter, true
+	if managed, ok := builtinManagedAdapter(entry.Descriptor); ok {
+		return managed, true
+	}
+	if factory, ok := managedAdapterFactories[id]; ok {
+		return factory(c.root, entry.Descriptor), true
 	}
 	return &registryManagedAdapter{descriptor: entry.Descriptor, source: entry.Source}, true
 }

--- a/internal/service/managed_catalog_test.go
+++ b/internal/service/managed_catalog_test.go
@@ -102,45 +102,6 @@ func TestManagedWorkflowValidateAcceptsBuiltInMuxiterm(t *testing.T) {
 	}
 }
 
-func managedCatalogIDs(adapters []*reinv1.Adapter) []string {
-	ids := make([]string, 0, len(adapters))
-	for _, descriptor := range adapters {
-		ids = append(ids, descriptor.GetId())
-	}
-	return ids
-}
-
-func writeManagedCatalogMarketplace(t *testing.T, root string, document map[string]any) {
-	t.Helper()
-
-	raw, err := json.MarshalIndent(document, "", "  ")
-	if err != nil {
-		t.Fatalf("json.MarshalIndent(marketplace.json) error = %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
-		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
-		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
-	}
-}
-
-func writeManagedCatalogManifest(t *testing.T, root, name string, manifest map[string]any) {
-	t.Helper()
-
-	manifestDir := filepath.Join(root, "plugins", name, ".claude-plugin")
-	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%q) error = %v", manifestDir, err)
-	}
-	raw, err := json.MarshalIndent(manifest, "", "  ")
-	if err != nil {
-		t.Fatalf("json.MarshalIndent(plugin.json) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), raw, 0o644); err != nil {
-		t.Fatalf("WriteFile(plugin.json) error = %v", err)
-	}
-}
-
 func TestManagedCatalogRemoteAdapterReportsSourceRepo(t *testing.T) {
 	t.Parallel()
 
@@ -177,5 +138,103 @@ func TestManagedCatalogRemoteAdapterReportsSourceRepo(t *testing.T) {
 	want := `adapter "coding-claude-code" is registered from GitHub repo "earchibald/rein-adapter-claude-code", but remote managed execution is not wired into the daemon yet`
 	if err == nil || err.Error() != want {
 		t.Fatalf("Run() error = %v, want %q", err, want)
+	}
+}
+
+func TestManagedCatalogWrapsBuiltInGitHubTracker(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeManagedCatalogMarketplace(t, root, map[string]any{
+		"name": "rein-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             githubTrackerAdapterID,
+				"source":           "./plugins/" + githubTrackerAdapterID,
+				"version":          "0.1.0",
+				"description":      "Fixture GitHub tracker adapter",
+				"category":         "tracker",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+				"capabilities": map[string]string{
+					"issue.sync":               "true",
+					"branch.prepare":           "true",
+					"worktree.create":          "true",
+					"pull_request":             "true",
+					"pull_request_review.poll": "true",
+					"merge":                    "true",
+				},
+			},
+		},
+	})
+	writeManagedCatalogManifest(t, root, githubTrackerAdapterID, map[string]any{
+		"name":             githubTrackerAdapterID,
+		"version":          "0.1.0",
+		"description":      "Fixture GitHub tracker adapter",
+		"category":         "tracker",
+		"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+		"capabilities": map[string]string{
+			"issue.sync":               "true",
+			"branch.prepare":           "true",
+			"worktree.create":          "true",
+			"pull_request":             "true",
+			"pull_request_review.poll": "true",
+			"merge":                    "true",
+		},
+	})
+
+	catalog, err := NewManagedCatalogFromRoot(root, adapter.DiscoveryOptions{AllowUnsignedIndex: true})
+	if err != nil {
+		t.Fatalf("NewManagedCatalogFromRoot() error = %v", err)
+	}
+
+	managed, ok := catalog.Lookup(githubTrackerAdapterID)
+	if !ok {
+		t.Fatalf("Lookup(%q) = !ok", githubTrackerAdapterID)
+	}
+	if _, ok := managed.(*githubTrackerAdapter); !ok {
+		t.Fatalf("Lookup(%q) type = %T, want *githubTrackerAdapter", githubTrackerAdapterID, managed)
+	}
+
+	if got, want := managedCatalogIDs(catalog.List()), []string{muxadapter.AdapterID, githubTrackerAdapterID}; !slices.Equal(got, want) {
+		t.Fatalf("List() ids = %v, want %v", got, want)
+	}
+}
+
+func managedCatalogIDs(adapters []*reinv1.Adapter) []string {
+	ids := make([]string, 0, len(adapters))
+	for _, descriptor := range adapters {
+		ids = append(ids, descriptor.GetId())
+	}
+	return ids
+}
+
+func writeManagedCatalogMarketplace(t *testing.T, root string, document map[string]any) {
+	t.Helper()
+
+	raw, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(marketplace.json) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+}
+
+func writeManagedCatalogManifest(t *testing.T, root, name string, manifest map[string]any) {
+	t.Helper()
+
+	manifestDir := filepath.Join(root, "plugins", name, ".claude-plugin")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", manifestDir, err)
+	}
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(plugin.json) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "plugin.json"), raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json) error = %v", err)
 	}
 }

--- a/plugins/tracker-github/.claude-plugin/plugin.json
+++ b/plugins/tracker-github/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "capabilities": {
+    "branch.prepare": "true",
+    "issue.sync": "true",
+    "merge": "true",
+    "pull_request": "true",
+    "pull_request_review.poll": "true",
+    "worktree.create": "true"
+  },
+  "category": "tracker",
+  "daemonApiVersion": "rein.v1",
+  "description": "First-party GitHub issue and pull-request tracker adapter",
+  "name": "tracker-github",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary\n- add a first-party managed GitHub tracker adapter with prepare, PR, review polling, merge, and cleanup operations\n- wire managed catalog lookup to instantiate the in-tree adapter for registry entries\n- add signed marketplace + manifest entries and focused conformance/operation tests\n\nCloses #22