### PR TITLE
RN-27: expose public migration seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - RN-23 boots the Claude Code coding-agent adapter as a remote GitHub marketplace entry (`earchibald/rein-adapter-claude-code`) instead of a local plugin checkout.
 - The registry and adapter APIs now surface that remote entry immediately; managed execution still reports an explicit “not wired yet” stub until the external adapter bridge lands.
 
+## External migration tooling
+
+- One-shot migration/import tools should live in separate repos rather than pulling legacy source-system dependencies into `rein`.
+- `github.com/earchibald/rein/instance` exposes the canonical instance layout helpers used to resolve `grpc.sock` and `rein.db` paths for external tools.
+- `github.com/earchibald/rein/sqlite` exposes the migrated locked-entity SQLite store needed to create and populate rein state from those external tools.
+- RN-27 boots the op-obsidian migration CLI as the separate repo `earchibald/rein-migrate-from-op-obsidian`.
+
 ## Development
 
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -1,0 +1,89 @@
+package instance
+
+import internalinstance "github.com/earchibald/rein/internal/instance"
+
+const (
+	DefaultName = internalinstance.DefaultName
+	EnvVar      = internalinstance.EnvVar
+)
+
+var (
+	ErrEmptyName         = internalinstance.ErrEmptyName
+	ErrInvalidName       = internalinstance.ErrInvalidName
+	ErrMissingStateHome  = internalinstance.ErrMissingStateHome
+	ErrRelativeStateHome = internalinstance.ErrRelativeStateHome
+)
+
+type Layout struct {
+	Name         string
+	StateHome    string
+	RootDir      string
+	SocketPath   string
+	DatabasePath string
+}
+
+type ResolveOptions struct {
+	Name        string
+	LookupEnv   func(string) (string, bool)
+	UserHomeDir func() (string, error)
+}
+
+func Resolve(options ResolveOptions) (Layout, error) {
+	layout, err := internalinstance.Resolve(toInternalResolveOptions(options))
+	if err != nil {
+		return Layout{}, err
+	}
+	return fromInternalLayout(layout), nil
+}
+
+func NewLayout(name, stateHome string) (Layout, error) {
+	layout, err := internalinstance.NewLayout(name, stateHome)
+	if err != nil {
+		return Layout{}, err
+	}
+	return fromInternalLayout(layout), nil
+}
+
+func ValidateName(name string) error {
+	return internalinstance.ValidateName(name)
+}
+
+func (l Layout) Validate() error {
+	return toInternalLayout(l).Validate()
+}
+
+func (l Layout) EnsureRootDir() error {
+	return toInternalLayout(l).EnsureRootDir()
+}
+
+func (l Layout) AutoStartEnabled() bool {
+	return toInternalLayout(l).AutoStartEnabled()
+}
+
+func fromInternalLayout(layout internalinstance.Layout) Layout {
+	return Layout{
+		Name:         layout.Name,
+		StateHome:    layout.StateHome,
+		RootDir:      layout.RootDir,
+		SocketPath:   layout.SocketPath,
+		DatabasePath: layout.DatabasePath,
+	}
+}
+
+func toInternalLayout(layout Layout) internalinstance.Layout {
+	return internalinstance.Layout{
+		Name:         layout.Name,
+		StateHome:    layout.StateHome,
+		RootDir:      layout.RootDir,
+		SocketPath:   layout.SocketPath,
+		DatabasePath: layout.DatabasePath,
+	}
+}
+
+func toInternalResolveOptions(options ResolveOptions) internalinstance.ResolveOptions {
+	return internalinstance.ResolveOptions{
+		Name:        options.Name,
+		LookupEnv:   options.LookupEnv,
+		UserHomeDir: options.UserHomeDir,
+	}
+}

--- a/instance/instance_test.go
+++ b/instance/instance_test.go
@@ -1,0 +1,35 @@
+package instance
+
+import "testing"
+
+func TestResolveUsesCanonicalLayout(t *testing.T) {
+	t.Parallel()
+
+	layout, err := Resolve(ResolveOptions{
+		Name: "import",
+		LookupEnv: func(string) (string, bool) {
+			return "", false
+		},
+		UserHomeDir: func() (string, error) {
+			return "/Users/tester", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if got, want := layout.RootDir, "/Users/tester/.local/state/rein/instances/import"; got != want {
+		t.Fatalf("Resolve() root dir = %q, want %q", got, want)
+	}
+	if got, want := layout.DatabasePath, "/Users/tester/.local/state/rein/instances/import/rein.db"; got != want {
+		t.Fatalf("Resolve() database path = %q, want %q", got, want)
+	}
+}
+
+func TestNewLayoutRejectsRelativeStateHome(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewLayout("import", "relative"); err == nil {
+		t.Fatal("NewLayout() error = nil, want error")
+	}
+}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -1,0 +1,185 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	storesqlite "github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+var (
+	ErrMissingPath          = storesqlite.ErrMissingPath
+	ErrUnknownKind          = storesqlite.ErrUnknownKind
+	ErrEmptyID              = storesqlite.ErrEmptyID
+	ErrInvalidPayload       = storesqlite.ErrInvalidPayload
+	ErrNotFound             = storesqlite.ErrNotFound
+	ErrLockVersionMismatch  = storesqlite.ErrLockVersionMismatch
+	ErrInvalidMigrationStep = storesqlite.ErrInvalidMigrationStep
+)
+
+type EntityKind string
+
+const (
+	ProjectKind     EntityKind = EntityKind(storesqlite.ProjectKind)
+	WorkflowKind    EntityKind = EntityKind(storesqlite.WorkflowKind)
+	IssueKind       EntityKind = EntityKind(storesqlite.IssueKind)
+	ExecutionKind   EntityKind = EntityKind(storesqlite.ExecutionKind)
+	TaskStepKind    EntityKind = EntityKind(storesqlite.TaskStepKind)
+	SideEffectKind  EntityKind = EntityKind(storesqlite.SideEffectKind)
+	CostEventKind   EntityKind = EntityKind(storesqlite.CostEventKind)
+	FeatureFlagKind EntityKind = EntityKind(storesqlite.FeatureFlagKind)
+)
+
+type Config struct {
+	Path            string
+	MigrationsTable string
+	BusyTimeout     time.Duration
+}
+
+type Record struct {
+	ID          string
+	LockVersion int64
+	Payload     json.RawMessage
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ListOptions struct {
+	JSONEquals map[string]string
+	Limit      int
+}
+
+type Store struct {
+	inner *storesqlite.Store
+}
+
+func Open(ctx context.Context, cfg Config) (*Store, error) {
+	store, err := storesqlite.Open(ctx, toInternalConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
+	return &Store{inner: store}, nil
+}
+
+func OpenAndMigrate(ctx context.Context, cfg Config) (*Store, error) {
+	store, err := storesqlite.OpenAndMigrate(ctx, toInternalConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
+	return &Store{inner: store}, nil
+}
+
+func MigrateUp(ctx context.Context, cfg Config) error {
+	return storesqlite.MigrateUp(ctx, toInternalConfig(cfg))
+}
+
+func MigrateDown(ctx context.Context, cfg Config) error {
+	return storesqlite.MigrateDown(ctx, toInternalConfig(cfg))
+}
+
+func MigrateDownSteps(ctx context.Context, cfg Config, steps int) error {
+	return storesqlite.MigrateDownSteps(ctx, toInternalConfig(cfg), steps)
+}
+
+func InMemoryConfig(name string) Config {
+	return fromInternalConfig(storesqlite.InMemoryConfig(name))
+}
+
+func OpenInMemoryAndMigrate(ctx context.Context, name string) (*Store, error) {
+	store, err := storesqlite.OpenInMemoryAndMigrate(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{inner: store}, nil
+}
+
+func (s *Store) Close() error {
+	return s.inner.Close()
+}
+
+func (s *Store) DB() *sql.DB {
+	return s.inner.DB()
+}
+
+func (s *Store) Create(ctx context.Context, kind EntityKind, id string, payload json.RawMessage) (Record, error) {
+	record, err := s.inner.Create(ctx, toInternalKind(kind), id, payload)
+	if err != nil {
+		return Record{}, err
+	}
+	return fromInternalRecord(record), nil
+}
+
+func (s *Store) Get(ctx context.Context, kind EntityKind, id string) (Record, error) {
+	record, err := s.inner.Get(ctx, toInternalKind(kind), id)
+	if err != nil {
+		return Record{}, err
+	}
+	return fromInternalRecord(record), nil
+}
+
+func (s *Store) Update(ctx context.Context, kind EntityKind, id string, expectedLockVersion int64, payload json.RawMessage) (Record, error) {
+	record, err := s.inner.Update(ctx, toInternalKind(kind), id, expectedLockVersion, payload)
+	if err != nil {
+		return Record{}, err
+	}
+	return fromInternalRecord(record), nil
+}
+
+func (s *Store) List(ctx context.Context, kind EntityKind, options ListOptions) ([]Record, error) {
+	records, err := s.inner.List(ctx, toInternalKind(kind), toInternalListOptions(options))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]Record, 0, len(records))
+	for _, record := range records {
+		result = append(result, fromInternalRecord(record))
+	}
+	return result, nil
+}
+
+func (s *Store) Delete(ctx context.Context, kind EntityKind, id string, expectedLockVersion int64) error {
+	return s.inner.Delete(ctx, toInternalKind(kind), id, expectedLockVersion)
+}
+
+func toInternalKind(kind EntityKind) storesqlite.EntityKind {
+	return storesqlite.EntityKind(kind)
+}
+
+func toInternalConfig(cfg Config) storesqlite.Config {
+	return storesqlite.Config{
+		Path:            cfg.Path,
+		MigrationsTable: cfg.MigrationsTable,
+		BusyTimeout:     cfg.BusyTimeout,
+	}
+}
+
+func fromInternalConfig(cfg storesqlite.Config) Config {
+	return Config{
+		Path:            cfg.Path,
+		MigrationsTable: cfg.MigrationsTable,
+		BusyTimeout:     cfg.BusyTimeout,
+	}
+}
+
+func fromInternalRecord(record storesqlite.Record) Record {
+	return Record{
+		ID:          record.ID,
+		LockVersion: record.LockVersion,
+		Payload:     append(json.RawMessage(nil), record.Payload...),
+		CreatedAt:   record.CreatedAt,
+		UpdatedAt:   record.UpdatedAt,
+	}
+}
+
+func toInternalListOptions(options ListOptions) storesqlite.ListOptions {
+	cloned := make(map[string]string, len(options.JSONEquals))
+	for key, value := range options.JSONEquals {
+		cloned[key] = value
+	}
+	return storesqlite.ListOptions{
+		JSONEquals: cloned,
+		Limit:      options.Limit,
+	}
+}

--- a/sqlite/sqlite_test.go
+++ b/sqlite/sqlite_test.go
@@ -1,0 +1,41 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOpenInMemoryAndMigrateCreatesUsableStore(t *testing.T) {
+	t.Parallel()
+
+	store, err := OpenInMemoryAndMigrate(context.Background(), "public-wrapper")
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	defer store.Close()
+
+	record, err := store.Create(context.Background(), ProjectKind, "project-1", []byte(`{"id":"project-1","displayName":"Project 1"}`))
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	loaded, err := store.Get(context.Background(), ProjectKind, "project-1")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if loaded.ID != record.ID {
+		t.Fatalf("Get() id = %q, want %q", loaded.ID, record.ID)
+	}
+	if string(loaded.Payload) != string(record.Payload) {
+		t.Fatalf("Get() payload = %s, want %s", loaded.Payload, record.Payload)
+	}
+}
+
+func TestMigrateDownStepsRejectsInvalidStepCount(t *testing.T) {
+	t.Parallel()
+
+	if err := MigrateDownSteps(context.Background(), Config{Path: "rein.db"}, 0); err != ErrInvalidMigrationStep {
+		t.Fatalf("MigrateDownSteps() error = %v, want %v", err, ErrInvalidMigrationStep)
+	}
+}


### PR DESCRIPTION
## Summary\n- add public instance and sqlite packages so external one-shot migrators can bootstrap canonical rein state without importing internal packages\n- add wrapper tests for the exported seams\n- document RN-27's external migration-tool pattern in the README\n\nCloses #27