### PR TITLE
RN-32: Harden CI and release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,15 @@ on:
     branches: [main]
 
 jobs:
-  build-lint-test:
-    name: Build, Lint & Test
+  ci-ubuntu:
+    name: CI (ubuntu)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -24,21 +26,30 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
 
-      - name: Lint and generate protobuf stubs
-        run: |
-          just proto
-          git diff --exit-code
+      - name: Install mdBook
+        uses: taiki-e/install-action@mdbook
 
-      - name: Build
-        run: go build ./...
+      - name: Run CI-equivalent checks
+        run: just ci
 
-      - name: Vet
-        run: go vet ./...
+  ci-macos:
+    name: CI (macOS)
+    runs-on: macos-latest
 
-      - name: Test
-        run: just test-race
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          version: v2.12.1
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Run macOS-targeted checks
+        run: just ci-macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+
+    steps:
+      - name: Validate CalVer tag
+        id: tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+$ ]]; then
+            echo "release tags must match YYYY.MM.PATCH, got ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@mdbook
+
+      - name: Run CI-equivalent checks
+        run: just ci
+
+  macos-smoke:
+    name: macOS smoke
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Run macOS-targeted checks
+        run: just ci-macos
+
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    needs:
+      - preflight
+      - macos-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            archive_ext: tar.gz
+          - goos: linux
+            goarch: arm64
+            archive_ext: tar.gz
+          - goos: darwin
+            goarch: amd64
+            archive_ext: tar.gz
+          - goos: darwin
+            goarch: arm64
+            archive_ext: tar.gz
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release archive
+        id: package
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+
+          archive_base="rein_${VERSION}_${GOOS}_${GOARCH}"
+          dist_dir="dist/${archive_base}"
+          mkdir -p "${dist_dir}"
+
+          build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          ldflags="-s -w \
+            -X github.com/earchibald/rein/internal/buildinfo.Version=${VERSION} \
+            -X github.com/earchibald/rein/internal/buildinfo.Commit=${GITHUB_SHA} \
+            -X github.com/earchibald/rein/internal/buildinfo.BuildTime=${build_time} \
+            -X github.com/earchibald/rein/internal/buildinfo.BuiltBy=github-actions"
+
+          CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
+            go build -trimpath -ldflags "${ldflags}" -o "${dist_dir}/rein" ./cmd/rein
+
+          archive_path="dist/${archive_base}.${{ matrix.archive_ext }}"
+          tar -C dist -czf "${archive_path}" "${archive_base}"
+
+          echo "archive=${archive_path}" >> "$GITHUB_OUTPUT"
+          echo "archive_name=$(basename "${archive_path}")" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.package.outputs.archive }}
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.archive_name }}
+          path: ${{ steps.package.outputs.archive }}
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs:
+      - preflight
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Normalize downloaded artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          find dist -type f -mindepth 2 -maxdepth 2 -exec mv {} release/ \;
+
+      - name: Generate checksums
+        working-directory: release
+        run: shasum -a 256 * > checksums.txt
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release/*

--- a/Justfile
+++ b/Justfile
@@ -14,9 +14,31 @@ proto:
     {{buf}} lint
     {{buf}} generate
 
+# Verify protobuf generation is current
+proto-check:
+    just proto
+    git --no-pager diff --exit-code -- gen/go
+
+# Enforce buf breaking policy against main
+proto-breaking:
+    @if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then \
+        against='.git#ref=origin/main,subdir=proto'; \
+    elif git rev-parse --verify --quiet main >/dev/null 2>&1; then \
+        against='.git#branch=main,subdir=proto'; \
+    else \
+        echo 'buf breaking requires origin/main or main to exist locally' >&2; \
+        exit 1; \
+    fi; \
+    echo "buf breaking against $against"; \
+    {{buf}} breaking --against "$against"
+
 # Build the rein binary
 build:
     go build -o bin/rein ./cmd/rein
+
+# Build every package the same way CI does
+build-all:
+    go build ./...
 
 # Run tests
 test:
@@ -33,7 +55,11 @@ test-cover:
 
 # Run golangci-lint
 lint:
-    {{golangci_lint}} run ./...
+    GOLANGCI_LINT_CACHE="$PWD/.golangci-lint-cache" {{golangci_lint}} run ./...
+
+# Validate docs render as an mdBook
+docs:
+    mdbook build docs
 
 # Run go vet
 vet:
@@ -52,11 +78,16 @@ tidy:
 clean:
     rm -rf bin/
 
-# Run build + vet + lint + race-tested suite (CI equivalent)
-ci: build vet lint test-race
+# Run proto, build, vet, lint, race tests, breaking checks, and docs (CI equivalent)
+ci: proto-check build-all vet lint test-race proto-breaking docs
+
+# Run the macOS-targeted CI coverage for daemon listener/auth paths
+ci-macos: build-all vet
+    {{gotestsum}} --format pkgname -- -race ./cmd/rein ./internal/instance ./internal/server
 
 # Install development tools
 install-tools:
     go install gotest.tools/gotestsum@v1.10.0
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
     go install golang.org/x/tools/cmd/goimports@latest
+    cargo install mdbook --locked

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In another terminal, inspect health and the current API surface:
 ./bin/rein project list
 ./bin/rein issue list
 ./bin/rein describe-as=cli
+./bin/rein version
 ```
 
 Launch the terminal UI against that same daemon:
@@ -74,6 +75,11 @@ cargo install mdbook --locked
 mdbook serve docs
 ```
 
+## Releases
+
+- Pushing a CalVer tag in the form `YYYY.MM.PATCH` triggers the GitHub release workflow, which reruns CI, builds release archives, publishes a GitHub Release, and records GitHub artifact attestations for the uploaded archives.
+- The release pipeline does not attempt platform-native code signing or notarization. Those remain future follow-ups that require Apple/Windows signing material and any associated notarization credentials.
+
 ## Current limitations to keep in mind
 
 - The repository marketplace can advertise remote adapters today, but remote managed execution is still an explicit stub until the external adapter bridge lands.
@@ -107,6 +113,7 @@ mdbook serve docs
 - Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface and reachable protobuf schemas.
 - Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.
 - Use `rein tui` for the terminal-native HMI over that same daemon surface.
+- Use `rein version` to print the current CalVer, commit/build metadata, and local-vs-release provenance.
 - Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
 - Top-level request flags map 1:1 to top-level protobuf request fields and use the protobuf field names (for example `--project_id`).
 - Scalar fields take plain values; message, repeated, and map fields take JSON blobs.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -103,6 +103,8 @@ func (a *app) run(args []string) error {
 		return a.runRestore(root, remaining[1:])
 	case "tui":
 		return a.runTUI(root, remaining[1:])
+	case "version":
+		return a.runVersion(remaining[1:])
 	default:
 		if strings.HasPrefix(remaining[0], "describe-as=") {
 			return a.runDescribe(remaining)
@@ -555,6 +557,7 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as=<format>")
 	fmt.Fprintln(a.stderr, "  rein [global flags] restore [flags] <source>")
 	fmt.Fprintln(a.stderr, "  rein [global flags] tui")
+	fmt.Fprintln(a.stderr, "  rein version [--json]")
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Global flags:")
 	for _, flag := range globalFlagDescriptions() {
@@ -588,6 +591,7 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr, "  doctor\tEmit JSON diagnostics for daemon health and local instance readiness.")
 	fmt.Fprintln(a.stderr, "  describe-as=<format>\tEmit a stable machine-consumable surface description.")
 	fmt.Fprintln(a.stderr, "  restore\tAtomically replace the selected instance state from a backup copy.")
+	fmt.Fprintln(a.stderr, "  version\tPrint the CLI version and embedded build provenance.")
 }
 
 func (a *app) printBackupHelp() {

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -216,6 +216,8 @@ func TestRootHelpListsStaticCommands(t *testing.T) {
 		"describe-as=<format>\tEmit a stable machine-consumable surface description.",
 		"restore\tAtomically replace the selected instance state from a backup copy.",
 		"tui\tTerminal UI over the canonical gRPC surface.",
+		"rein version [--json]",
+		"version\tPrint the CLI version and embedded build provenance.",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q\n%s", want, output)

--- a/cmd/rein/version.go
+++ b/cmd/rein/version.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/earchibald/rein/internal/buildinfo"
+)
+
+func (a *app) runVersion(args []string) error {
+	flagSet := flag.NewFlagSet("rein version", flag.ContinueOnError)
+	flagSet.SetOutput(a.stderr)
+
+	jsonOutput := flagSet.Bool("json", false, "emit structured JSON")
+	if err := flagSet.Parse(args); err != nil {
+		return err
+	}
+	if flagSet.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %v", flagSet.Args())
+	}
+
+	info := buildinfo.Current()
+	if *jsonOutput {
+		return writeJSONObject(a.stdout, info)
+	}
+
+	if _, err := fmt.Fprintf(a.stdout, "rein %s\n", info.Version); err != nil {
+		return err
+	}
+	if info.Commit != "" {
+		if _, err := fmt.Fprintf(a.stdout, "commit: %s\n", info.Commit); err != nil {
+			return err
+		}
+	}
+	if info.BuildTime != "" {
+		if _, err := fmt.Fprintf(a.stdout, "build_time: %s\n", info.BuildTime); err != nil {
+			return err
+		}
+	}
+	if info.BuiltBy != "" {
+		if _, err := fmt.Fprintf(a.stdout, "built_by: %s\n", info.BuiltBy); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(a.stdout, "go_version: %s\n", info.GoVersion); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(a.stdout, "platform: %s\n", info.Platform); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(a.stdout, "modified: %t\n", info.Modified)
+	return err
+}

--- a/cmd/rein/version_test.go
+++ b/cmd/rein/version_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/earchibald/rein/internal/buildinfo"
+)
+
+func TestAppVersionCommandEmitsText(t *testing.T) {
+	restore := setBuildStampForTest(t, "2025.05.7", "abc123", "2025-05-02T03:04:05Z", "github-actions")
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	if err := app.run([]string{"version"}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"rein 2025.05.7",
+		"commit: abc123",
+		"build_time: 2025-05-02T03:04:05Z",
+		"built_by: github-actions",
+		"go_version:",
+		"platform:",
+		"modified: false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("version output missing %q\n%s", want, output)
+		}
+	}
+}
+
+func TestAppVersionCommandEmitsJSON(t *testing.T) {
+	restore := setBuildStampForTest(t, "2025.05.7", "abc123", "2025-05-02T03:04:05Z", "github-actions")
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	if err := app.run([]string{"version", "--json"}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+
+	var payload buildinfo.Info
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if payload.Version != "2025.05.7" {
+		t.Fatalf("Version = %q, want 2025.05.7", payload.Version)
+	}
+	if payload.Commit != "abc123" {
+		t.Fatalf("Commit = %q, want abc123", payload.Commit)
+	}
+	if payload.BuildTime != "2025-05-02T03:04:05Z" {
+		t.Fatalf("BuildTime = %q, want stamped time", payload.BuildTime)
+	}
+	if payload.BuiltBy != "github-actions" {
+		t.Fatalf("BuiltBy = %q, want github-actions", payload.BuiltBy)
+	}
+}
+
+func setBuildStampForTest(t *testing.T, version, commit, buildTime, builtBy string) func() {
+	t.Helper()
+
+	previousVersion := buildinfo.Version
+	previousCommit := buildinfo.Commit
+	previousBuildTime := buildinfo.BuildTime
+	previousBuiltBy := buildinfo.BuiltBy
+
+	buildinfo.Version = version
+	buildinfo.Commit = commit
+	buildinfo.BuildTime = buildTime
+	buildinfo.BuiltBy = builtBy
+
+	return func() {
+		buildinfo.Version = previousVersion
+		buildinfo.Commit = previousCommit
+		buildinfo.BuildTime = previousBuildTime
+		buildinfo.BuiltBy = previousBuiltBy
+	}
+}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,68 @@
+package buildinfo
+
+import (
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+var (
+	// Version is the user-visible CalVer or dev version stamped at build time.
+	Version = "dev"
+	// Commit is the source revision stamped at build time.
+	Commit = ""
+	// BuildTime is the UTC build timestamp stamped at build time.
+	BuildTime = ""
+	// BuiltBy identifies the build system that produced the binary.
+	BuiltBy = ""
+)
+
+// Info captures the user-visible build provenance embedded in the CLI.
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	BuildTime string `json:"buildTime,omitempty"`
+	BuiltBy   string `json:"builtBy,omitempty"`
+	GoVersion string `json:"goVersion"`
+	Platform  string `json:"platform"`
+	Modified  bool   `json:"modified"`
+}
+
+// Current returns the best available build provenance for the running binary.
+func Current() Info {
+	return infoFromSettings(Version, Commit, BuildTime, BuiltBy, readBuildSettings())
+}
+
+func infoFromSettings(version, commit, buildTime, builtBy string, settings map[string]string) Info {
+	info := Info{
+		Version:   normalize(version, "dev"),
+		Commit:    normalize(commit, settings["vcs.revision"]),
+		BuildTime: normalize(buildTime, settings["vcs.time"]),
+		BuiltBy:   normalize(builtBy, "local"),
+		GoVersion: runtime.Version(),
+		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+		Modified:  settings["vcs.modified"] == "true",
+	}
+	return info
+}
+
+func normalize(primary, fallback string) string {
+	primary = strings.TrimSpace(primary)
+	if primary != "" {
+		return primary
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func readBuildSettings() map[string]string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	settings := make(map[string]string, len(info.Settings))
+	for _, setting := range info.Settings {
+		settings[setting.Key] = setting.Value
+	}
+	return settings
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,66 @@
+package buildinfo
+
+import "testing"
+
+func TestInfoFromSettingsPrefersExplicitStamping(t *testing.T) {
+	t.Parallel()
+
+	info := infoFromSettings(
+		"2025.05.7",
+		"abc123",
+		"2025-05-02T03:04:05Z",
+		"github-actions",
+		map[string]string{
+			"vcs.revision": "fallback",
+			"vcs.time":     "2024-01-01T00:00:00Z",
+			"vcs.modified": "true",
+		},
+	)
+
+	if info.Version != "2025.05.7" {
+		t.Fatalf("Version = %q, want 2025.05.7", info.Version)
+	}
+	if info.Commit != "abc123" {
+		t.Fatalf("Commit = %q, want abc123", info.Commit)
+	}
+	if info.BuildTime != "2025-05-02T03:04:05Z" {
+		t.Fatalf("BuildTime = %q, want stamped time", info.BuildTime)
+	}
+	if info.BuiltBy != "github-actions" {
+		t.Fatalf("BuiltBy = %q, want github-actions", info.BuiltBy)
+	}
+	if !info.Modified {
+		t.Fatal("Modified = false, want true")
+	}
+	if info.GoVersion == "" {
+		t.Fatal("GoVersion = empty, want runtime version")
+	}
+	if info.Platform == "" {
+		t.Fatal("Platform = empty, want runtime platform")
+	}
+}
+
+func TestInfoFromSettingsFallsBackToVCSMetadata(t *testing.T) {
+	t.Parallel()
+
+	info := infoFromSettings("", "", "", "", map[string]string{
+		"vcs.revision": "deadbeef",
+		"vcs.time":     "2025-05-02T03:04:05Z",
+	})
+
+	if info.Version != "dev" {
+		t.Fatalf("Version = %q, want dev", info.Version)
+	}
+	if info.Commit != "deadbeef" {
+		t.Fatalf("Commit = %q, want deadbeef", info.Commit)
+	}
+	if info.BuildTime != "2025-05-02T03:04:05Z" {
+		t.Fatalf("BuildTime = %q, want vcs time", info.BuildTime)
+	}
+	if info.BuiltBy != "local" {
+		t.Fatalf("BuiltBy = %q, want local", info.BuiltBy)
+	}
+	if info.Modified {
+		t.Fatal("Modified = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- add a user-visible `rein version` provenance surface with ldflags + VCS metadata fallback
- align `just ci` with GitHub CI, including buf breaking checks, mdBook validation, and macOS-targeted coverage
- add a CalVer tag-driven release workflow that builds archives, publishes GitHub releases, and records artifact attestations

## Validation
- `just ci`
- `just ci-macos`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'`\n- `just build && ./bin/rein version`\n- stamped local build via `go build -ldflags ... ./cmd/rein && ./bin/rein-stamped version`\n- linux/amd64 cross-build via `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags ... ./cmd/rein`