### PR TITLE
RN-33: harden describe/help surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ mdbook serve docs
 - Use `rein restore <source>` to swap the selected instance state directory back from a backup copy.
 - Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics.
 - Use `rein dashboards apply` to push the bundled `rein-dashboards` SigNoz reference dashboards into a SigNoz workspace over the HTTP API.
-- Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface and reachable protobuf schemas.
-- Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.
+- Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface, service-group help, utility commands, and reachable protobuf schemas.
+- Use `rein describe-as=mcp` for a compact stable YAML description of commands, help entry points, gateway stub routes, and a schema index suitable for wrapper/skill tooling.
+- Use `rein describe-as=mcp-full` when you need the exhaustive YAML schema dump behind that compact MCP surface.
 - Use `rein tui` for the terminal-native HMI over that same daemon surface.
 - Use `rein version` to print the current CalVer, commit/build metadata, and local-vs-release provenance.
 - Service commands mirror the protobuf API: `rein project|issue|execution|workflow|adapter <verb>`.
+- Use `rein <service> --help` to discover verbs for a service group, then `rein <service> <verb> --help` for request flags.
 - Top-level request flags map 1:1 to top-level protobuf request fields and use the protobuf field names (for example `--project_id`).
 - Scalar fields take plain values; message, repeated, and map fields take JSON blobs.
 - Nested JSON payloads are decoded with protobuf JSON field names (for example `displayName` inside a `Project` payload).

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -35,6 +36,12 @@ import (
 )
 
 const defaultRPCTimeout = 10 * time.Second
+
+var (
+	loadRPCCommandsOnce  sync.Once
+	cachedRPCCommands    map[string]rpcCommand
+	cachedRPCCommandsErr error
+)
 
 type app struct {
 	stdout      io.Writer
@@ -303,7 +310,24 @@ func (a *app) runRPC(root rootConfig, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(args) < 2 {
+	grouped := groupRPCCommandsByNoun(commands)
+	if len(args) == 0 {
+		a.printRootHelp()
+		return flag.ErrHelp
+	}
+	if len(args) == 1 {
+		if serviceCommands, ok := grouped[args[0]]; ok {
+			a.printServiceHelp(args[0], serviceCommands)
+			return flag.ErrHelp
+		}
+		a.printRootHelp()
+		return flag.ErrHelp
+	}
+	if isHelpToken(args[1]) {
+		if serviceCommands, ok := grouped[args[0]]; ok {
+			a.printServiceHelp(args[0], serviceCommands)
+			return flag.ErrHelp
+		}
 		a.printRootHelp()
 		return flag.ErrHelp
 	}
@@ -373,6 +397,13 @@ func dialGRPC(_ context.Context, config clientConfig) (*grpc.ClientConn, error) 
 }
 
 func loadRPCCommands() (map[string]rpcCommand, error) {
+	loadRPCCommandsOnce.Do(func() {
+		cachedRPCCommands, cachedRPCCommandsErr = loadRPCCommandsUncached()
+	})
+	return cachedRPCCommands, cachedRPCCommandsErr
+}
+
+func loadRPCCommandsUncached() (map[string]rpcCommand, error) {
 	services := []struct {
 		fullName protoreflect.FullName
 		noun     string
@@ -414,6 +445,19 @@ func loadRPCCommands() (map[string]rpcCommand, error) {
 		}
 	}
 	return commands, nil
+}
+
+func groupRPCCommandsByNoun(commands map[string]rpcCommand) map[string][]rpcCommand {
+	grouped := make(map[string][]rpcCommand, len(commands))
+	for _, command := range commands {
+		grouped[command.noun] = append(grouped[command.noun], command)
+	}
+	for noun := range grouped {
+		sort.Slice(grouped[noun], func(i, j int) bool {
+			return grouped[noun][i].verb < grouped[noun][j].verb
+		})
+	}
+	return grouped
 }
 
 func methodVerb(name protoreflect.Name) (string, bool) {
@@ -551,15 +595,9 @@ func (a *app) printRootHelp() {
 	}
 
 	fmt.Fprintln(a.stderr, "Usage:")
-	fmt.Fprintln(a.stderr, "  rein [global flags] <service> <verb> [flags]")
-	fmt.Fprintln(a.stderr, "  rein [global flags] backup [flags] <destination>")
-	fmt.Fprintln(a.stderr, "  rein [global flags] daemon serve [flags]")
-	fmt.Fprintln(a.stderr, "  rein dashboards apply [flags]")
-	fmt.Fprintln(a.stderr, "  rein [global flags] doctor")
-	fmt.Fprintln(a.stderr, "  rein [global flags] describe-as=<format>")
-	fmt.Fprintln(a.stderr, "  rein [global flags] restore [flags] <source>")
-	fmt.Fprintln(a.stderr, "  rein [global flags] tui")
-	fmt.Fprintln(a.stderr, "  rein version [--json]")
+	for _, line := range rootUsageLines() {
+		fmt.Fprintf(a.stderr, "  %s\n", line)
+	}
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Global flags:")
 	for _, flag := range globalFlagDescriptions() {
@@ -568,10 +606,7 @@ func (a *app) printRootHelp() {
 	fmt.Fprintln(a.stderr)
 	fmt.Fprintln(a.stderr, "Commands:")
 
-	grouped := map[string][]rpcCommand{}
-	for _, command := range commands {
-		grouped[command.noun] = append(grouped[command.noun], command)
-	}
+	grouped := groupRPCCommandsByNoun(commands)
 	nouns := make([]string, 0, len(grouped))
 	for noun := range grouped {
 		nouns = append(nouns, noun)
@@ -579,21 +614,23 @@ func (a *app) printRootHelp() {
 	sort.Strings(nouns)
 	for _, noun := range nouns {
 		commandsForNoun := grouped[noun]
-		sort.Slice(commandsForNoun, func(i, j int) bool { return commandsForNoun[i].verb < commandsForNoun[j].verb })
 		fmt.Fprintf(a.stderr, "  %s\t%s\n", noun, cleanComment(commentText(commandsForNoun[0].service)))
 		for _, command := range commandsForNoun {
 			fmt.Fprintf(a.stderr, "    %s %s\t%s\n", noun, command.verb, cleanComment(commentText(command.method)))
 		}
 	}
 	fmt.Fprintln(a.stderr)
-	fmt.Fprintln(a.stderr, "  backup\tCheckpoint SQLite WAL and atomically copy the selected instance state.")
-	fmt.Fprintln(a.stderr, "  tui\tTerminal UI over the canonical gRPC surface.")
-	fmt.Fprintln(a.stderr, "  daemon serve\tStart the daemon and expose the canonical gRPC surface.")
-	fmt.Fprintln(a.stderr, "  dashboards apply\tApply reference OTLP dashboards to a SigNoz workspace.")
-	fmt.Fprintln(a.stderr, "  doctor\tEmit JSON diagnostics for daemon health and local instance readiness.")
-	fmt.Fprintln(a.stderr, "  describe-as=<format>\tEmit a stable machine-consumable surface description.")
-	fmt.Fprintln(a.stderr, "  restore\tAtomically replace the selected instance state from a backup copy.")
-	fmt.Fprintln(a.stderr, "  version\tPrint the CLI version and embedded build provenance.")
+	for _, utility := range utilityCommandDescriptions() {
+		command := utility.Command
+		if utility.Name == "describe_as" {
+			command = "describe-as=<format>"
+		}
+		fmt.Fprintf(a.stderr, "  %s\t%s\n", command, utility.Summary)
+	}
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintln(a.stderr, "Help:")
+	fmt.Fprintln(a.stderr, "  rein <service> --help\tList verbs for a service group.")
+	fmt.Fprintln(a.stderr, "  rein <service> <verb> --help\tShow flags for a specific RPC command.")
 }
 
 func (a *app) printBackupHelp() {
@@ -680,6 +717,23 @@ func (a *app) printTUIHelp() {
 	fmt.Fprintln(a.stderr, "  enter            Toggle compact vs expanded execution drilldown.")
 	fmt.Fprintln(a.stderr, "  r                Refresh daemon data.")
 	fmt.Fprintln(a.stderr, "  q                Quit.")
+}
+
+func (a *app) printServiceHelp(noun string, commands []rpcCommand) {
+	fmt.Fprintln(a.stderr, "Usage:")
+	fmt.Fprintf(a.stderr, "  rein [global flags] %s <verb> [flags]\n", noun)
+	fmt.Fprintf(a.stderr, "  rein [global flags] %s --help\n", noun)
+	fmt.Fprintln(a.stderr)
+	if len(commands) > 0 {
+		fmt.Fprintln(a.stderr, cleanComment(commentText(commands[0].service)))
+		fmt.Fprintln(a.stderr)
+	}
+	fmt.Fprintln(a.stderr, "Verbs:")
+	for _, command := range commands {
+		fmt.Fprintf(a.stderr, "  %s\t%s\n", command.verb, cleanComment(commentText(command.method)))
+	}
+	fmt.Fprintln(a.stderr)
+	fmt.Fprintf(a.stderr, "Use \"rein [global flags] %s <verb> --help\" for verb-specific flags.\n", noun)
 }
 
 func (a *app) printCommandHelp(command rpcCommand) {

--- a/cmd/rein/backup_test.go
+++ b/cmd/rein/backup_test.go
@@ -134,6 +134,14 @@ func TestBackupStopStopsDaemonBeforeCopy(t *testing.T) {
 	}
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
+	waited := false
+	waitHelper := func() error {
+		if waited {
+			return nil
+		}
+		waited = true
+		return <-done
+	}
 	helperExited := false
 	defer func() {
 		if helperExited {
@@ -141,9 +149,10 @@ func TestBackupStopStopsDaemonBeforeCopy(t *testing.T) {
 		}
 		select {
 		case <-done:
+			waited = true
 		default:
 			_ = cmd.Process.Kill()
-			<-done
+			_ = waitHelper()
 		}
 	}()
 	waitForPIDLock(t, layout.PIDPath)
@@ -156,8 +165,11 @@ func TestBackupStopStopsDaemonBeforeCopy(t *testing.T) {
 	if err := app.run([]string{"backup", "--stop", backupPath}); err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
-	if err := <-done; err != nil {
-		t.Fatalf("helper exit error = %v", err)
+	if err := waitHelper(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("helper exit error = %v", err)
+		}
 	}
 	helperExited = true
 	if _, err := os.Stat(filepath.Join(backupPath, "state.txt")); err != nil {

--- a/cmd/rein/config_test.go
+++ b/cmd/rein/config_test.go
@@ -192,6 +192,61 @@ func TestAppCommandHelpUsesProtoComments(t *testing.T) {
 	}
 }
 
+func TestAppServiceGroupHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	err := app.run([]string{"project", "--help"})
+	if err != flag.ErrHelp {
+		t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+	}
+
+	output := stderr.String()
+	for _, want := range []string{
+		"rein [global flags] project <verb> [flags]",
+		"List projects stored in the daemon.",
+		"list\tList projects stored in the daemon.",
+		"Use \"rein [global flags] project <verb> --help\" for verb-specific flags.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("service help output missing %q\n%s", want, output)
+		}
+	}
+}
+
+func TestAppUnknownServiceHelpFallsBackToRootHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	err := app.run([]string{"unknown", "--help"})
+	if err != flag.ErrHelp {
+		t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
+	}
+
+	output := stderr.String()
+	for _, want := range []string{
+		"Usage:",
+		"rein [global flags] <service> <verb> [flags]",
+		"rein <service> --help\tList verbs for a service group.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("root help output missing %q\n%s", want, output)
+		}
+	}
+}
+
 func TestRootHelpListsStaticCommands(t *testing.T) {
 	t.Parallel()
 
@@ -216,6 +271,7 @@ func TestRootHelpListsStaticCommands(t *testing.T) {
 		"describe-as=<format>\tEmit a stable machine-consumable surface description.",
 		"restore\tAtomically replace the selected instance state from a backup copy.",
 		"tui\tTerminal UI over the canonical gRPC surface.",
+		"rein <service> --help\tList verbs for a service group.",
 		"rein version [--json]",
 		"version\tPrint the CLI version and embedded build provenance.",
 	} {
@@ -396,6 +452,9 @@ func TestAppDescribeCLIOutput(t *testing.T) {
 	output := stdout.String()
 	for _, want := range []string{
 		"REIN SURFACE v1",
+		"SERVICE GROUPS",
+		"UTILITY COMMANDS",
+		"  backup",
 		"COMMAND project list",
 		"full_method: /rein.v1.ProjectService/ListProjects",
 		"schema: rein.v1.PageRequest",
@@ -428,14 +487,52 @@ func TestAppDescribeMCPOutput(t *testing.T) {
 	output := stdout.String()
 	for _, want := range []string{
 		"surface: \"rein\"",
+		"services:",
+		"help_cli: \"rein [global flags] project --help\"",
+		"utility_commands:",
+		"command: \"backup\"",
 		"- name: \"project_list\"",
 		"full_method: \"/rein.v1.ProjectService/ListProjects\"",
 		"path: \"/v2/projects\"",
+		"schema_index:",
+		"detail_format: \"mcp-full\"",
 		"- name: \"rein.v1.ListProjectsRequest\"",
-		"- name: \"rein.v1.ProjectStatus\"",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("describe-as=mcp output missing %q\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "schemas:\n") {
+		t.Fatalf("describe-as=mcp output unexpectedly included full schemas\n%s", output)
+	}
+}
+
+func TestAppDescribeMCPFullOutput(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	app := newApp(&stdout, &stderr, func(string) (string, bool) { return "", false }, func() (string, error) {
+		return "/Users/tester", nil
+	}, func() (string, error) {
+		return "/repo", nil
+	})
+
+	if err := app.run([]string{"describe-as=mcp-full"}); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"schema_index:",
+		"schemas:",
+		"- name: \"rein.v1.ListProjectsRequest\"",
+		"- name: \"rein.v1.ProjectStatus\"",
+		"fields:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("describe-as=mcp-full output missing %q\n%s", want, output)
 		}
 	}
 }
@@ -456,7 +553,7 @@ func TestAppDescribeHelpAndInvalidFormat(t *testing.T) {
 			t.Fatalf("run() error = %v, want %v", err, flag.ErrHelp)
 		}
 		output := stderr.String()
-		for _, want := range []string{"Formats:", "cli", "mcp"} {
+		for _, want := range []string{"Formats:", "cli", "mcp", "mcp-full"} {
 			if !strings.Contains(output, want) {
 				t.Fatalf("describe help missing %q\n%s", want, output)
 			}
@@ -475,7 +572,7 @@ func TestAppDescribeHelpAndInvalidFormat(t *testing.T) {
 		if err == nil {
 			t.Fatal("run() error = nil, want non-nil")
 		}
-		if !strings.Contains(err.Error(), "supported: cli, mcp") {
+		if !strings.Contains(err.Error(), "supported: cli, mcp, mcp-full") {
 			t.Fatalf("run() error = %v, want supported formats", err)
 		}
 	})

--- a/cmd/rein/describe.go
+++ b/cmd/rein/describe.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"google.golang.org/protobuf/reflect/protoreflect"
 
@@ -15,22 +16,25 @@ import (
 )
 
 const (
-	describeFormatCLI = "cli"
-	describeFormatMCP = "mcp"
+	describeFormatCLI     = "cli"
+	describeFormatMCP     = "mcp"
+	describeFormatMCPFull = "mcp-full"
 )
 
 type describeSurface struct {
-	Title       string
-	Summary     string
-	Conventions []string
-	Usage       []string
-	Formats     []describeFormatDescription
-	GlobalFlags []staticFlagDescription
-	Commands    []commandDescription
-	Daemon      daemonCommandDescription
-	Gateway     gatewayDescription
-	Messages    []messageSchemaDescription
-	Enums       []enumSchemaDescription
+	Title           string
+	Summary         string
+	Conventions     []string
+	Usage           []string
+	Formats         []describeFormatDescription
+	GlobalFlags     []staticFlagDescription
+	Services        []serviceGroupDescription
+	Commands        []commandDescription
+	UtilityCommands []utilityCommandDescription
+	Gateway         gatewayDescription
+	SchemaIndex     schemaIndexDescription
+	Messages        []messageSchemaDescription
+	Enums           []enumSchemaDescription
 }
 
 type describeFormatDescription struct {
@@ -44,11 +48,34 @@ type staticFlagDescription struct {
 	Description string
 }
 
-type daemonCommandDescription struct {
+type staticArgumentDescription struct {
+	Name        string
+	Type        string
+	Description string
+	Required    bool
+}
+
+type serviceGroupDescription struct {
+	Name    string
+	CLI     string
+	HelpCLI string
+	Summary string
+	Verbs   []serviceVerbDescription
+}
+
+type serviceVerbDescription struct {
 	Name    string
 	CLI     string
 	Summary string
-	Flags   []staticFlagDescription
+}
+
+type utilityCommandDescription struct {
+	Name      string
+	Command   string
+	CLI       string
+	Summary   string
+	Flags     []staticFlagDescription
+	Arguments []staticArgumentDescription
 }
 
 type commandDescription struct {
@@ -83,6 +110,20 @@ type gatewayDescription struct {
 	Streams []gateway.Stream
 }
 
+type schemaIndexDescription struct {
+	DetailFormat  string
+	DetailCommand string
+	MessageCount  int
+	EnumCount     int
+	Messages      []namedSchemaDescription
+	Enums         []namedSchemaDescription
+}
+
+type namedSchemaDescription struct {
+	Name        string
+	Description string
+}
+
 type messageSchemaDescription struct {
 	Name        string
 	Description string
@@ -101,10 +142,21 @@ type enumValueDescription struct {
 	Description string
 }
 
+var (
+	compactDescribeSurfaceOnce sync.Once
+	compactDescribeSurface     describeSurface
+	compactDescribeSurfaceErr  error
+
+	fullDescribeSurfaceOnce sync.Once
+	fullDescribeSurface     describeSurface
+	fullDescribeSurfaceErr  error
+)
+
 func supportedDescribeFormats() []describeFormatDescription {
 	return []describeFormatDescription{
-		{Name: describeFormatCLI, Description: "Manual-style description of the descriptor-driven CLI, daemon command, and reachable protobuf schemas."},
-		{Name: describeFormatMCP, Description: "YAML reference for wrapper and skill tooling, including CLI commands, gateway stub routes, and protobuf schemas."},
+		{Name: describeFormatCLI, Description: "Manual-style description of RPC service groups, top-level utility commands, gateway routes, and reachable protobuf schemas."},
+		{Name: describeFormatMCP, Description: "Compact YAML reference for wrapper and skill tooling with command/help discovery, gateway routes, and a schema index. Use mcp-full for the exhaustive schema dump."},
+		{Name: describeFormatMCPFull, Description: "Exhaustive YAML surface including the detailed protobuf schema dump used by cli."},
 	}
 }
 
@@ -114,8 +166,11 @@ func rootUsageLines() []string {
 		"rein [global flags] backup [flags] <destination>",
 		"rein [global flags] daemon serve [flags]",
 		"rein dashboards apply [flags]",
+		"rein [global flags] doctor",
 		"rein [global flags] describe-as=<format>",
 		"rein [global flags] restore [flags] <source>",
+		"rein [global flags] tui",
+		"rein version [--json]",
 	}
 }
 
@@ -124,6 +179,7 @@ func rootConventions() []string {
 		"Request flags map 1:1 to top-level gRPC request fields.",
 		"Scalar fields take plain values; message, repeated, and map fields take JSON blobs.",
 		"Responses are emitted as JSON using protobuf field names.",
+		"Use 'rein <service> --help' for subgroup help and 'rein <service> <verb> --help' for command flags.",
 	}
 }
 
@@ -147,7 +203,113 @@ func daemonServeFlagDescriptions() []staticFlagDescription {
 	}
 }
 
-func buildDescribeSurface() (describeSurface, error) {
+func utilityCommandDescriptions() []utilityCommandDescription {
+	return []utilityCommandDescription{
+		{
+			Name:    "backup",
+			Command: "backup",
+			CLI:     "rein [global flags] backup [flags] <destination>",
+			Summary: "Checkpoint SQLite WAL and atomically copy the selected instance state.",
+			Flags: []staticFlagDescription{{
+				Name:        "stop",
+				Type:        "bool",
+				Description: "Stop the selected daemon first as a paranoid fallback.",
+			}},
+			Arguments: []staticArgumentDescription{{
+				Name:        "destination",
+				Type:        "path",
+				Description: "Destination directory that must not already exist.",
+				Required:    true,
+			}},
+		},
+		{
+			Name:    "daemon_serve",
+			Command: "daemon serve",
+			CLI:     "rein [global flags] daemon serve [flags]",
+			Summary: "Start the daemon and expose the canonical gRPC surface.",
+			Flags:   daemonServeFlagDescriptions(),
+		},
+		{
+			Name:    "dashboards_apply",
+			Command: "dashboards apply",
+			CLI:     "rein dashboards apply [flags]",
+			Summary: "Apply reference OTLP dashboards to a SigNoz workspace.",
+			Flags: []staticFlagDescription{
+				{Name: "plugin", Type: "string", Description: "Dashboards plugin name (default \"rein-dashboards\")."},
+				{Name: "signoz-url", Type: "string", Description: "SigNoz base URL (or SIGNOZ_BASE_URL / SIGNOZ_URL)."},
+				{Name: "signoz-api-key", Type: "string", Description: "SigNoz API key (or SIGNOZ_API_KEY)."},
+			},
+		},
+		{
+			Name:    "doctor",
+			Command: "doctor",
+			CLI:     "rein [global flags] doctor",
+			Summary: "Emit JSON diagnostics for daemon health and local instance readiness.",
+		},
+		{
+			Name:    "describe_as",
+			Command: "describe-as",
+			CLI:     "rein [global flags] describe-as=<format>",
+			Summary: "Emit a stable machine-consumable surface description.",
+			Arguments: []staticArgumentDescription{{
+				Name:        "format",
+				Type:        "string",
+				Description: fmt.Sprintf("Supported formats: %s.", supportedDescribeFormatNames()),
+				Required:    true,
+			}},
+		},
+		{
+			Name:    "restore",
+			Command: "restore",
+			CLI:     "rein [global flags] restore [flags] <source>",
+			Summary: "Atomically replace the selected instance state from a backup copy.",
+			Flags: []staticFlagDescription{{
+				Name:        "stop",
+				Type:        "bool",
+				Description: "Stop the selected daemon before replacing its state directory.",
+			}},
+			Arguments: []staticArgumentDescription{{
+				Name:        "source",
+				Type:        "path",
+				Description: "Backup directory to restore from.",
+				Required:    true,
+			}},
+		},
+		{
+			Name:    "tui",
+			Command: "tui",
+			CLI:     "rein [global flags] tui",
+			Summary: "Terminal UI over the canonical gRPC surface.",
+		},
+		{
+			Name:    "version",
+			Command: "version",
+			CLI:     "rein version [--json]",
+			Summary: "Print the CLI version and embedded build provenance.",
+			Flags: []staticFlagDescription{{
+				Name:        "json",
+				Type:        "bool",
+				Description: "Emit structured JSON.",
+			}},
+		},
+	}
+}
+
+func buildDescribeSurfaceCompact() (describeSurface, error) {
+	compactDescribeSurfaceOnce.Do(func() {
+		compactDescribeSurface, compactDescribeSurfaceErr = constructDescribeSurface(false)
+	})
+	return compactDescribeSurface, compactDescribeSurfaceErr
+}
+
+func buildDescribeSurfaceFull() (describeSurface, error) {
+	fullDescribeSurfaceOnce.Do(func() {
+		fullDescribeSurface, fullDescribeSurfaceErr = constructDescribeSurface(true)
+	})
+	return fullDescribeSurface, fullDescribeSurfaceErr
+}
+
+func constructDescribeSurface(includeSchemas bool) (describeSurface, error) {
 	commandsByKey, err := loadRPCCommands()
 	if err != nil {
 		return describeSurface{}, err
@@ -168,24 +330,54 @@ func buildDescribeSurface() (describeSurface, error) {
 	})
 
 	gatewayStub := gateway.NewV2Stub()
-	return describeSurface{
-		Title:       "rein",
-		Summary:     "Descriptor-driven reference for the rein CLI, gRPC services, and v2 gateway stub.",
-		Conventions: rootConventions(),
-		Usage:       rootUsageLines(),
-		Formats:     supportedDescribeFormats(),
-		GlobalFlags: globalFlagDescriptions(),
-		Commands:    commands,
-		Daemon: daemonCommandDescription{
-			Name:    "daemon_serve",
-			CLI:     "rein [global flags] daemon serve [flags]",
-			Summary: "Start the daemon and expose the canonical gRPC surface.",
-			Flags:   daemonServeFlagDescriptions(),
-		},
-		Gateway:  gatewayDescription{Routes: gatewayStub.Routes(), Streams: gatewayStub.Streams()},
-		Messages: collector.messageSchemas(),
-		Enums:    collector.enumSchemas(),
-	}, nil
+	surface := describeSurface{
+		Title:           "rein",
+		Summary:         "Descriptor-driven reference for the rein CLI, gRPC services, and v2 gateway stub.",
+		Conventions:     rootConventions(),
+		Usage:           rootUsageLines(),
+		Formats:         supportedDescribeFormats(),
+		GlobalFlags:     globalFlagDescriptions(),
+		Services:        describeServiceGroups(commandsByKey),
+		Commands:        commands,
+		UtilityCommands: utilityCommandDescriptions(),
+		Gateway:         gatewayDescription{Routes: gatewayStub.Routes(), Streams: gatewayStub.Streams()},
+		SchemaIndex:     collector.schemaIndex(),
+	}
+	if includeSchemas {
+		surface.Messages = collector.messageSchemas()
+		surface.Enums = collector.enumSchemas()
+	}
+	return surface, nil
+}
+
+func describeServiceGroups(commandsByKey map[string]rpcCommand) []serviceGroupDescription {
+	grouped := groupRPCCommandsByNoun(commandsByKey)
+	nouns := make([]string, 0, len(grouped))
+	for noun := range grouped {
+		nouns = append(nouns, noun)
+	}
+	sort.Strings(nouns)
+
+	services := make([]serviceGroupDescription, 0, len(nouns))
+	for _, noun := range nouns {
+		commands := grouped[noun]
+		verbs := make([]serviceVerbDescription, 0, len(commands))
+		for _, command := range commands {
+			verbs = append(verbs, serviceVerbDescription{
+				Name:    command.verb,
+				CLI:     fmt.Sprintf("rein [global flags] %s %s [flags]", command.noun, command.verb),
+				Summary: cleanComment(commentText(command.method)),
+			})
+		}
+		services = append(services, serviceGroupDescription{
+			Name:    noun,
+			CLI:     fmt.Sprintf("rein [global flags] %s <verb> [flags]", noun),
+			HelpCLI: fmt.Sprintf("rein [global flags] %s --help", noun),
+			Summary: cleanComment(commentText(commands[0].service)),
+			Verbs:   verbs,
+		})
+	}
+	return services
 }
 
 func describeCommand(command rpcCommand) commandDescription {
@@ -373,6 +565,45 @@ func (c *schemaCollector) addEnum(enum protoreflect.EnumDescriptor) {
 	c.enums[enum.FullName()] = enum
 }
 
+func (c *schemaCollector) schemaIndex() schemaIndexDescription {
+	messageNames := make([]string, 0, len(c.messages))
+	for name := range c.messages {
+		messageNames = append(messageNames, string(name))
+	}
+	sort.Strings(messageNames)
+	messages := make([]namedSchemaDescription, 0, len(messageNames))
+	for _, name := range messageNames {
+		message := c.messages[protoreflect.FullName(name)]
+		messages = append(messages, namedSchemaDescription{
+			Name:        name,
+			Description: cleanComment(commentText(message)),
+		})
+	}
+
+	enumNames := make([]string, 0, len(c.enums))
+	for name := range c.enums {
+		enumNames = append(enumNames, string(name))
+	}
+	sort.Strings(enumNames)
+	enums := make([]namedSchemaDescription, 0, len(enumNames))
+	for _, name := range enumNames {
+		enum := c.enums[protoreflect.FullName(name)]
+		enums = append(enums, namedSchemaDescription{
+			Name:        name,
+			Description: cleanComment(commentText(enum)),
+		})
+	}
+
+	return schemaIndexDescription{
+		DetailFormat:  describeFormatMCPFull,
+		DetailCommand: "rein [global flags] describe-as=mcp-full",
+		MessageCount:  len(messages),
+		EnumCount:     len(enums),
+		Messages:      messages,
+		Enums:         enums,
+	}
+}
+
 func (c *schemaCollector) messageSchemas() []messageSchemaDescription {
 	names := make([]string, 0, len(c.messages))
 	for name := range c.messages {
@@ -416,15 +647,25 @@ func (c *schemaCollector) enumSchemas() []enumSchemaDescription {
 }
 
 func renderDescribeAs(format string) (string, error) {
-	surface, err := buildDescribeSurface()
-	if err != nil {
-		return "", err
-	}
 	switch format {
 	case describeFormatCLI:
+		surface, err := buildDescribeSurfaceFull()
+		if err != nil {
+			return "", err
+		}
 		return renderDescribeCLI(surface), nil
 	case describeFormatMCP:
+		surface, err := buildDescribeSurfaceCompact()
+		if err != nil {
+			return "", err
+		}
 		return renderDescribeMCP(surface), nil
+	case describeFormatMCPFull:
+		surface, err := buildDescribeSurfaceFull()
+		if err != nil {
+			return "", err
+		}
+		return renderDescribeMCPFull(surface), nil
 	default:
 		return "", fmt.Errorf("unsupported describe-as format %q (supported: %s)", format, supportedDescribeFormatNames())
 	}
@@ -471,54 +712,76 @@ func renderDescribeCLI(surface describeSurface) string {
 	}
 	buf.WriteString("\n")
 
-	fmt.Fprintln(&buf, "COMMAND GROUPS")
-	currentNoun := ""
-	for _, command := range surface.Commands {
-		if command.Noun != currentNoun {
-			currentNoun = command.Noun
-			fmt.Fprintf(&buf, "  %s\n", currentNoun)
-			if command.ServiceSummary != "" {
-				fmt.Fprintf(&buf, "    %s\n", command.ServiceSummary)
-			}
-			buf.WriteString("\n")
+	fmt.Fprintln(&buf, "SERVICE GROUPS")
+	for _, service := range surface.Services {
+		fmt.Fprintf(&buf, "  %s\n", service.Name)
+		fmt.Fprintf(&buf, "    summary: %s\n", service.Summary)
+		fmt.Fprintf(&buf, "    cli: %s\n", service.CLI)
+		fmt.Fprintf(&buf, "    help: %s\n", service.HelpCLI)
+		fmt.Fprintln(&buf, "    verbs:")
+		for _, verb := range service.Verbs {
+			fmt.Fprintf(&buf, "      %s\n", verb.Name)
+			fmt.Fprintf(&buf, "        cli: %s\n", verb.CLI)
+			fmt.Fprintf(&buf, "        summary: %s\n", verb.Summary)
 		}
-		fmt.Fprintf(&buf, "    COMMAND %s %s\n", command.Noun, command.Verb)
-		fmt.Fprintf(&buf, "      summary: %s\n", command.Summary)
-		fmt.Fprintf(&buf, "      grpc_service: %s\n", command.Service)
-		fmt.Fprintf(&buf, "      grpc_method: %s\n", command.Method)
-		fmt.Fprintf(&buf, "      full_method: %s\n", command.FullMethod)
-		fmt.Fprintf(&buf, "      request: %s\n", command.RequestType)
-		fmt.Fprintf(&buf, "      response: %s\n", command.ResponseType)
-		fmt.Fprintf(&buf, "      cli: %s\n", command.CLI)
-		fmt.Fprintf(&buf, "      flags:\n")
-		for _, flag := range command.Flags {
-			fmt.Fprintf(&buf, "        --%s %s\n", flag.Name, flag.Type)
-			fmt.Fprintf(&buf, "          proto: %s\n", flag.ProtoType)
-			fmt.Fprintf(&buf, "          description: %s\n", flag.Description)
-			fmt.Fprintf(&buf, "          accepts_json: %t\n", flag.AcceptsJSON)
-			if flag.SchemaRef != "" {
-				fmt.Fprintf(&buf, "          schema: %s\n", flag.SchemaRef)
+		buf.WriteString("\n")
+	}
+
+	fmt.Fprintln(&buf, "UTILITY COMMANDS")
+	for _, utility := range surface.UtilityCommands {
+		fmt.Fprintf(&buf, "  %s\n", utility.Command)
+		fmt.Fprintf(&buf, "    summary: %s\n", utility.Summary)
+		fmt.Fprintf(&buf, "    cli: %s\n", utility.CLI)
+		if len(utility.Arguments) == 0 {
+			fmt.Fprintln(&buf, "    args: none")
+		} else {
+			fmt.Fprintln(&buf, "    args:")
+			for _, arg := range utility.Arguments {
+				fmt.Fprintf(&buf, "      <%s> %s\n", arg.Name, arg.Type)
+				fmt.Fprintf(&buf, "        required: %t\n", arg.Required)
+				fmt.Fprintf(&buf, "        description: %s\n", arg.Description)
 			}
-			if len(flag.EnumValues) > 0 {
-				fmt.Fprintf(&buf, "          enum_values:\n")
-				for _, value := range flag.EnumValues {
-					fmt.Fprintf(&buf, "            - %s = %d\n", value.Name, value.Number)
-				}
+		}
+		if len(utility.Flags) == 0 {
+			fmt.Fprintln(&buf, "    flags: none")
+		} else {
+			fmt.Fprintln(&buf, "    flags:")
+			for _, flag := range utility.Flags {
+				fmt.Fprintf(&buf, "      --%s %s\n", flag.Name, flag.Type)
+				fmt.Fprintf(&buf, "        %s\n", flag.Description)
 			}
 		}
 		buf.WriteString("\n")
 	}
 
-	fmt.Fprintln(&buf, "DAEMON COMMANDS")
-	fmt.Fprintf(&buf, "  daemon serve\n")
-	fmt.Fprintf(&buf, "    summary: %s\n", surface.Daemon.Summary)
-	fmt.Fprintf(&buf, "    cli: %s\n", surface.Daemon.CLI)
-	fmt.Fprintln(&buf, "    flags:")
-	for _, flag := range surface.Daemon.Flags {
-		fmt.Fprintf(&buf, "      --%s %s\n", flag.Name, flag.Type)
-		fmt.Fprintf(&buf, "        %s\n", flag.Description)
+	fmt.Fprintln(&buf, "RPC COMMANDS")
+	for _, command := range surface.Commands {
+		fmt.Fprintf(&buf, "  COMMAND %s %s\n", command.Noun, command.Verb)
+		fmt.Fprintf(&buf, "    summary: %s\n", command.Summary)
+		fmt.Fprintf(&buf, "    grpc_service: %s\n", command.Service)
+		fmt.Fprintf(&buf, "    grpc_method: %s\n", command.Method)
+		fmt.Fprintf(&buf, "    full_method: %s\n", command.FullMethod)
+		fmt.Fprintf(&buf, "    request: %s\n", command.RequestType)
+		fmt.Fprintf(&buf, "    response: %s\n", command.ResponseType)
+		fmt.Fprintf(&buf, "    cli: %s\n", command.CLI)
+		fmt.Fprintf(&buf, "    flags:\n")
+		for _, flag := range command.Flags {
+			fmt.Fprintf(&buf, "      --%s %s\n", flag.Name, flag.Type)
+			fmt.Fprintf(&buf, "        proto: %s\n", flag.ProtoType)
+			fmt.Fprintf(&buf, "        description: %s\n", flag.Description)
+			fmt.Fprintf(&buf, "        accepts_json: %t\n", flag.AcceptsJSON)
+			if flag.SchemaRef != "" {
+				fmt.Fprintf(&buf, "        schema: %s\n", flag.SchemaRef)
+			}
+			if len(flag.EnumValues) > 0 {
+				fmt.Fprintf(&buf, "        enum_values:\n")
+				for _, value := range flag.EnumValues {
+					fmt.Fprintf(&buf, "          - %s = %d\n", value.Name, value.Number)
+				}
+			}
+		}
+		buf.WriteString("\n")
 	}
-	buf.WriteString("\n")
 
 	fmt.Fprintln(&buf, "GATEWAY STUB")
 	fmt.Fprintln(&buf, "  routes:")
@@ -532,6 +795,13 @@ func renderDescribeCLI(surface describeSurface) string {
 		fmt.Fprintf(&buf, "      event: %s\n", stream.Event)
 		fmt.Fprintf(&buf, "      purpose: %s\n", stream.Purpose)
 	}
+	buf.WriteString("\n")
+
+	fmt.Fprintln(&buf, "SCHEMA INDEX")
+	fmt.Fprintf(&buf, "  detail_format: %s\n", surface.SchemaIndex.DetailFormat)
+	fmt.Fprintf(&buf, "  detail_command: %s\n", surface.SchemaIndex.DetailCommand)
+	fmt.Fprintf(&buf, "  message_count: %d\n", surface.SchemaIndex.MessageCount)
+	fmt.Fprintf(&buf, "  enum_count: %d\n", surface.SchemaIndex.EnumCount)
 	buf.WriteString("\n")
 
 	fmt.Fprintln(&buf, "SCHEMAS")
@@ -575,6 +845,14 @@ func renderDescribeCLI(surface describeSurface) string {
 }
 
 func renderDescribeMCP(surface describeSurface) string {
+	return renderDescribeMCPDocument(surface, false)
+}
+
+func renderDescribeMCPFull(surface describeSurface) string {
+	return renderDescribeMCPDocument(surface, true)
+}
+
+func renderDescribeMCPDocument(surface describeSurface, includeDetailedSchemas bool) string {
 	var buf bytes.Buffer
 	writeYAMLString(&buf, "version", "1")
 	writeYAMLString(&buf, "surface", surface.Title)
@@ -603,6 +881,49 @@ func renderDescribeMCP(surface describeSurface) string {
 		fmt.Fprintf(&buf, "    type: %s\n", yamlString(flag.Type))
 		fmt.Fprintf(&buf, "    description: %s\n", yamlString(flag.Description))
 	}
+	buf.WriteString("services:\n")
+	for _, service := range surface.Services {
+		buf.WriteString("  - name: ")
+		buf.WriteString(yamlString(service.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "    cli: %s\n", yamlString(service.CLI))
+		fmt.Fprintf(&buf, "    help_cli: %s\n", yamlString(service.HelpCLI))
+		fmt.Fprintf(&buf, "    summary: %s\n", yamlString(service.Summary))
+		buf.WriteString("    verbs:\n")
+		for _, verb := range service.Verbs {
+			buf.WriteString("      - name: ")
+			buf.WriteString(yamlString(verb.Name))
+			buf.WriteString("\n")
+			fmt.Fprintf(&buf, "        cli: %s\n", yamlString(verb.CLI))
+			fmt.Fprintf(&buf, "        summary: %s\n", yamlString(verb.Summary))
+		}
+	}
+	buf.WriteString("utility_commands:\n")
+	for _, utility := range surface.UtilityCommands {
+		buf.WriteString("  - name: ")
+		buf.WriteString(yamlString(utility.Name))
+		buf.WriteString("\n")
+		fmt.Fprintf(&buf, "    command: %s\n", yamlString(utility.Command))
+		fmt.Fprintf(&buf, "    cli: %s\n", yamlString(utility.CLI))
+		fmt.Fprintf(&buf, "    summary: %s\n", yamlString(utility.Summary))
+		buf.WriteString("    arguments:\n")
+		for _, arg := range utility.Arguments {
+			buf.WriteString("      - name: ")
+			buf.WriteString(yamlString(arg.Name))
+			buf.WriteString("\n")
+			fmt.Fprintf(&buf, "        type: %s\n", yamlString(arg.Type))
+			fmt.Fprintf(&buf, "        description: %s\n", yamlString(arg.Description))
+			fmt.Fprintf(&buf, "        required: %t\n", arg.Required)
+		}
+		buf.WriteString("    flags:\n")
+		for _, flag := range utility.Flags {
+			buf.WriteString("      - name: ")
+			buf.WriteString(yamlString(flag.Name))
+			buf.WriteString("\n")
+			fmt.Fprintf(&buf, "        type: %s\n", yamlString(flag.Type))
+			fmt.Fprintf(&buf, "        description: %s\n", yamlString(flag.Description))
+		}
+	}
 	buf.WriteString("commands:\n")
 	for _, command := range surface.Commands {
 		buf.WriteString("  - name: ")
@@ -623,20 +944,6 @@ func renderDescribeMCP(surface describeSurface) string {
 			writeYAMLField(&buf, "      ", flag)
 		}
 	}
-	buf.WriteString("daemon:\n")
-	buf.WriteString("  - name: ")
-	buf.WriteString(yamlString(surface.Daemon.Name))
-	buf.WriteString("\n")
-	fmt.Fprintf(&buf, "    cli: %s\n", yamlString(surface.Daemon.CLI))
-	fmt.Fprintf(&buf, "    summary: %s\n", yamlString(surface.Daemon.Summary))
-	buf.WriteString("    flags:\n")
-	for _, flag := range surface.Daemon.Flags {
-		buf.WriteString("      - name: ")
-		buf.WriteString(yamlString(flag.Name))
-		buf.WriteString("\n")
-		fmt.Fprintf(&buf, "        type: %s\n", yamlString(flag.Type))
-		fmt.Fprintf(&buf, "        description: %s\n", yamlString(flag.Description))
-	}
 	buf.WriteString("gateway:\n")
 	buf.WriteString("  routes:\n")
 	for _, route := range surface.Gateway.Routes {
@@ -654,31 +961,52 @@ func renderDescribeMCP(surface describeSurface) string {
 		fmt.Fprintf(&buf, "      event: %s\n", yamlString(stream.Event))
 		fmt.Fprintf(&buf, "      purpose: %s\n", yamlString(stream.Purpose))
 	}
-	buf.WriteString("schemas:\n")
+	buf.WriteString("schema_index:\n")
+	fmt.Fprintf(&buf, "  detail_format: %s\n", yamlString(surface.SchemaIndex.DetailFormat))
+	fmt.Fprintf(&buf, "  detail_command: %s\n", yamlString(surface.SchemaIndex.DetailCommand))
+	fmt.Fprintf(&buf, "  message_count: %d\n", surface.SchemaIndex.MessageCount)
+	fmt.Fprintf(&buf, "  enum_count: %d\n", surface.SchemaIndex.EnumCount)
 	buf.WriteString("  messages:\n")
-	for _, message := range surface.Messages {
+	for _, message := range surface.SchemaIndex.Messages {
 		buf.WriteString("    - name: ")
 		buf.WriteString(yamlString(message.Name))
 		buf.WriteString("\n")
 		fmt.Fprintf(&buf, "      description: %s\n", yamlString(message.Description))
-		buf.WriteString("      fields:\n")
-		for _, field := range message.Fields {
-			writeYAMLField(&buf, "        ", field)
-		}
 	}
 	buf.WriteString("  enums:\n")
-	for _, enum := range surface.Enums {
+	for _, enum := range surface.SchemaIndex.Enums {
 		buf.WriteString("    - name: ")
 		buf.WriteString(yamlString(enum.Name))
 		buf.WriteString("\n")
 		fmt.Fprintf(&buf, "      description: %s\n", yamlString(enum.Description))
-		buf.WriteString("      values:\n")
-		for _, value := range enum.Values {
-			buf.WriteString("        - name: ")
-			buf.WriteString(yamlString(value.Name))
+	}
+	if includeDetailedSchemas {
+		buf.WriteString("schemas:\n")
+		buf.WriteString("  messages:\n")
+		for _, message := range surface.Messages {
+			buf.WriteString("    - name: ")
+			buf.WriteString(yamlString(message.Name))
 			buf.WriteString("\n")
-			fmt.Fprintf(&buf, "          number: %d\n", value.Number)
-			fmt.Fprintf(&buf, "          description: %s\n", yamlString(value.Description))
+			fmt.Fprintf(&buf, "      description: %s\n", yamlString(message.Description))
+			buf.WriteString("      fields:\n")
+			for _, field := range message.Fields {
+				writeYAMLField(&buf, "        ", field)
+			}
+		}
+		buf.WriteString("  enums:\n")
+		for _, enum := range surface.Enums {
+			buf.WriteString("    - name: ")
+			buf.WriteString(yamlString(enum.Name))
+			buf.WriteString("\n")
+			fmt.Fprintf(&buf, "      description: %s\n", yamlString(enum.Description))
+			buf.WriteString("      values:\n")
+			for _, value := range enum.Values {
+				buf.WriteString("        - name: ")
+				buf.WriteString(yamlString(value.Name))
+				buf.WriteString("\n")
+				fmt.Fprintf(&buf, "          number: %d\n", value.Number)
+				fmt.Fprintf(&buf, "          description: %s\n", yamlString(value.Description))
+			}
 		}
 	}
 	return buf.String()

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -50,11 +50,19 @@ The JSON output includes:
 
 ## 4. Explore the shipped surface
 
-The CLI surface is descriptor-driven. Two built-in describe modes are useful when you want authoritative command metadata:
+The CLI surface is descriptor-driven. The built-in describe modes are useful when you want authoritative command metadata:
 
 ```bash
 ./bin/rein describe-as=cli
 ./bin/rein describe-as=mcp
+./bin/rein describe-as=mcp-full
+```
+
+For help discovery, use subgroup help before drilling into a verb:
+
+```bash
+./bin/rein project --help
+./bin/rein project list --help
 ```
 
 The common top-level service commands are:

--- a/docs/src/tui-quickstart.md
+++ b/docs/src/tui-quickstart.md
@@ -80,7 +80,7 @@ Prefer the CLI when you need:
 
 - machine-readable JSON output
 - precise filters or scripted automation
-- `describe-as=cli` / `describe-as=mcp`
+- `describe-as=cli` / `describe-as=mcp` / `describe-as=mcp-full`
 - backup/restore operations
 - SigNoz dashboard installation
 


### PR DESCRIPTION
## Summary
- add service-group help and include utility commands in describe output
- make describe-as=mcp compact by default with mcp-full for full schema details
- update focused docs/tests for the new help and describe surface

## Validation
- go test ./cmd/rein -count=1 -timeout 5m
- go build -o bin/rein ./cmd/rein
- mdbook build docs