### PR TITLE
RN-28: expand user docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 bin/
+docs/book/
 
 # Go test cache
 *.test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,86 @@
 # rein
 Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMIs (CLI/TUI) + plugin marketplace.
 
+Rein is still early, but the current tree already ships a usable local daemon, a descriptor-driven CLI, a terminal UI, per-instance SQLite state management, backup/restore tooling, diagnostics, and opt-in OTLP telemetry with a bundled SigNoz dashboard pack.
+
+## What ships today
+
+- A single `rein` binary that can run the daemon, speak the canonical gRPC/CLI surface, and launch the TUI.
+- Per-instance state under `~/.local/state/rein/instances/<name>/` (or `$XDG_STATE_HOME/rein/instances/<name>/`) with `rein backup` and `rein restore` for safe copies.
+- `rein doctor` JSON diagnostics for instance layout, daemon reachability, adapter registry readiness, credential-provider readiness, and SQLite migration state.
+- Opt-in OTLP/gRPC export for traces, metrics, and logs, plus a bundled `rein dashboards apply` workflow for SigNoz.
+- A signed repository marketplace index plus bundled first-party plugins under `plugins/`.
+- External seams for one-shot migration tooling and external coding adapters, without pulling those source-system dependencies into the core daemon.
+
+## Quickstart
+
+Build the current tree with Go 1.25:
+
+```bash
+go build -o bin/rein ./cmd/rein
+```
+
+Start the daemon for the default `live` instance:
+
+```bash
+./bin/rein daemon serve
+```
+
+In another terminal, inspect health and the current API surface:
+
+```bash
+./bin/rein doctor
+./bin/rein project list
+./bin/rein issue list
+./bin/rein describe-as=cli
+```
+
+Launch the terminal UI against that same daemon:
+
+```bash
+./bin/rein tui
+```
+
+Checkpoint the selected instance before risky changes:
+
+```bash
+./bin/rein backup ./backups/live
+```
+
+Apply the bundled SigNoz dashboards from the repo root (or any child directory inside this repo):
+
+```bash
+SIGNOZ_BASE_URL=http://localhost:3301 \
+SIGNOZ_API_KEY=replace-me \
+./bin/rein dashboards apply
+```
+
+## Documentation
+
+Longer user guides live under `docs/` and can be read directly in the repo or served as an mdBook:
+
+- [Docs overview](docs/src/README.md)
+- [CLI quickstart](docs/src/cli-quickstart.md)
+- [TUI quickstart](docs/src/tui-quickstart.md)
+- [Metrics, logs, and OTLP](docs/src/metrics-logs-otlp.md)
+- [Plugin author guide](docs/src/plugin-author-guide.md)
+- [Migration guide](docs/src/migration-guide.md)
+- [Docs summary / table of contents](docs/src/SUMMARY.md)
+
+To browse the same content as a docs site locally:
+
+```bash
+cargo install mdbook --locked
+mdbook serve docs
+```
+
+## Current limitations to keep in mind
+
+- The repository marketplace can advertise remote adapters today, but remote managed execution is still an explicit stub until the external adapter bridge lands.
+- `rein dashboards apply` currently installs bundled local dashboard plugins; remote dashboard bootstrap is an explicit follow-up.
+- Looking-glass tail support is surfaced in the TUI and execution inspection, but the daemon does not stream live tails yet.
+- One-shot imports from op-obsidian live in the separate [`earchibald/rein-migrate-from-op-obsidian`](https://github.com/earchibald/rein-migrate-from-op-obsidian) repo.
+
 ## Instance state layout
 
 - Rein keeps per-instance state under `~/.local/state/rein/instances/<name>/` by default, or under `$XDG_STATE_HOME/rein/instances/<name>/` when `XDG_STATE_HOME` is set.
@@ -28,21 +108,28 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 - Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.
 - Use `rein tui` for the terminal-native HMI over that same daemon surface.
 - Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
-- Request flags map 1:1 to top-level gRPC request fields. Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
+- Top-level request flags map 1:1 to top-level protobuf request fields and use the protobuf field names (for example `--project_id`).
+- Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
+- Nested JSON payloads are decoded with protobuf JSON field names (for example `displayName` inside a `Project` payload).
 - Responses are emitted as JSON using protobuf field names.
 
 ## Adapter registry
 
 - The repo ships a signed marketplace index at `.claude-plugin/marketplace.json` for built-in and remote adapter discovery.
-- Repository-local trusted public keys live at `.claude-plugin/trusted-keys.json`; the daemon and `rein doctor` load them automatically before verifying marketplace signatures.
+- Repository-local trusted public keys live at `.claude-plugin/trusted-keys.json`; `rein doctor` reports signature presence and verification status.
+- The daemon's local discovery path tolerates unsigned marketplace indexes for local development, but the committed repository index should remain signed.
 - `messaging-null` is a no-op notification adapter that advertises `messaging.post` so workflows can stay launchable until Slack and Discord adapters land.
 - The in-tree `muxiterm` multiplexer adapter manifest lives at `plugins/muxiterm/.claude-plugin/plugin.json` and advertises the bundled mux capability surface.
+- The in-tree `tracker-github` manifest lives at `plugins/tracker-github/.claude-plugin/plugin.json` and advertises worktree/PR/tracker capabilities.
 
 ## OTLP telemetry
 
-- OTLP export is opt-in. When no OTLP endpoint is configured, the daemon keeps its existing no-op behavior for traces, metrics, and logs.
-- When configured, the daemon emits OTLP/gRPC traces, logs, and bounded custom metrics for daemon starts, daemon liveness, gRPC request counts, gRPC error counts, and gRPC request duration.
+- OTLP export is opt-in. When no OTLP endpoint is configured, the daemon keeps its existing no-op behavior for traces, metrics, and OTLP log export.
+- The daemon still writes structured text logs to stdout even when OTLP export is disabled.
+- When configured, the daemon exports traces, logs, and bounded custom metrics for daemon starts, daemon liveness, gRPC request counts, gRPC error counts, and gRPC request duration.
+- Current metric names are `rein.daemon.starts`, `rein.daemon.running`, `rein.rpc.requests`, `rein.rpc.errors`, and `rein.rpc.duration`.
 - Default OTLP resource attributes include `service.name=rein-daemon`, `rein.instance=<instance>`, and `service.instance.id=<instance>`.
+- `rein dashboards apply` installs the bundled SigNoz dashboard JSON at `plugins/rein-dashboards/signoz/rein-daemon-otlp.json`.
 
 ## Dashboards marketplace
 
@@ -61,21 +148,24 @@ Modular orchestrator daemon — successor to op-obsidian. Go daemon + plural HMI
 
 - Rein discovers adapters from `.claude-plugin/marketplace.json` at the repository root.
 - RN-23 boots the Claude Code coding-agent adapter as a remote GitHub marketplace entry (`earchibald/rein-adapter-claude-code`) instead of a local plugin checkout.
-- The registry and adapter APIs now surface that remote entry immediately; managed execution still reports an explicit “not wired yet” stub until the external adapter bridge lands.
+- The registry and adapter APIs surface that remote entry immediately; managed execution still reports an explicit “not wired yet” stub until the external adapter bridge lands.
 
 ## External migration tooling
 
-- One-shot migration/import tools should live in separate repos rather than pulling legacy source-system dependencies into `rein`.
+- One-shot migration/import tools live in separate repos rather than pulling legacy source-system dependencies into `rein`.
 - `github.com/earchibald/rein/instance` exposes the canonical instance layout helpers used to resolve `grpc.sock` and `rein.db` paths for external tools.
 - `github.com/earchibald/rein/sqlite` exposes the migrated locked-entity SQLite store needed to create and populate rein state from those external tools.
-- RN-27 boots the op-obsidian migration CLI as the separate repo `earchibald/rein-migrate-from-op-obsidian`.
+- RN-27 boots the op-obsidian migration CLI as the separate repo [`earchibald/rein-migrate-from-op-obsidian`](https://github.com/earchibald/rein-migrate-from-op-obsidian).
 
 ## Development
 
+- Go 1.25 is the repository baseline.
 - `just proto` lints the Buf workspace and regenerates the committed Go protobuf/gRPC stubs.
+- `just build` builds `./cmd/rein` into `bin/rein`.
 - `just test` is the standard test entrypoint and runs the suite via `gotestsum`.
 - `just test-race` keeps the same runner while enabling the Go race detector.
 - `just test-cover` writes `coverage.out` and prints `go tool cover -func` output for local review.
+- `just lint` runs golangci-lint v2 (`go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1`).
 
 ## Test harness
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,12 @@
+[book]
+title = "rein"
+description = "User documentation for the rein daemon, CLI, TUI, telemetry, plugins, and migration tooling."
+authors = ["earchibald"]
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "navy"
+git-repository-url = "https://github.com/earchibald/rein"
+edit-url-template = "https://github.com/earchibald/rein/edit/main/docs/src/{path}"
+site-url = "/rein/"

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,47 @@
+# rein docs
+
+These pages are the longer-form companion to the repository [README](../../README.md). The goal is to keep the README useful as a landing page while giving operators, plugin authors, and migrators a place for the current details that matter.
+
+## What rein is today
+
+Rein currently ships:
+
+- a Go daemon with a canonical gRPC surface
+- a descriptor-driven CLI in the same `rein` binary
+- a terminal UI (`rein tui`) over that daemon surface
+- per-instance SQLite state with backup/restore commands
+- `rein doctor` JSON diagnostics
+- opt-in OTLP export for traces, metrics, and logs
+- a bundled SigNoz dashboard plugin and marketplace metadata
+
+It also deliberately keeps some work out of tree:
+
+- op-obsidian migration lives in [`earchibald/rein-migrate-from-op-obsidian`](https://github.com/earchibald/rein-migrate-from-op-obsidian)
+- the Claude Code coding-agent adapter bootstrap lives in [`earchibald/rein-adapter-claude-code`](https://github.com/earchibald/rein-adapter-claude-code)
+
+## Start here
+
+- New operator? Read the [CLI quickstart](cli-quickstart.md).
+- Prefer a terminal UI? Read the [TUI quickstart](tui-quickstart.md).
+- Wiring observability? Read [Metrics, logs, and OTLP](metrics-logs-otlp.md).
+- Adding marketplace entries or local manifests? Read the [Plugin author guide](plugin-author-guide.md).
+- Moving data over from op-obsidian? Read the [Migration guide](migration-guide.md).
+
+## Serving the docs site locally
+
+The docs are structured as an mdBook rooted at `docs/`:
+
+```bash
+cargo install mdbook --locked
+mdbook serve docs
+```
+
+If you do not want to install mdBook, you can read the Markdown files directly in GitHub or in your editor.
+
+## Scope notes
+
+These docs intentionally describe the shipped behavior in this tree today:
+
+- remote adapters can be discovered through the marketplace, but remote managed execution is still a stub
+- remote dashboard plugin sources are parsed by the loader, but `rein dashboards apply` currently installs bundled local plugins only
+- looking-glass tail support is surfaced in CLI/TUI status, but the daemon does not yet stream live tails

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,8 @@
+# Summary
+
+- [Overview](README.md)
+- [CLI quickstart](cli-quickstart.md)
+- [TUI quickstart](tui-quickstart.md)
+- [Metrics, logs, and OTLP](metrics-logs-otlp.md)
+- [Plugin author guide](plugin-author-guide.md)
+- [Migration guide](migration-guide.md)

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -1,0 +1,169 @@
+# CLI quickstart
+
+This guide assumes you are working from a checkout of `earchibald/rein` and want to exercise the current daemon + CLI flow without guessing at the request shape.
+
+## 1. Build the binary
+
+Rein currently builds from source with Go 1.25:
+
+```bash
+go build -o bin/rein ./cmd/rein
+```
+
+All examples below use `./bin/rein`, but the same commands work if you place the binary on your `PATH`.
+
+## 2. Start the daemon
+
+By default, rein talks to the `live` instance over that instance's unix socket:
+
+```bash
+./bin/rein daemon serve
+```
+
+Useful global flags:
+
+- `--instance <name>` — switch to a different instance directory
+- `--grpc-network tcp|unix` — override the client transport
+- `--grpc-address <addr>` — override the client address
+
+For example, to run a second instance explicitly:
+
+```bash
+./bin/rein --instance scratch daemon serve
+```
+
+## 3. Confirm local health
+
+`rein doctor` is the fastest way to confirm the selected instance is wired correctly:
+
+```bash
+./bin/rein doctor
+```
+
+The JSON output includes:
+
+- instance paths (`rootDir`, `socketPath`, `databasePath`)
+- daemon reachability and a real RPC probe
+- adapter marketplace + signature diagnostics
+- credential-provider readiness
+- SQLite migration readiness
+
+## 4. Explore the shipped surface
+
+The CLI surface is descriptor-driven. Two built-in describe modes are useful when you want authoritative command metadata:
+
+```bash
+./bin/rein describe-as=cli
+./bin/rein describe-as=mcp
+```
+
+The common top-level service commands are:
+
+```bash
+./bin/rein project list
+./bin/rein issue list
+./bin/rein workflow list
+./bin/rein execution list
+./bin/rein adapter list
+```
+
+## 5. Understand the flag conventions
+
+Rein follows two slightly different naming conventions on purpose:
+
+- top-level request flags use the protobuf field names, so filters look like `--project_id`, `--page`, or `--status`
+- nested JSON payloads are decoded as protobuf JSON, so embedded objects use JSON names like `displayName`, `projectId`, and `createdTime`
+
+Responses are emitted with protobuf field names (snake_case).
+
+## 6. Create some data
+
+Create a project:
+
+```bash
+./bin/rein project create --project '{
+  "id": "rein",
+  "slug": "rein",
+  "displayName": "rein",
+  "summary": "Local rein project",
+  "status": "PROJECT_STATUS_ACTIVE"
+}'
+```
+
+Create an issue in that project:
+
+```bash
+./bin/rein issue create --issue '{
+  "id": "RN-28",
+  "projectId": "rein",
+  "title": "User docs",
+  "summary": "README, quickstarts, telemetry, and migration docs",
+  "status": "ISSUE_STATUS_IN_PROGRESS",
+  "priority": "ISSUE_PRIORITY_HIGH",
+  "assignee": "copilot"
+}'
+```
+
+Filter the lists back down:
+
+```bash
+./bin/rein issue list --project_id rein --status ISSUE_STATUS_IN_PROGRESS
+./bin/rein project get --id rein
+./bin/rein issue get --id RN-28
+```
+
+## 7. Use backup and restore intentionally
+
+Checkpoint the selected instance state into a new destination directory:
+
+```bash
+./bin/rein backup ./backups/live
+```
+
+If you want rein to stop the selected daemon before copying, add `--stop`:
+
+```bash
+./bin/rein backup --stop ./backups/live-stopped
+```
+
+Restore from a backup copy:
+
+```bash
+./bin/rein restore --stop ./backups/live
+```
+
+Notes:
+
+- `rein backup` checkpoints SQLite WAL before copying
+- runtime artifacts (`grpc.sock`, `daemon.pid`) are skipped
+- `rein restore` refuses to replace live state while the daemon is still running unless you pass `--stop`
+
+## 8. Install the bundled dashboards
+
+The repo ships a dedicated dashboards marketplace plus the local `rein-dashboards` plugin. From the repo root (or any child directory inside it), run:
+
+```bash
+SIGNOZ_BASE_URL=http://localhost:3301 \
+SIGNOZ_API_KEY=replace-me \
+./bin/rein dashboards apply
+```
+
+Equivalent flags are also available:
+
+```bash
+./bin/rein dashboards apply \
+  --signoz-url http://localhost:3301 \
+  --signoz-api-key replace-me
+```
+
+Today this command installs the bundled local dashboards plugin. Remote dashboard bootstrap is not wired into the CLI yet.
+
+## 9. When to switch to the TUI
+
+Once the daemon has enough project/issue/execution state to browse, launch:
+
+```bash
+./bin/rein tui
+```
+
+See the [TUI quickstart](tui-quickstart.md) for the keymap and drilldown behavior.

--- a/docs/src/metrics-logs-otlp.md
+++ b/docs/src/metrics-logs-otlp.md
@@ -1,0 +1,134 @@
+# Metrics, logs, and OTLP
+
+Rein's observability story is intentionally simple in this phase:
+
+- daemon logs always go to stdout as structured text
+- OTLP export is opt-in
+- when OTLP is enabled, rein exports traces, metrics, and logs over OTLP/gRPC
+- the repo ships a bundled SigNoz dashboard pack you can apply with `rein dashboards apply`
+
+## OTLP is off by default
+
+If you do not set an OTLP endpoint, rein keeps its current no-op exporter behavior.
+
+This means:
+
+- no OTLP traces
+- no OTLP metrics
+- no OTLP log export
+- stdout logging still works
+
+## Enable OTLP with environment variables
+
+The daemon honors these environment variables:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_HEADERS`
+- `OTEL_EXPORTER_OTLP_INSECURE`
+- `OTEL_SERVICE_NAME`
+- `OTEL_RESOURCE_ATTRIBUTES`
+
+Example:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
+OTEL_EXPORTER_OTLP_INSECURE=true \
+OTEL_EXPORTER_OTLP_HEADERS='authorization=Bearer replace-me' \
+OTEL_SERVICE_NAME=rein-daemon \
+OTEL_RESOURCE_ATTRIBUTES='deployment.environment=dev,service.namespace=rein' \
+./bin/rein daemon serve
+```
+
+## Enable OTLP with CLI flags
+
+You can override the daemon's OTLP settings directly on the command line:
+
+```bash
+./bin/rein daemon serve \
+  --otlp-endpoint localhost:4317 \
+  --otlp-insecure \
+  --otlp-headers 'authorization=Bearer replace-me'
+```
+
+When present, the CLI flags override the corresponding environment-derived values.
+
+## Endpoint format notes
+
+Rein accepts:
+
+- bare `host:port` endpoints
+- `http://host:port` URLs
+- `https://host:port` URLs
+
+Normalization rules:
+
+- `http://...` is normalized to `host:port` and implies insecure transport
+- `https://...` is normalized to `host:port` and keeps TLS enabled
+- bare `host:port` stays as-is, so add `--otlp-insecure` or `OTEL_EXPORTER_OTLP_INSECURE=true` when your collector expects plaintext gRPC
+
+## What gets exported
+
+### Logs
+
+The daemon always writes structured text logs to stdout.
+
+When OTLP is enabled, those same slog events are also sent through the OTLP log exporter. In the current tree, that primarily means daemon lifecycle/startup logs and any future daemon-side slog events.
+
+### Metrics
+
+The current custom metric set is intentionally bounded:
+
+- `rein.daemon.starts`
+- `rein.daemon.running`
+- `rein.rpc.requests`
+- `rein.rpc.errors`
+- `rein.rpc.duration`
+
+The RPC instruments are annotated with gRPC attributes such as:
+
+- `rpc.system=grpc`
+- `rpc.service`
+- `rpc.method`
+- `rpc.stream`
+- `rpc.grpc.status_code`
+- `rpc.grpc.status_text`
+
+### Traces
+
+Each unary or streaming RPC handled by the daemon becomes a server span with the same gRPC attribute set.
+
+## Resource attributes
+
+Rein always sets instance-aware resource information for the daemon runtime:
+
+- `service.name` defaults to `rein-daemon`
+- `rein.instance` is set to the selected instance name
+- `service.instance.id` is set to the selected instance name
+
+`OTEL_SERVICE_NAME` overrides `service.name`.
+
+`OTEL_RESOURCE_ATTRIBUTES` is merged in before the daemon adds the instance-specific attributes, so the selected instance still appears consistently.
+
+## Diagnostics and dashboards
+
+Use `rein doctor` for local readiness checks:
+
+```bash
+./bin/rein doctor
+```
+
+Use the bundled dashboard installer to push the reference SigNoz dashboards:
+
+```bash
+SIGNOZ_BASE_URL=http://localhost:3301 \
+SIGNOZ_API_KEY=replace-me \
+./bin/rein dashboards apply
+```
+
+The dashboards marketplace currently points at the bundled local `rein-dashboards` plugin under `plugins/rein-dashboards/`.
+
+## Current limits
+
+- OTLP export is daemon-only; the CLI itself does not expose a separate observability pipeline
+- `rein dashboards apply` supports bundled local dashboard plugins today, not remote bootstrap
+- the TUI can show looking-glass/tail support state, but rein does not yet stream live tails

--- a/docs/src/migration-guide.md
+++ b/docs/src/migration-guide.md
@@ -1,0 +1,62 @@
+# Migration guide
+
+Rein intentionally keeps one-shot migration logic out of the core daemon repo. The current op-obsidian import path lives in the separate [`earchibald/rein-migrate-from-op-obsidian`](https://github.com/earchibald/rein-migrate-from-op-obsidian) repository.
+
+## What the migration tool does today
+
+According to the external tool's current README, it:
+
+- discovers `Projects/*/STATUS.md` notes and issue notes under `ISSUES/` and `RESOLVED ISSUES/`
+- writes rein project and issue records into the target `rein.db`
+- writes an import manifest at `imports/op-obsidian-manifest.json`
+- supports `--reset` so a failed import can be discarded and retried cleanly
+
+The tool is intentionally standalone and discardable after a successful import.
+
+## Scope limits
+
+The current bootstrap migration is intentionally narrow:
+
+- projects and issues are imported
+- tasks, docs, and workflow-module notes stay in the vault for now
+- the rein repo itself does not take on op-obsidian runtime dependencies
+
+## Run the importer
+
+Build or install the external tool from its repository, then point it at your vault and target rein instance:
+
+```bash
+rein-migrate-from-op-obsidian \
+  --vault /path/to/Agent-Vault \
+  --instance live \
+  --state-home "$HOME/.local/state" \
+  --reset
+```
+
+Useful optional flags from the current tool README:
+
+- `--project <slug>` — repeat to limit the import to specific vault projects
+- `--dry-run` — print what would be imported without writing files
+
+## Verify the result with rein
+
+After the import, inspect the target instance with the normal rein surfaces:
+
+```bash
+./bin/rein --instance live doctor
+./bin/rein --instance live project list
+./bin/rein --instance live issue list
+./bin/rein --instance live tui
+```
+
+That gives you one JSON diagnostic view (`doctor`), one machine-readable inventory view (`project list` / `issue list`), and one operator-facing browse view (`tui`).
+
+## Why the tool is external
+
+This split is deliberate:
+
+- `github.com/earchibald/rein/instance` exposes the canonical instance layout helpers
+- `github.com/earchibald/rein/sqlite` exposes the migrated SQLite store used by external importers
+- the rein daemon stays free of source-system-specific dependencies once the migration is done
+
+If you need migration behavior beyond projects/issues, track that work in the external migration repo rather than assuming the core daemon already supports it.

--- a/docs/src/plugin-author-guide.md
+++ b/docs/src/plugin-author-guide.md
@@ -1,0 +1,145 @@
+# Plugin author guide
+
+This guide describes the plugin and marketplace surface that exists in the repository today. It is intentionally conservative: rein can already discover, diagnose, and list adapters from marketplace metadata, but remote managed execution is still a staged follow-up for some adapter classes.
+
+## The files that matter
+
+Repository-level marketplace metadata lives in:
+
+- `.claude-plugin/marketplace.json`
+- `.claude-plugin/trusted-keys.json`
+
+Bundled local plugins live under `plugins/<name>/`, with a manifest at:
+
+- `plugins/<name>/.claude-plugin/plugin.json`
+
+Examples in this repo:
+
+- `plugins/messaging-null/.claude-plugin/plugin.json`
+- `plugins/muxiterm/.claude-plugin/plugin.json`
+- `plugins/tracker-github/.claude-plugin/plugin.json`
+- `plugins/rein-dashboards/.claude-plugin/plugin.json`
+
+## Marketplace entry shape
+
+A local adapter can be declared with the shorthand path form:
+
+```json
+{
+  "name": "muxiterm",
+  "source": "./plugins/muxiterm",
+  "version": "0.9.0",
+  "description": "First-party mux adapter backed by the muxiterm JSON CLI.",
+  "category": "mux",
+  "daemonApiVersion": "rein.v1"
+}
+```
+
+The marketplace loader also understands object-form sources for:
+
+- `github`
+- `url`
+- `git-subdir`
+- `npm`
+
+Current behavior is important:
+
+- local entries can load and overlay a local manifest immediately
+- remote entries are visible through registry and diagnostic surfaces today
+- remote managed execution is still an explicit stub for the external coding-adapter path
+
+## Local manifest shape
+
+A bundled manifest lives at `.claude-plugin/plugin.json` inside the plugin root.
+
+Minimal example:
+
+```json
+{
+  "name": "example-mux",
+  "version": "0.1.0",
+  "description": "Example mux adapter",
+  "category": "mux",
+  "daemonApiVersion": "rein.v1",
+  "capabilities": {
+    "session.attach": "true"
+  }
+}
+```
+
+Useful optional fields:
+
+- `capabilities` — free-form string map advertised to the daemon and UIs
+- `tail` — boolean shorthand for `capabilities.tail`
+- `requires` — list of required capability strings; rein encodes this into `capabilities.requires`
+
+Supported marketplace categories in the current daemon are:
+
+- `codingAgent`
+- `mux`
+- `tracker`
+- `messaging`
+- `projection`
+
+Use the canonical spellings above in committed manifests even though the loader normalizes a few aliases.
+
+## Precedence and `strict`
+
+For local plugins, rein combines marketplace metadata with the local manifest.
+
+- default behavior is `strict: true`, which means the local manifest overlays marketplace metadata
+- if a marketplace entry sets `"strict": false`, marketplace values win over the local manifest for overlapping fields
+
+That makes the common case simple: keep stable discovery metadata in the marketplace and let the plugin manifest own the concrete local adapter details.
+
+## Path and source rules
+
+Local source paths must:
+
+- start with `./`
+- stay within the repository root
+- point at a plugin root that may contain `.claude-plugin/plugin.json`
+
+`git-subdir` sources must also stay within the remote repository root.
+
+## Signatures and trusted keys
+
+The repo ships a signed `.claude-plugin/marketplace.json` and verifier keys in `.claude-plugin/trusted-keys.json`.
+
+Important nuance for local development:
+
+- `rein doctor` reports whether the marketplace signature is present and verified
+- the daemon's local discovery path tolerates unsigned marketplace indexes for local iteration
+- committed repository metadata should still stay signed
+
+This lets contributors iterate locally without blocking on a signing step while preserving a signed canonical index in the repo.
+
+## Validation loop
+
+Use the current runtime surfaces to validate your work:
+
+```bash
+./bin/rein doctor
+./bin/rein adapter list
+./bin/rein adapter get --id muxiterm
+```
+
+`rein doctor` is especially useful because it reports:
+
+- marketplace presence
+- signature status
+- manifest presence for local plugins
+- daemon API compatibility
+- the first load error that would block the registry
+
+## Dashboard plugins vs adapter plugins
+
+Dashboard plugins use a parallel marketplace file, `.claude-plugin/dashboards-marketplace.json`, plus a local manifest shape under `plugins/rein-dashboards/.claude-plugin/plugin.json`.
+
+Today:
+
+- adapter marketplace entries can be local or remote metadata
+- dashboard marketplace entries can be described as local/GitHub/URL sources
+- `rein dashboards apply` only installs bundled local dashboard plugins
+
+If you are documenting or shipping a plugin, be explicit about which parts are discovery metadata versus actually executable bootstrap today.

--- a/docs/src/tui-quickstart.md
+++ b/docs/src/tui-quickstart.md
@@ -1,0 +1,87 @@
+# TUI quickstart
+
+`rein tui` is the terminal-native view over the same daemon API that the CLI uses. It is best when you want to browse projects, issues, executions, workflow drilldown, and adapter capability state without manually issuing several list/get commands.
+
+## 1. Start the daemon first
+
+The TUI is a client, not a standalone store browser, so it needs a running daemon:
+
+```bash
+go build -o bin/rein ./cmd/rein
+./bin/rein daemon serve
+```
+
+If the selected instance is empty, the TUI still launches — you will just see empty lists until you create or import data.
+
+## 2. Launch the TUI
+
+In another terminal:
+
+```bash
+./bin/rein tui
+```
+
+Use `--instance <name>` first if you want to browse a non-default instance:
+
+```bash
+./bin/rein --instance scratch tui
+```
+
+## 3. Learn the keymap
+
+The shipped keymap is intentionally small:
+
+- `tab` / `shift+tab` — move focus between **Projects**, **Issues**, and **Executions**
+- `up` / `down` — move the selected row in the focused list
+- `enter` — toggle compact vs expanded execution drilldown
+- `r` — refresh immediately
+- `q` or `ctrl+c` — quit
+
+The TUI also auto-refreshes on a short interval, so you can leave it open while another terminal mutates daemon state.
+
+## 4. What the layout shows
+
+The left side is a navigator with three linked lists:
+
+1. **Projects**
+2. **Issues** filtered to the selected project
+3. **Executions** filtered to the selected issue
+
+The right side is the overview/drilldown panel. Depending on what is selected, it shows:
+
+- overall counts and last refresh time
+- the selected project summary
+- the selected issue status, priority, assignee, and workflow reference
+- workflow step status for the related workflow
+- execution drilldown, including task steps, side effects, metadata, and looking-glass state
+
+## 5. Looking glass expectations
+
+The TUI surfaces looking-glass state conservatively:
+
+- **disabled** — no adapter in the execution advertises `tail=true`
+- **gated** — adapters advertise tail support, but the daemon does not expose looking-glass streaming yet
+- **available** — reserved for the future fully available streaming state
+
+Today, adapters can advertise tail support and the TUI will display that fact, but live tail streaming is not implemented yet.
+
+## 6. Practical workflow
+
+A typical loop is:
+
+1. use the [CLI quickstart](cli-quickstart.md) to start the daemon and seed or import data
+2. launch `rein tui`
+3. browse projects/issues/executions in one terminal
+4. keep a second terminal open for `rein doctor`, `rein issue update`, `rein execution inspect`, or `rein dashboards apply`
+
+## 7. When to fall back to the CLI
+
+Prefer the CLI when you need:
+
+- machine-readable JSON output
+- precise filters or scripted automation
+- `describe-as=cli` / `describe-as=mcp`
+- backup/restore operations
+- SigNoz dashboard installation
+
+The TUI is for inspection and drilldown; the CLI remains the canonical automation surface.


### PR DESCRIPTION
## Summary\n- expand the README into a stronger landing page with quickstart and docs links\n- add an in-repo mdBook user docs site for CLI, TUI, telemetry, plugin authoring, and migration\n- document current telemetry, dashboards, and external migration/adapter limitations without overpromising\n\n## Validation\n- just test\n- mdbook build docs\n