### PR TITLE
RN-25: add backup and restore commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - Only the `live` instance is eligible for future auto-start behavior. Other instances must be started explicitly.
 - The current reserved layout is:
   - `grpc.sock` — default unix gRPC listener socket for that instance.
+  - `daemon.pid` — advisory pid/lock file while the selected daemon is running.
   - `rein.db` — canonical SQLite path reserved for that instance's persisted state.
 - `rein doctor` emits JSON diagnostics for daemon reachability, canonical instance layout, adapter registry compatibility, credential provider readiness, and SQLite migration state.
+- `rein backup <destination>` checkpoints SQLite WAL with `PRAGMA wal_checkpoint(TRUNCATE)` and atomically copies the selected instance state directory into `<destination>` while the daemon may still be running.
+- `rein backup --stop <destination>` is the paranoid fallback when you want the selected daemon stopped before copying.
+- `rein restore <source>` atomically replaces the selected instance state directory from `<source>`; stop the daemon first or pass `--stop` so rein can stop the selected instance before restoring.
 
 ## CLI surface
 
 - `rein` is the canonical gRPC client CLI. By default it connects to the selected instance over that instance's unix socket.
 - Use `rein daemon serve` to start the daemon for the selected instance.
+- Use `rein backup <destination>` to checkpoint and copy the selected instance state directory.
+- Use `rein restore <source>` to swap the selected instance state directory back from a backup copy.
 - Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics.
 - Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface and reachable protobuf schemas.
 - Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 
 	"github.com/earchibald/rein/internal/adapter"
+	"github.com/earchibald/rein/internal/instance"
 	"github.com/earchibald/rein/internal/server"
 	"github.com/earchibald/rein/internal/service"
 	"github.com/earchibald/rein/internal/storage/sqlite"
@@ -89,10 +90,14 @@ func (a *app) run(args []string) error {
 	switch remaining[0] {
 	case "daemon":
 		return a.runDaemon(root, remaining[1:])
+	case "backup":
+		return a.runBackup(root, remaining[1:])
 	case "doctor":
 		return a.runDoctor(root, remaining[1:])
 	case "describe-as":
 		return a.runDescribe(remaining)
+	case "restore":
+		return a.runRestore(root, remaining[1:])
 	case "tui":
 		return a.runTUI(root, remaining[1:])
 	default:
@@ -142,6 +147,11 @@ func (a *app) serveDaemon(config daemonServeConfig) error {
 	if err := config.instance.EnsureRootDir(); err != nil {
 		return fmt.Errorf("prepare instance state directory: %w", err)
 	}
+	pidFile, err := instance.AcquirePIDFile(config.instance.PIDPath)
+	if err != nil {
+		return fmt.Errorf("lock instance daemon pid file: %w", err)
+	}
+	defer pidFile.Close()
 
 	store, err := sqlite.OpenAndMigrate(context.Background(), sqlite.Config{Path: config.instance.DatabasePath})
 	if err != nil {
@@ -463,9 +473,11 @@ func (a *app) printRootHelp() {
 
 	fmt.Fprintln(a.stderr, "Usage:")
 	fmt.Fprintln(a.stderr, "  rein [global flags] <service> <verb> [flags]")
+	fmt.Fprintln(a.stderr, "  rein [global flags] backup [flags] <destination>")
 	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
 	fmt.Fprintln(a.stderr, "  rein [global flags] doctor")
 	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as=<format>")
+	fmt.Fprintln(a.stderr, "  rein [global flags] restore [flags] <source>")
 	fmt.Fprintln(a.stderr, "  rein [global flags] tui")
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Global flags:")
@@ -493,10 +505,25 @@ func (a *app) printRootHelp() {
 		}
 	}
 	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "  backup\tCheckpoint SQLite WAL and atomically copy the selected instance state.")
 	fmt.Fprintln(a.stderr, "  tui\tTerminal UI over the canonical gRPC surface.")
 	fmt.Fprintln(a.stderr, "  daemon serve\tStart the daemon and expose the canonical gRPC surface.")
 	fmt.Fprintln(a.stderr, "  doctor\tEmit JSON diagnostics for daemon health and local instance readiness.")
 	fmt.Fprintln(a.stderr, "  describe-as=<format>\tEmit a stable machine-consumable surface description.")
+	fmt.Fprintln(a.stderr, "  restore\tAtomically replace the selected instance state from a backup copy.")
+}
+
+func (a *app) printBackupHelp() {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] backup [flags] <destination>")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Checkpoint SQLite WAL for the selected instance and atomically copy its")
+	fmt.Fprintln(a.stderr, "state directory into <destination>. Runtime sockets and daemon pid files")
+	fmt.Fprintln(a.stderr, "are skipped. <destination> must not already exist.")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Flags:")
+	fmt.Fprintln(a.stderr, "  --stop bool")
+	fmt.Fprintln(a.stderr, "    Stop the selected daemon first as a paranoid fallback.")
 }
 
 func (a *app) printDaemonHelp() {
@@ -527,6 +554,20 @@ func (a *app) printDoctorHelp() {
 	fmt.Fprintln(a.stderr, "Emit machine-parseable JSON diagnostics covering daemon reachability,")
 	fmt.Fprintln(a.stderr, "instance layout, adapter registry compatibility, credential readiness,")
 	fmt.Fprintln(a.stderr, "and SQLite migration state for the selected instance.")
+}
+
+func (a *app) printRestoreHelp() {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintln(a.stderr, "  rein [global flags] restore [flags] <source>")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Atomically replace the selected instance state directory from <source>.")
+	fmt.Fprintln(a.stderr, "The daemon must be stopped first; pass --stop to stop a daemon that still")
+	fmt.Fprintln(a.stderr, "holds the selected instance pid file. Runtime sockets and daemon pid files")
+	fmt.Fprintln(a.stderr, "from the backup are not restored.")
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Flags:")
+	fmt.Fprintln(a.stderr, "  --stop bool")
+	fmt.Fprintln(a.stderr, "    Stop the selected daemon before replacing its state directory.")
 }
 
 func (a *app) printTUIHelp() {

--- a/cmd/rein/backup.go
+++ b/cmd/rein/backup.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+const stateCommandTimeout = 30 * time.Second
+
+type stateTransferConfig struct {
+	stop bool
+	path string
+}
+
+func (a *app) runBackup(root rootConfig, args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		a.printBackupHelp()
+		return flag.ErrHelp
+	}
+	config, err := parseStateTransferConfig("rein backup", args, a.stderr)
+	if err != nil {
+		return err
+	}
+	if config.stop {
+		if err := stopInstanceDaemon(root.instance, stateCommandTimeout); err != nil {
+			return fmt.Errorf("stop selected daemon: %w", err)
+		}
+	}
+	if err := checkpointInstanceDatabase(root.instance, stateCommandTimeout); err != nil {
+		return fmt.Errorf("checkpoint selected instance: %w", err)
+	}
+
+	destination, err := a.resolveCLIPath(config.path)
+	if err != nil {
+		return err
+	}
+	if err := instance.AtomicCopyDir(root.instance.RootDir, destination, instance.CopyDirOptions{Filter: instance.SkipRuntimeArtifacts}); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(a.stdout, "backup created at %s\n", destination)
+	return err
+}
+
+func (a *app) runRestore(root rootConfig, args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		a.printRestoreHelp()
+		return flag.ErrHelp
+	}
+	config, err := parseStateTransferConfig("rein restore", args, a.stderr)
+	if err != nil {
+		return err
+	}
+
+	running, err := daemonRunning(root.instance)
+	if err != nil {
+		return err
+	}
+	if running && !config.stop {
+		return fmt.Errorf("selected instance daemon is running; stop it first or pass --stop")
+	}
+	if config.stop {
+		if err := stopInstanceDaemon(root.instance, stateCommandTimeout); err != nil {
+			return fmt.Errorf("stop selected daemon: %w", err)
+		}
+	}
+
+	source, err := a.resolveCLIPath(config.path)
+	if err != nil {
+		return err
+	}
+	if err := instance.AtomicReplaceDir(source, root.instance.RootDir, instance.CopyDirOptions{Filter: instance.SkipRuntimeArtifacts}); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(a.stdout, "restored instance state from %s\n", source)
+	return err
+}
+
+func parseStateTransferConfig(name string, args []string, stderr io.Writer) (stateTransferConfig, error) {
+	flagSet := flag.NewFlagSet(name, flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+
+	stop := flagSet.Bool("stop", false, "stop the selected daemon first")
+	if err := flagSet.Parse(args); err != nil {
+		return stateTransferConfig{}, err
+	}
+	if flagSet.NArg() != 1 {
+		return stateTransferConfig{}, fmt.Errorf("exactly one path is required")
+	}
+	return stateTransferConfig{stop: *stop, path: flagSet.Arg(0)}, nil
+}
+
+func checkpointInstanceDatabase(layout instance.Layout, timeout time.Duration) error {
+	if _, err := os.Stat(layout.DatabasePath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect database %q: %w", layout.DatabasePath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if _, err := sqlite.CheckpointWAL(ctx, sqlite.Config{Path: layout.DatabasePath}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func daemonRunning(layout instance.Layout) (bool, error) {
+	_, running, err := instance.ReadRunningPID(layout.PIDPath)
+	if err != nil {
+		return false, err
+	}
+	if running {
+		return true, nil
+	}
+	return socketReachable(layout.SocketPath), nil
+}
+
+func stopInstanceDaemon(layout instance.Layout, timeout time.Duration) error {
+	pid, running, err := instance.ReadRunningPID(layout.PIDPath)
+	if err != nil {
+		return err
+	}
+	if !running {
+		if socketReachable(layout.SocketPath) {
+			return fmt.Errorf("daemon reachable at %q but pid file is unavailable; stop it manually", layout.SocketPath)
+		}
+		return nil
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find daemon process %d: %w", pid, err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil && !isProcessGone(err) {
+		return fmt.Errorf("signal daemon process %d: %w", pid, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		_, running, err := instance.ReadRunningPID(layout.PIDPath)
+		if err != nil {
+			return err
+		}
+		if !running {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for daemon process %d to stop", pid)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func socketReachable(path string) bool {
+	conn, err := net.DialTimeout("unix", path, 250*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func isProcessGone(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}
+
+func (a *app) resolveCLIPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	workingDir, err := a.getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	return filepath.Clean(filepath.Join(workingDir, path)), nil
+}

--- a/cmd/rein/backup_test.go
+++ b/cmd/rein/backup_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/storage/sqlite"
+)
+
+func TestBackupHelperProcess(t *testing.T) {
+	if os.Getenv("REIN_TEST_PID_HELPER") != "1" {
+		t.Skip("helper process only")
+	}
+
+	pidPath := os.Getenv("REIN_TEST_PID_PATH")
+	if pidPath == "" {
+		t.Fatal("REIN_TEST_PID_PATH is required")
+	}
+	pidFile, err := instance.AcquirePIDFile(pidPath)
+	if err != nil {
+		t.Fatalf("AcquirePIDFile() error = %v", err)
+	}
+	defer pidFile.Close()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM)
+	defer signal.Stop(signals)
+	<-signals
+}
+
+func TestBackupAndRestoreHelp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "backup",
+			args: []string{"backup", "--help"},
+			want: []string{"rein [global flags] backup [flags] <destination>", "Checkpoint SQLite WAL", "--stop bool"},
+		},
+		{
+			name: "restore",
+			args: []string{"restore", "--help"},
+			want: []string{"rein [global flags] restore [flags] <source>", "Atomically replace the selected instance state directory", "--stop bool"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			app := newTestApp(&stdout, &stderr, t.TempDir())
+			err := app.run(tc.args)
+			if err != flag.ErrHelp {
+				t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("help output missing %q\n%s", want, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func TestBackupCommandCheckpointsAndCopiesInstance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stateHome := t.TempDir()
+	layout := mustLayout(t, stateHome)
+	store := openFileStore(t, ctx, layout.DatabasePath)
+	if _, err := store.Create(ctx, sqlite.ProjectKind, "project-1", json.RawMessage(`{"name":"rein"}`)); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	backupPath := filepath.Join(t.TempDir(), "backup")
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, envLookup(stateHome), nil, func() (string, error) {
+		return t.TempDir(), nil
+	})
+	if err := app.run([]string{"backup", backupPath}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), backupPath) {
+		t.Fatalf("stdout = %q, want backup path %q", stdout.String(), backupPath)
+	}
+
+	copiedStore := openFileStore(t, ctx, filepath.Join(backupPath, "rein.db"))
+	if _, err := copiedStore.Get(ctx, sqlite.ProjectKind, "project-1"); err != nil {
+		t.Fatalf("copied store Get() error = %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(backupPath, "rein.db-wal")); err == nil && info.Size() != 0 {
+		t.Fatalf("backup wal size = %d, want 0 after checkpoint", info.Size())
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backup wal stat error = %v", err)
+	}
+}
+
+func TestBackupStopStopsDaemonBeforeCopy(t *testing.T) {
+	stateHome := t.TempDir()
+	layout := mustLayout(t, stateHome)
+	if err := os.WriteFile(filepath.Join(layout.RootDir, "state.txt"), []byte("ready"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestBackupHelperProcess")
+	cmd.Env = append(os.Environ(),
+		"REIN_TEST_PID_HELPER=1",
+		"REIN_TEST_PID_PATH="+layout.PIDPath,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start() error = %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	helperExited := false
+	defer func() {
+		if helperExited {
+			return
+		}
+		select {
+		case <-done:
+		default:
+			_ = cmd.Process.Kill()
+			<-done
+		}
+	}()
+	waitForPIDLock(t, layout.PIDPath)
+
+	backupPath := filepath.Join(t.TempDir(), "backup")
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, envLookup(stateHome), nil, func() (string, error) {
+		return t.TempDir(), nil
+	})
+	if err := app.run([]string{"backup", "--stop", backupPath}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("helper exit error = %v", err)
+	}
+	helperExited = true
+	if _, err := os.Stat(filepath.Join(backupPath, "state.txt")); err != nil {
+		t.Fatalf("backup state file missing: %v", err)
+	}
+}
+
+func TestRestoreCommandRejectsRunningDaemonWithoutStop(t *testing.T) {
+	t.Parallel()
+
+	stateHome := t.TempDir()
+	layout := mustLayout(t, stateHome)
+	pidFile, err := instance.AcquirePIDFile(layout.PIDPath)
+	if err != nil {
+		t.Fatalf("AcquirePIDFile() error = %v", err)
+	}
+	defer pidFile.Close()
+
+	source := filepath.Join(t.TempDir(), "backup")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, envLookup(stateHome), nil, func() (string, error) {
+		return t.TempDir(), nil
+	})
+	err = app.run([]string{"restore", source})
+	if err == nil || !strings.Contains(err.Error(), "daemon is running") {
+		t.Fatalf("run() error = %v, want daemon running", err)
+	}
+}
+
+func TestRestoreCommandReplacesInstanceState(t *testing.T) {
+	t.Parallel()
+
+	stateHome := t.TempDir()
+	layout := mustLayout(t, stateHome)
+	if err := os.WriteFile(filepath.Join(layout.RootDir, "old.txt"), []byte("old"), 0o600); err != nil {
+		t.Fatalf("WriteFile(old) error = %v", err)
+	}
+
+	source := filepath.Join(t.TempDir(), "backup")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatalf("MkdirAll(source) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "rein.db"), []byte("db"), 0o600); err != nil {
+		t.Fatalf("WriteFile(db) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "daemon.pid"), []byte("123\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(pid) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "grpc.sock"), []byte("socket"), 0o600); err != nil {
+		t.Fatalf("WriteFile(socket) error = %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, envLookup(stateHome), nil, func() (string, error) {
+		return t.TempDir(), nil
+	})
+	if err := app.run([]string{"restore", source}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(layout.RootDir, "rein.db")); err != nil {
+		t.Fatalf("restored database missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(layout.RootDir, "old.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old state stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(layout.PIDPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restored pid stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(layout.SocketPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restored socket stat error = %v, want not exist", err)
+	}
+}
+
+func newTestApp(stdout, stderr *bytes.Buffer, stateHome string) *app {
+	return newApp(stdout, stderr, envLookup(stateHome), nil, func() (string, error) {
+		return tTempDir(stateHome), nil
+	})
+}
+
+func envLookup(stateHome string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		if key == "XDG_STATE_HOME" {
+			return stateHome, true
+		}
+		return "", false
+	}
+}
+
+func mustLayout(t *testing.T, stateHome string) instance.Layout {
+	t.Helper()
+	layout, err := instance.NewLayout(instance.DefaultName, stateHome)
+	if err != nil {
+		t.Fatalf("NewLayout() error = %v", err)
+	}
+	if err := layout.EnsureRootDir(); err != nil {
+		t.Fatalf("EnsureRootDir() error = %v", err)
+	}
+	return layout
+}
+
+func openFileStore(t *testing.T, ctx context.Context, path string) *sqlite.Store {
+	t.Helper()
+	store, err := sqlite.OpenAndMigrate(ctx, sqlite.Config{Path: path})
+	if err != nil {
+		t.Fatalf("OpenAndMigrate(%q) error = %v", path, err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return store
+}
+
+func waitForPIDLock(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		pid, running, err := instance.ReadRunningPID(path)
+		if err == nil && running && pid > 0 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for running pid at %q", path)
+}
+
+func tTempDir(stateHome string) string {
+	return filepath.Join(stateHome, "worktree")
+}

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -190,7 +190,7 @@ func TestAppCommandHelpUsesProtoComments(t *testing.T) {
 	}
 }
 
-func TestRootHelpListsDoctorDescribeAndTUICommands(t *testing.T) {
+func TestRootHelpListsStaticCommands(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -206,9 +206,11 @@ func TestRootHelpListsDoctorDescribeAndTUICommands(t *testing.T) {
 	}
 	output := stderr.String()
 	for _, want := range []string{
+		"backup\tCheckpoint SQLite WAL",
 		"doctor\tEmit JSON diagnostics",
 		"rein [global flags] describe-as=<format>",
 		"describe-as=<format>\tEmit a stable machine-consumable surface description.",
+		"restore\tAtomically replace the selected instance state from a backup copy.",
 		"tui\tTerminal UI over the canonical gRPC surface.",
 	} {
 		if !strings.Contains(output, want) {

--- a/cmd/rein/describe.go
+++ b/cmd/rein/describe.go
@@ -111,8 +111,10 @@ func supportedDescribeFormats() []describeFormatDescription {
 func rootUsageLines() []string {
 	return []string{
 		"rein [global flags] <service> <verb> [flags]",
+		"rein [global flags] backup [flags] <destination>",
 		"rein [global flags] daemon serve [flags]",
 		"rein [global flags] describe-as=<format>",
+		"rein [global flags] restore [flags] <source>",
 	}
 }
 

--- a/cmd/rein/doctor.go
+++ b/cmd/rein/doctor.go
@@ -33,6 +33,7 @@ type doctorInstanceDiagnostic struct {
 	StateHome    string                 `json:"stateHome"`
 	RootDir      string                 `json:"rootDir"`
 	SocketPath   string                 `json:"socketPath"`
+	PIDPath      string                 `json:"pidPath"`
 	DatabasePath string                 `json:"databasePath"`
 	AutoStart    bool                   `json:"autoStart"`
 	Layout       doctorLayoutDiagnostic `json:"layout"`
@@ -167,6 +168,7 @@ func diagnoseInstance(layout instance.Layout) doctorInstanceDiagnostic {
 		StateHome:    layout.StateHome,
 		RootDir:      layout.RootDir,
 		SocketPath:   layout.SocketPath,
+		PIDPath:      layout.PIDPath,
 		DatabasePath: layout.DatabasePath,
 		AutoStart:    layout.AutoStartEnabled(),
 	}

--- a/cmd/rein/doctor_test.go
+++ b/cmd/rein/doctor_test.go
@@ -89,8 +89,9 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 
 	var payload struct {
 		Instance struct {
-			Name   string `json:"name"`
-			Layout struct {
+			Name    string `json:"name"`
+			PIDPath string `json:"pidPath"`
+			Layout  struct {
 				Canonical      bool `json:"canonical"`
 				RootExists     bool `json:"rootExists"`
 				DatabaseExists bool `json:"databaseExists"`
@@ -128,6 +129,9 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 
 	if payload.Instance.Name != instance.DefaultName {
 		t.Fatalf("instance name = %q, want %q", payload.Instance.Name, instance.DefaultName)
+	}
+	if payload.Instance.PIDPath != layout.PIDPath {
+		t.Fatalf("instance pid path = %q, want %q", payload.Instance.PIDPath, layout.PIDPath)
 	}
 	if !payload.Instance.Layout.Canonical || !payload.Instance.Layout.RootExists || !payload.Instance.Layout.DatabaseExists {
 		t.Fatalf("instance layout = %+v, want canonical existing layout", payload.Instance.Layout)

--- a/internal/instance/layout.go
+++ b/internal/instance/layout.go
@@ -14,6 +14,7 @@ const (
 	rootDirName      = "rein"
 	instancesDirName = "instances"
 	socketFileName   = "grpc.sock"
+	pidFileName      = "daemon.pid"
 	storeFileName    = "rein.db"
 )
 
@@ -31,6 +32,7 @@ type Layout struct {
 	StateHome    string
 	RootDir      string
 	SocketPath   string
+	PIDPath      string
 	DatabasePath string
 }
 
@@ -80,6 +82,7 @@ func NewLayout(name, stateHome string) (Layout, error) {
 		StateHome:    stateHome,
 		RootDir:      rootDir,
 		SocketPath:   filepath.Join(rootDir, socketFileName),
+		PIDPath:      filepath.Join(rootDir, pidFileName),
 		DatabasePath: filepath.Join(rootDir, storeFileName),
 	}
 
@@ -120,6 +123,9 @@ func (l Layout) Validate() error {
 	}
 	if filepath.Clean(l.SocketPath) != filepath.Join(expectedRoot, socketFileName) {
 		return fmt.Errorf("instance: socket path %q does not match canonical layout", l.SocketPath)
+	}
+	if filepath.Clean(l.PIDPath) != filepath.Join(expectedRoot, pidFileName) {
+		return fmt.Errorf("instance: pid path %q does not match canonical layout", l.PIDPath)
 	}
 	if filepath.Clean(l.DatabasePath) != filepath.Join(expectedRoot, storeFileName) {
 		return fmt.Errorf("instance: database path %q does not match canonical layout", l.DatabasePath)

--- a/internal/instance/pidfile_test.go
+++ b/internal/instance/pidfile_test.go
@@ -1,0 +1,42 @@
+//go:build darwin || linux
+
+package instance
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPIDFileTracksRunningDaemon(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), pidFileName)
+	pidFile, err := AcquirePIDFile(path)
+	if err != nil {
+		t.Fatalf("AcquirePIDFile() error = %v", err)
+	}
+	defer pidFile.Close()
+
+	pid, running, err := ReadRunningPID(path)
+	if err != nil {
+		t.Fatalf("ReadRunningPID() error = %v", err)
+	}
+	if !running {
+		t.Fatal("ReadRunningPID() running = false, want true")
+	}
+	if pid <= 0 {
+		t.Fatalf("ReadRunningPID() pid = %d, want > 0", pid)
+	}
+
+	if err := pidFile.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	pid, running, err = ReadRunningPID(path)
+	if err != nil {
+		t.Fatalf("ReadRunningPID() after close error = %v", err)
+	}
+	if running || pid != 0 {
+		t.Fatalf("ReadRunningPID() after close = (%d, %t), want (0, false)", pid, running)
+	}
+}

--- a/internal/instance/pidfile_unix.go
+++ b/internal/instance/pidfile_unix.go
@@ -1,0 +1,116 @@
+//go:build darwin || linux
+
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+var ErrDaemonAlreadyRunning = errors.New("instance: daemon already running")
+
+// PIDFile holds the advisory lock that marks an instance daemon as running.
+type PIDFile struct {
+	path string
+	file *os.File
+}
+
+func AcquirePIDFile(path string) (*PIDFile, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("instance: open pid file %q: %w", path, err)
+	}
+
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		if isLockHeld(err) {
+			return nil, fmt.Errorf("%w: %s", ErrDaemonAlreadyRunning, path)
+		}
+		return nil, fmt.Errorf("instance: lock pid file %q: %w", path, err)
+	}
+
+	if err := file.Truncate(0); err != nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+		return nil, fmt.Errorf("instance: truncate pid file %q: %w", path, err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+		return nil, fmt.Errorf("instance: seek pid file %q: %w", path, err)
+	}
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+		return nil, fmt.Errorf("instance: write pid file %q: %w", path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+		return nil, fmt.Errorf("instance: sync pid file %q: %w", path, err)
+	}
+
+	return &PIDFile{path: path, file: file}, nil
+}
+
+func ReadRunningPID(path string) (pid int, running bool, err error) {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("instance: open pid file %q: %w", path, err)
+	}
+	defer file.Close()
+
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err == nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		return 0, false, nil
+	} else if !isLockHeld(err) {
+		return 0, false, fmt.Errorf("instance: inspect pid file lock %q: %w", path, err)
+	}
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return 0, false, fmt.Errorf("instance: seek pid file %q: %w", path, err)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return 0, false, fmt.Errorf("instance: read pid file %q: %w", path, err)
+	}
+
+	pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false, fmt.Errorf("instance: parse pid file %q: %w", path, err)
+	}
+
+	return pid, true, nil
+}
+
+func (p *PIDFile) Close() error {
+	if p == nil || p.file == nil {
+		return nil
+	}
+
+	lockErr := unix.Flock(int(p.file.Fd()), unix.LOCK_UN)
+	closeErr := p.file.Close()
+	removeErr := os.Remove(p.path)
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+	p.file = nil
+
+	if lockErr != nil || closeErr != nil || removeErr != nil {
+		return errors.Join(lockErr, closeErr, removeErr)
+	}
+	return nil
+}
+
+func isLockHeld(err error) bool {
+	return errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN)
+}

--- a/internal/instance/statecopy.go
+++ b/internal/instance/statecopy.go
@@ -1,0 +1,254 @@
+package instance
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type CopyDirOptions struct {
+	Filter func(relPath string, entry fs.DirEntry) (bool, error)
+}
+
+func AtomicCopyDir(src, dst string, options CopyDirOptions) error {
+	source, destination, err := normalizeDistinctPaths(src, dst)
+	if err != nil {
+		return err
+	}
+	if exists, err := pathExists(destination); err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("instance: destination %q already exists", destination)
+	}
+
+	if err := ensureSourceDir(source); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("instance: create destination parent for %q: %w", destination, err)
+	}
+
+	temporary := siblingTempPath(destination, "copy")
+	if err := copyDirTree(source, temporary, options); err != nil {
+		_ = os.RemoveAll(temporary)
+		return err
+	}
+	if err := os.Rename(temporary, destination); err != nil {
+		_ = os.RemoveAll(temporary)
+		return fmt.Errorf("instance: publish copied directory %q: %w", destination, err)
+	}
+	return nil
+}
+
+func AtomicReplaceDir(src, dst string, options CopyDirOptions) error {
+	source, destination, err := normalizeDistinctPaths(src, dst)
+	if err != nil {
+		return err
+	}
+	if err := ensureSourceDir(source); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("instance: create destination parent for %q: %w", destination, err)
+	}
+
+	newPath := siblingTempPath(destination, "restore-new")
+	if err := copyDirTree(source, newPath, options); err != nil {
+		_ = os.RemoveAll(newPath)
+		return err
+	}
+
+	if exists, err := pathExists(destination); err != nil {
+		_ = os.RemoveAll(newPath)
+		return err
+	} else if !exists {
+		if err := os.Rename(newPath, destination); err != nil {
+			_ = os.RemoveAll(newPath)
+			return fmt.Errorf("instance: publish restored directory %q: %w", destination, err)
+		}
+		return nil
+	}
+
+	oldPath := siblingTempPath(destination, "restore-old")
+	if err := os.Rename(destination, oldPath); err != nil {
+		_ = os.RemoveAll(newPath)
+		return fmt.Errorf("instance: move existing directory %q aside: %w", destination, err)
+	}
+	if err := os.Rename(newPath, destination); err != nil {
+		rollbackErr := os.Rename(oldPath, destination)
+		_ = os.RemoveAll(newPath)
+		if rollbackErr != nil {
+			return errors.Join(
+				fmt.Errorf("instance: publish restored directory %q: %w", destination, err),
+				fmt.Errorf("instance: rollback restored directory %q: %w", destination, rollbackErr),
+			)
+		}
+		return fmt.Errorf("instance: publish restored directory %q: %w", destination, err)
+	}
+	if err := os.RemoveAll(oldPath); err != nil {
+		return fmt.Errorf("instance: remove previous directory %q: %w", oldPath, err)
+	}
+	return nil
+}
+
+func SkipRuntimeArtifacts(relPath string, entry fs.DirEntry) (bool, error) {
+	clean := filepath.Clean(relPath)
+	if clean == "." {
+		return false, nil
+	}
+	if entry.Type()&os.ModeSocket != 0 {
+		return true, nil
+	}
+	name := filepath.Base(clean)
+	if name == socketFileName || name == pidFileName {
+		return true, nil
+	}
+	return false, nil
+}
+
+func copyDirTree(src, dst string, options CopyDirOptions) error {
+	rootInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("instance: inspect source directory %q: %w", src, err)
+	}
+	if !rootInfo.IsDir() {
+		return fmt.Errorf("instance: source %q is not a directory", src)
+	}
+	if err := os.Mkdir(dst, rootInfo.Mode().Perm()); err != nil {
+		return fmt.Errorf("instance: create directory %q: %w", dst, err)
+	}
+
+	return filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("instance: walk %q: %w", path, walkErr)
+		}
+		if path == src {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("instance: compute relative path for %q: %w", path, err)
+		}
+		if options.Filter != nil {
+			skip, err := options.Filter(relPath, entry)
+			if err != nil {
+				return err
+			}
+			if skip {
+				if entry.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
+		target := filepath.Join(dst, relPath)
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("instance: inspect %q: %w", path, err)
+		}
+
+		switch {
+		case info.IsDir():
+			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("instance: create directory %q: %w", target, err)
+			}
+		case info.Mode().IsRegular():
+			if err := copyRegularFile(path, target, info.Mode().Perm(), info.ModTime()); err != nil {
+				return err
+			}
+		case info.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("instance: refusing to copy symlink %q", path)
+		case info.Mode()&os.ModeSocket != 0:
+			return fmt.Errorf("instance: refusing to copy socket %q", path)
+		default:
+			return fmt.Errorf("instance: unsupported file mode %s for %q", info.Mode(), path)
+		}
+		return nil
+	})
+}
+
+func copyRegularFile(src, dst string, mode fs.FileMode, modifiedAt time.Time) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("instance: open source file %q: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("instance: create destination file %q: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("instance: copy file %q -> %q: %w", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("instance: close destination file %q: %w", dst, err)
+	}
+	if err := os.Chtimes(dst, modifiedAt, modifiedAt); err != nil {
+		return fmt.Errorf("instance: preserve timestamps for %q: %w", dst, err)
+	}
+	return nil
+}
+
+func normalizeDistinctPaths(src, dst string) (source, destination string, err error) {
+	source, err = filepath.Abs(src)
+	if err != nil {
+		return "", "", fmt.Errorf("instance: resolve source path %q: %w", src, err)
+	}
+	destination, err = filepath.Abs(dst)
+	if err != nil {
+		return "", "", fmt.Errorf("instance: resolve destination path %q: %w", dst, err)
+	}
+	source = filepath.Clean(source)
+	destination = filepath.Clean(destination)
+	if source == destination {
+		return "", "", fmt.Errorf("instance: source and destination must differ")
+	}
+	if pathContains(source, destination) || pathContains(destination, source) {
+		return "", "", fmt.Errorf("instance: source %q and destination %q must not overlap", source, destination)
+	}
+	return source, destination, nil
+}
+
+func ensureSourceDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("instance: inspect source directory %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("instance: source %q is not a directory", path)
+	}
+	return nil
+}
+
+func siblingTempPath(path, label string) string {
+	base := fmt.Sprintf(".%s.rein-%s-%d", filepath.Base(path), label, time.Now().UnixNano())
+	return filepath.Join(filepath.Dir(path), base)
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("instance: inspect %q: %w", path, err)
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/internal/instance/statecopy_test.go
+++ b/internal/instance/statecopy_test.go
@@ -1,0 +1,75 @@
+package instance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicCopyDirSkipsRuntimeArtifacts(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(filepath.Join(src, "nested"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "rein.db"), []byte("db"), 0o600); err != nil {
+		t.Fatalf("WriteFile(db) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "nested", "notes.txt"), []byte("notes"), 0o644); err != nil {
+		t.Fatalf("WriteFile(notes) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, pidFileName), []byte("123\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(pid) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, socketFileName), []byte("socket"), 0o600); err != nil {
+		t.Fatalf("WriteFile(socket) error = %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "backup")
+	if err := AtomicCopyDir(src, dst, CopyDirOptions{Filter: SkipRuntimeArtifacts}); err != nil {
+		t.Fatalf("AtomicCopyDir() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "rein.db")); err != nil {
+		t.Fatalf("copied database missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "nested", "notes.txt")); err != nil {
+		t.Fatalf("copied nested file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, pidFileName)); !os.IsNotExist(err) {
+		t.Fatalf("pid file stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, socketFileName)); !os.IsNotExist(err) {
+		t.Fatalf("socket stat error = %v, want not exist", err)
+	}
+}
+
+func TestAtomicReplaceDirReplacesExistingState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	src := filepath.Join(root, "backup")
+	dst := filepath.Join(root, "instance")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("MkdirAll(src) error = %v", err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("MkdirAll(dst) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "rein.db"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("WriteFile(new) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "old.txt"), []byte("old"), 0o600); err != nil {
+		t.Fatalf("WriteFile(old) error = %v", err)
+	}
+
+	if err := AtomicReplaceDir(src, dst, CopyDirOptions{Filter: SkipRuntimeArtifacts}); err != nil {
+		t.Fatalf("AtomicReplaceDir() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "rein.db")); err != nil {
+		t.Fatalf("restored database missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("old state stat error = %v, want not exist", err)
+	}
+}

--- a/internal/storage/sqlite/checkpoint.go
+++ b/internal/storage/sqlite/checkpoint.go
@@ -1,0 +1,37 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrCheckpointBusy = errors.New("sqlite: WAL checkpoint busy")
+
+type CheckpointResult struct {
+	Busy               int
+	LogFrames          int
+	CheckpointedFrames int
+}
+
+func CheckpointWAL(ctx context.Context, cfg Config) (CheckpointResult, error) {
+	normalized, err := cfg.normalize()
+	if err != nil {
+		return CheckpointResult{}, err
+	}
+
+	db, err := openDB(ctx, normalized)
+	if err != nil {
+		return CheckpointResult{}, err
+	}
+	defer db.Close()
+
+	var result CheckpointResult
+	if err := db.QueryRowContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`).Scan(&result.Busy, &result.LogFrames, &result.CheckpointedFrames); err != nil {
+		return CheckpointResult{}, fmt.Errorf("sqlite: checkpoint WAL for %q: %w", normalized.Path, err)
+	}
+	if result.Busy != 0 {
+		return result, fmt.Errorf("%w for %q: %d busy connections", ErrCheckpointBusy, normalized.Path, result.Busy)
+	}
+	return result, nil
+}

--- a/internal/storage/sqlite/checkpoint_test.go
+++ b/internal/storage/sqlite/checkpoint_test.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckpointWALTruncatesLiveDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "rein.db")
+	store, err := OpenAndMigrate(ctx, Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("OpenAndMigrate() error = %v", err)
+	}
+	defer store.Close()
+
+	for i := 0; i < 8; i++ {
+		payload, _ := json.Marshal(map[string]any{"index": i})
+		if _, err := store.Create(ctx, ProjectKind, fmt.Sprintf("project-%d", i), payload); err != nil {
+			t.Fatalf("Create(%d) error = %v", i, err)
+		}
+	}
+
+	walPath := dbPath + "-wal"
+	if info, err := os.Stat(walPath); err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", walPath, err)
+	} else if info.Size() == 0 {
+		t.Fatalf("wal size = 0, want pending frames before checkpoint")
+	}
+
+	result, err := CheckpointWAL(ctx, Config{Path: dbPath})
+	if err != nil {
+		t.Fatalf("CheckpointWAL() error = %v", err)
+	}
+	if result.Busy != 0 {
+		t.Fatalf("CheckpointWAL() busy = %d, want 0", result.Busy)
+	}
+	if info, err := os.Stat(walPath); err != nil {
+		t.Fatalf("os.Stat(%q) after checkpoint error = %v", walPath, err)
+	} else if info.Size() != 0 {
+		t.Fatalf("wal size after checkpoint = %d, want 0", info.Size())
+	}
+}


### PR DESCRIPTION
## Summary
- add `rein backup` / `rein restore` with WAL checkpointing, atomic directory copy/swap, and `--stop` support
- track a running daemon with an advisory `daemon.pid` lock file so backup/restore can stop the selected instance safely
- cover the new CLI and storage behavior with focused tests and README updates

## Testing
- just ci