### PR TITLE
RN-37: make dashboards apply idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ SIGNOZ_API_KEY=replace-me \
 ./bin/rein dashboards apply
 ```
 
+Re-running the command skips unchanged bundled dashboards and reports `createdIds`, `updatedIds`, and `skippedIds` in the JSON output.
+
 ## Documentation
 
 Longer user guides live under `docs/` and can be read directly in the repo or served as an mdBook:
@@ -135,7 +137,7 @@ mdbook serve docs
 
 - The reference dashboards ship from a dedicated marketplace index at `.claude-plugin/dashboards-marketplace.json`.
 - The bundled local plugin lives at `plugins/rein-dashboards/.claude-plugin/plugin.json` and currently targets SigNoz with `plugins/rein-dashboards/signoz/rein-daemon-otlp.json`.
-- `rein dashboards apply` resolves that marketplace entry from the repository root, then creates or updates dashboards in SigNoz using the `SIGNOZ-API-KEY` header.
+- `rein dashboards apply` resolves that marketplace entry from the repository root, then creates, updates, or skips dashboards in SigNoz using the `SIGNOZ-API-KEY` header.
 - The loader accepts the same future-facing local/GitHub/URL source shape as the adapter marketplace, but remote dashboard bootstrap remains an explicit follow-up.
 
 ## TUI

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -230,6 +230,7 @@ type dashboardsApplyOutput struct {
 	Repository string   `json:"repositoryRoot"`
 	CreatedIDs []string `json:"createdIds"`
 	UpdatedIDs []string `json:"updatedIds"`
+	SkippedIDs []string `json:"skippedIds"`
 }
 
 func (a *app) runDashboards(args []string) error {
@@ -266,6 +267,7 @@ func (a *app) applyDashboards(config dashboardsApplyConfig) error {
 		Repository: config.RootPath,
 		CreatedIDs: result.Created,
 		UpdatedIDs: result.Updated,
+		SkippedIDs: result.Skipped,
 	})
 }
 

--- a/cmd/rein/dashboards_apply_test.go
+++ b/cmd/rein/dashboards_apply_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestApplyDashboardsOutputsSkippedIDs(t *testing.T) {
+	t.Parallel()
+
+	root := writeDashboardsApplyFixture(t)
+	var stored []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/dashboards":
+			type responseDashboard struct {
+				ID   string         `json:"id"`
+				Data map[string]any `json:"data"`
+			}
+			dashboards := make([]responseDashboard, 0, len(stored))
+			for index, payload := range stored {
+				dashboards = append(dashboards, responseDashboard{
+					ID:   "created-1",
+					Data: payload,
+				})
+				if index > 0 {
+					t.Fatalf("unexpected stored dashboards: %d", len(stored))
+				}
+			}
+			_ = json.NewEncoder(w).Encode(dashboards)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/dashboards":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("Decode(POST body) error = %v", err)
+			}
+			stored = []map[string]any{payload}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "created-1", "data": payload})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	app := newApp(&stdout, &bytes.Buffer{}, func(string) (string, bool) { return "", false }, nil, nil)
+	config := dashboardsApplyConfig{
+		Plugin:   "rein-dashboards",
+		BaseURL:  server.URL,
+		APIKey:   "secret",
+		RootPath: root,
+	}
+
+	if err := app.applyDashboards(config); err != nil {
+		t.Fatalf("applyDashboards() first error = %v", err)
+	}
+	stdout.Reset()
+
+	if err := app.applyDashboards(config); err != nil {
+		t.Fatalf("applyDashboards() second error = %v", err)
+	}
+
+	var output dashboardsApplyOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if output.Repository != root {
+		t.Fatalf("Repository = %q, want %q", output.Repository, root)
+	}
+	if got, want := output.SkippedIDs, []string{"created-1"}; !slices.Equal(got, want) {
+		t.Fatalf("SkippedIDs = %v, want %v", got, want)
+	}
+	if len(output.CreatedIDs) != 0 || len(output.UpdatedIDs) != 0 {
+		t.Fatalf("CreatedIDs/UpdatedIDs = %v/%v, want empty", output.CreatedIDs, output.UpdatedIDs)
+	}
+}
+
+func writeDashboardsApplyFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
+	}
+	writeDashboardsApplyJSONFile(t, filepath.Join(root, ".claude-plugin", "dashboards-marketplace.json"), map[string]any{
+		"name": "rein-dashboards",
+		"plugins": []any{
+			map[string]any{
+				"name":        "rein-dashboards",
+				"version":     "0.1.0",
+				"description": "Fixture dashboards plugin",
+				"provider":    "signoz",
+				"source":      "./plugins/rein-dashboards",
+			},
+		},
+	})
+
+	pluginRoot := filepath.Join(root, "plugins", "rein-dashboards", ".claude-plugin")
+	if err := os.MkdirAll(pluginRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginRoot) error = %v", err)
+	}
+	writeDashboardsApplyJSONFile(t, filepath.Join(pluginRoot, "plugin.json"), map[string]any{
+		"name":        "rein-dashboards",
+		"version":     "0.1.0",
+		"description": "Fixture dashboards plugin",
+		"provider":    "signoz",
+		"dashboards": []any{
+			map[string]any{
+				"id":    "rein-daemon-otlp",
+				"title": "Rein Daemon OTLP",
+				"path":  "signoz/rein-daemon-otlp.json",
+			},
+		},
+	})
+
+	assetDir := filepath.Join(root, "plugins", "rein-dashboards", "signoz")
+	if err := os.MkdirAll(assetDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(assetDir) error = %v", err)
+	}
+	writeDashboardsApplyJSONFile(t, filepath.Join(assetDir, "rein-daemon-otlp.json"), map[string]any{
+		"title":   "Rein Daemon OTLP",
+		"version": "v5",
+		"widgets": []any{},
+		"layout":  []any{},
+	})
+	return root
+}
+
+func writeDashboardsApplyJSONFile(t *testing.T, path string, value any) {
+	t.Helper()
+
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent(%q) error = %v", path, err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -156,7 +156,7 @@ Equivalent flags are also available:
   --signoz-api-key replace-me
 ```
 
-Today this command installs the bundled local dashboards plugin. Remote dashboard bootstrap is not wired into the CLI yet.
+The JSON response reports which dashboards were `createdIds`, `updatedIds`, or `skippedIds`; unchanged bundled dashboards are skipped on repeat runs. Today this command installs the bundled local dashboards plugin. Remote dashboard bootstrap is not wired into the CLI yet.
 
 ## 9. When to switch to the TUI
 

--- a/docs/src/metrics-logs-otlp.md
+++ b/docs/src/metrics-logs-otlp.md
@@ -125,7 +125,7 @@ SIGNOZ_API_KEY=replace-me \
 ./bin/rein dashboards apply
 ```
 
-The dashboards marketplace currently points at the bundled local `rein-dashboards` plugin under `plugins/rein-dashboards/`.
+The dashboards marketplace currently points at the bundled local `rein-dashboards` plugin under `plugins/rein-dashboards/`. Repeat runs skip unchanged bundled dashboards and report `createdIds`, `updatedIds`, and `skippedIds` in the JSON response.
 
 ## Current limits
 

--- a/internal/dashboards/apply.go
+++ b/internal/dashboards/apply.go
@@ -3,6 +3,8 @@ package dashboards
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +20,8 @@ import (
 // #nosec G101 -- this is the public header name SigNoz expects, not a credential.
 const sigNozAPIKeyHeader = "SIGNOZ-API-KEY"
 
+const dashboardHashTagPrefix = "rein-dashboards-sha256:"
+
 type ApplyOptions struct {
 	Plugin     string
 	BaseURL    string
@@ -30,6 +34,7 @@ type ApplyResult struct {
 	Provider string   `json:"provider"`
 	Created  []string `json:"created"`
 	Updated  []string `json:"updated"`
+	Skipped  []string `json:"skipped"`
 }
 
 type sigNozDashboard struct {
@@ -83,8 +88,8 @@ func Apply(ctx context.Context, root string, options ApplyOptions) (ApplyResult,
 			return ApplyResult{}, err
 		}
 
-		existingID := findDashboardID(existing, asset)
-		if existingID == "" {
+		existingDashboard, ok := findDashboard(existing, asset)
+		if !ok {
 			created, err := client.createDashboard(ctx, payload)
 			if err != nil {
 				return ApplyResult{}, fmt.Errorf("create dashboard %q: %w", asset.ID, err)
@@ -94,13 +99,22 @@ func Apply(ctx context.Context, root string, options ApplyOptions) (ApplyResult,
 			continue
 		}
 
-		updated, err := client.updateDashboard(ctx, existingID, payload)
+		match, err := dashboardsMatch(existingDashboard.Data, payload)
+		if err != nil {
+			return ApplyResult{}, fmt.Errorf("compare dashboard %q: %w", asset.ID, err)
+		}
+		if match {
+			result.Skipped = append(result.Skipped, existingDashboard.ID)
+			continue
+		}
+
+		updated, err := client.updateDashboard(ctx, existingDashboard.ID, payload)
 		if err != nil {
 			return ApplyResult{}, fmt.Errorf("update dashboard %q: %w", asset.ID, err)
 		}
 		result.Updated = append(result.Updated, updated.ID)
 		for index := range existing {
-			if existing[index].ID == existingID {
+			if existing[index].ID == existingDashboard.ID {
 				existing[index] = updated
 				break
 			}
@@ -108,6 +122,7 @@ func Apply(ctx context.Context, root string, options ApplyOptions) (ApplyResult,
 	}
 
 	slices.Sort(result.Created)
+	slices.Sort(result.Skipped)
 	slices.Sort(result.Updated)
 	return result, nil
 }
@@ -139,28 +154,25 @@ func loadAsset(path string, asset Asset) (map[string]any, error) {
 		}
 	}
 	payload["tags"] = ensureDashboardTags(payload["tags"], asset.ID)
+	hashTag, err := dashboardHashTag(payload)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint dashboard asset %q: %w", asset.ID, err)
+	}
+	payload["tags"] = ensureDashboardTags(payload["tags"], asset.ID, hashTag)
 	return payload, nil
 }
 
-func ensureDashboardTags(current any, assetID string) []string {
+func ensureDashboardTags(current any, assetID string, extraTags ...string) []string {
 	tags := map[string]bool{}
-	switch value := current.(type) {
-	case []string:
-		for _, item := range value {
-			if item != "" {
-				tags[item] = true
-			}
-		}
-	case []any:
-		for _, item := range value {
-			if tag, ok := item.(string); ok && tag != "" {
-				tags[tag] = true
-			}
-		}
-	}
+	appendDashboardTags(tags, current)
 
 	for _, tag := range []string{"rein", "rein-dashboards", "rein-dashboards:" + assetID} {
 		tags[tag] = true
+	}
+	for _, tag := range extraTags {
+		if normalized := strings.TrimSpace(tag); normalized != "" {
+			tags[normalized] = true
+		}
 	}
 
 	ordered := make([]string, 0, len(tags))
@@ -171,21 +183,115 @@ func ensureDashboardTags(current any, assetID string) []string {
 	return ordered
 }
 
-func findDashboardID(existing []sigNozDashboard, asset Asset) string {
+func appendDashboardTags(tags map[string]bool, current any) {
+	switch value := current.(type) {
+	case []string:
+		for _, item := range value {
+			appendDashboardTag(tags, item)
+		}
+	case []any:
+		for _, item := range value {
+			if tag, ok := item.(string); ok {
+				appendDashboardTag(tags, tag)
+			}
+		}
+	}
+}
+
+func appendDashboardTag(tags map[string]bool, tag string) {
+	normalized := strings.TrimSpace(tag)
+	if normalized == "" || strings.HasPrefix(normalized, dashboardHashTagPrefix) {
+		return
+	}
+	tags[normalized] = true
+}
+
+func dashboardHashTag(payload map[string]any) (string, error) {
+	normalized, err := normalizedDashboardPayload(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(normalized)
+	return dashboardHashTagPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+func dashboardsMatch(existing, desired map[string]any) (bool, error) {
+	expectedHashTag, err := dashboardHashTag(desired)
+	if err != nil {
+		return false, err
+	}
+	if hasTag(existing["tags"], expectedHashTag) {
+		return true, nil
+	}
+
+	existingPayload, err := normalizedDashboardPayload(existing)
+	if err != nil {
+		return false, err
+	}
+	desiredPayload, err := normalizedDashboardPayload(desired)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(existingPayload, desiredPayload), nil
+}
+
+func normalizedDashboardPayload(payload map[string]any) ([]byte, error) {
+	return json.Marshal(normalizeDashboardValue(payload, ""))
+}
+
+func normalizeDashboardValue(value any, field string) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(typed))
+		for key, item := range typed {
+			normalized[key] = normalizeDashboardValue(item, key)
+		}
+		return normalized
+	case []string:
+		if field == "tags" {
+			return normalizeDashboardTags(typed)
+		}
+		return append([]string(nil), typed...)
+	case []any:
+		if field == "tags" {
+			return normalizeDashboardTags(typed)
+		}
+		normalized := make([]any, 0, len(typed))
+		for _, item := range typed {
+			normalized = append(normalized, normalizeDashboardValue(item, ""))
+		}
+		return normalized
+	default:
+		return value
+	}
+}
+
+func normalizeDashboardTags(current any) []string {
+	tags := map[string]bool{}
+	appendDashboardTags(tags, current)
+	ordered := make([]string, 0, len(tags))
+	for tag := range tags {
+		ordered = append(ordered, tag)
+	}
+	slices.Sort(ordered)
+	return ordered
+}
+
+func findDashboard(existing []sigNozDashboard, asset Asset) (sigNozDashboard, bool) {
 	marker := "rein-dashboards:" + asset.ID
 	title := strings.TrimSpace(asset.Title)
 	for _, dashboard := range existing {
 		if hasTag(dashboard.Data["tags"], marker) {
-			return dashboard.ID
+			return dashboard, true
 		}
 		if title == "" {
 			continue
 		}
 		if dashboardTitle, _ := dashboard.Data["title"].(string); strings.TrimSpace(dashboardTitle) == title {
-			return dashboard.ID
+			return dashboard, true
 		}
 	}
-	return ""
+	return sigNozDashboard{}, false
 }
 
 func hasTag(current any, want string) bool {

--- a/internal/dashboards/dashboards_test.go
+++ b/internal/dashboards/dashboards_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -32,11 +33,13 @@ func TestLoadLocalMarketplacePlugin(t *testing.T) {
 	}
 }
 
-func TestApplyCreatesAndUpdatesDashboards(t *testing.T) {
+func TestApplyCreatesSkipsAndUpdatesDashboards(t *testing.T) {
 	t.Parallel()
 
 	root := writeDashboardFixture(t, fixtureOptions{})
 	var stored []sigNozDashboard
+	var createRequests int
+	var updateRequests int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get(sigNozAPIKeyHeader); got != "secret" {
@@ -46,6 +49,7 @@ func TestApplyCreatesAndUpdatesDashboards(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/dashboards":
 			_ = json.NewEncoder(w).Encode(stored)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/dashboards":
+			createRequests++
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("Decode(POST body) error = %v", err)
@@ -55,6 +59,7 @@ func TestApplyCreatesAndUpdatesDashboards(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(dashboard)
 		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/dashboards/created-1":
+			updateRequests++
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Fatalf("Decode(PUT body) error = %v", err)
@@ -81,6 +86,9 @@ func TestApplyCreatesAndUpdatesDashboards(t *testing.T) {
 	if len(stored) != 1 || !hasTag(stored[0].Data["tags"], "rein-dashboards:rein-daemon-otlp") {
 		t.Fatalf("stored dashboard tags = %+v", stored)
 	}
+	if !hasTagPrefix(stored[0].Data["tags"], dashboardHashTagPrefix) {
+		t.Fatalf("stored dashboard hash tags = %+v, want %q prefix", stored[0].Data["tags"], dashboardHashTagPrefix)
+	}
 
 	second, err := Apply(context.Background(), root, ApplyOptions{
 		Plugin:  DefaultPluginName,
@@ -90,8 +98,76 @@ func TestApplyCreatesAndUpdatesDashboards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply() second error = %v", err)
 	}
-	if got, want := second.Updated, []string{"created-1"}; !slices.Equal(got, want) {
-		t.Fatalf("second.Updated = %v, want %v", got, want)
+	if got, want := second.Skipped, []string{"created-1"}; !slices.Equal(got, want) {
+		t.Fatalf("second.Skipped = %v, want %v", got, want)
+	}
+	if updateRequests != 0 {
+		t.Fatalf("updateRequests after unchanged apply = %d, want 0", updateRequests)
+	}
+
+	writeJSONFile(t, filepath.Join(root, "plugins", "rein-dashboards", "signoz", "rein-daemon-otlp.json"), map[string]any{
+		"title":   "Rein Daemon OTLP",
+		"version": "v6",
+		"widgets": []any{map[string]any{"id": "cpu"}},
+		"layout":  []any{},
+	})
+
+	third, err := Apply(context.Background(), root, ApplyOptions{
+		Plugin:  DefaultPluginName,
+		BaseURL: server.URL,
+		APIKey:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("Apply() third error = %v", err)
+	}
+	if got, want := third.Updated, []string{"created-1"}; !slices.Equal(got, want) {
+		t.Fatalf("third.Updated = %v, want %v", got, want)
+	}
+	if createRequests != 1 {
+		t.Fatalf("createRequests = %d, want 1", createRequests)
+	}
+	if updateRequests != 1 {
+		t.Fatalf("updateRequests after changed apply = %d, want 1", updateRequests)
+	}
+	if got := stored[0].Data["version"]; got != "v6" {
+		t.Fatalf("stored version = %v, want v6", got)
+	}
+}
+
+func TestApplySkipsLegacyDashboardsWhenPayloadMatches(t *testing.T) {
+	t.Parallel()
+
+	root := writeDashboardFixture(t, fixtureOptions{})
+	payload, err := loadAsset(filepath.Join(root, "plugins", "rein-dashboards", "signoz", "rein-daemon-otlp.json"), Asset{
+		ID:    "rein-daemon-otlp",
+		Title: "Rein Daemon OTLP",
+	})
+	if err != nil {
+		t.Fatalf("loadAsset() error = %v", err)
+	}
+	payload["tags"] = []any{"rein-dashboards:rein-daemon-otlp", "rein-dashboards", "rein"}
+	stored := []sigNozDashboard{{ID: "existing-1", Data: payload}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/dashboards":
+			_ = json.NewEncoder(w).Encode(stored)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	result, err := Apply(context.Background(), root, ApplyOptions{
+		Plugin:  DefaultPluginName,
+		BaseURL: server.URL,
+		APIKey:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if got, want := result.Skipped, []string{"existing-1"}; !slices.Equal(got, want) {
+		t.Fatalf("result.Skipped = %v, want %v", got, want)
 	}
 }
 
@@ -195,4 +271,22 @@ func writeJSONFile(t *testing.T, path string, value any) {
 	if err := os.WriteFile(path, raw, 0o644); err != nil {
 		t.Fatalf("WriteFile(%q) error = %v", path, err)
 	}
+}
+
+func hasTagPrefix(current any, prefix string) bool {
+	switch value := current.(type) {
+	case []string:
+		for _, item := range value {
+			if strings.HasPrefix(item, prefix) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range value {
+			if tag, ok := item.(string); ok && strings.HasPrefix(tag, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- skip SigNoz dashboard updates when the normalized bundled payload is unchanged and stamp a stable payload hash tag
- surface skipped dashboard IDs in the dashboards apply JSON output and cover the create/skip/update flows in tests
- document that repeat dashboards apply runs skip unchanged bundled dashboards

## Testing
- go test ./internal/dashboards ./cmd/rein
- go build ./cmd/rein
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1 run ./internal/dashboards ./cmd/rein