### PR TITLE
RN-34: share repo-root discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rein is still early, but the current tree already ships a usable local daemon, a
 
 - A single `rein` binary that can run the daemon, speak the canonical gRPC/CLI surface, and launch the TUI.
 - Per-instance state under `~/.local/state/rein/instances/<name>/` (or `$XDG_STATE_HOME/rein/instances/<name>/`) with `rein backup` and `rein restore` for safe copies.
-- `rein doctor` JSON diagnostics for instance layout, daemon reachability, adapter registry readiness, credential-provider readiness, and SQLite migration state.
+- `rein doctor` JSON diagnostics for instance layout, daemon reachability, repo-local adapter marketplace discovery/readiness, credential-provider readiness, and SQLite migration state.
 - Opt-in OTLP/gRPC export for traces, metrics, and logs, plus a bundled `rein dashboards apply` workflow for SigNoz.
 - A signed repository marketplace index plus bundled first-party plugins under `plugins/`.
 - External seams for one-shot migration tooling and external coding adapters, without pulling those source-system dependencies into the core daemon.
@@ -20,13 +20,13 @@ Build the current tree with Go 1.25:
 go build -o bin/rein ./cmd/rein
 ```
 
-Start the daemon for the default `live` instance:
+Start the daemon for the default `live` instance from the repo root (or any child directory inside this repo so bundled adapters are discovered consistently):
 
 ```bash
 ./bin/rein daemon serve
 ```
 
-In another terminal, inspect health and the current API surface:
+In another terminal, inspect health and the current API surface from that same checkout (doctor reports repo-local marketplace discovery explicitly when you are outside a repo checkout):
 
 ```bash
 ./bin/rein doctor
@@ -107,10 +107,10 @@ mdbook serve docs
 ## CLI surface
 
 - `rein` is the canonical gRPC client CLI. By default it connects to the selected instance over that instance's unix socket.
-- Use `rein daemon serve` to start the daemon for the selected instance.
+- Use `rein daemon serve` to start the daemon for the selected instance; when you run from a rein checkout, the bundled adapter marketplace is discovered from the repo root even in child directories.
 - Use `rein backup <destination>` to checkpoint and copy the selected instance state directory.
 - Use `rein restore <source>` to swap the selected instance state directory back from a backup copy.
-- Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics.
+- Use `rein doctor` to inspect the selected instance and emit machine-parseable JSON readiness diagnostics, including whether repo-local adapter marketplace discovery succeeded.
 - Use `rein dashboards apply` to push the bundled `rein-dashboards` SigNoz reference dashboards into a SigNoz workspace over the HTTP API.
 - Use `rein describe-as=cli` for a manual-style, machine-consumable description of the CLI/gRPC surface and reachable protobuf schemas.
 - Use `rein describe-as=mcp` for a stable YAML description of commands, flags, gateway stub routes, and schemas suitable for wrapper/skill tooling.
@@ -124,7 +124,7 @@ mdbook serve docs
 
 ## Adapter registry
 
-- The repo ships a signed marketplace index at `.claude-plugin/marketplace.json` for built-in and remote adapter discovery.
+- The repo ships a signed marketplace index at `.claude-plugin/marketplace.json` for built-in and remote adapter discovery, and repo-local commands walk upward so child directories resolve the same checkout root.
 - Repository-local trusted public keys live at `.claude-plugin/trusted-keys.json`; `rein doctor` reports signature presence and verification status.
 - The daemon's local discovery path tolerates unsigned marketplace indexes for local development, but the committed repository index should remain signed.
 - `messaging-null` is a no-op notification adapter that advertises `messaging.post` so workflows can stay launchable until Slack and Discord adapters land.

--- a/cmd/rein/app.go
+++ b/cmd/rein/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"github.com/earchibald/rein/internal/adapter"
 	"github.com/earchibald/rein/internal/dashboards"
 	"github.com/earchibald/rein/internal/instance"
+	"github.com/earchibald/rein/internal/reporoot"
 	"github.com/earchibald/rein/internal/server"
 	"github.com/earchibald/rein/internal/service"
 	"github.com/earchibald/rein/internal/storage/sqlite"
@@ -180,9 +182,9 @@ func (a *app) serveDaemon(config daemonServeConfig) error {
 	}
 	defer store.Close()
 
-	catalog, err := service.NewManagedCatalogFromRoot(".", adapter.LocalDiscoveryOptions())
+	catalog, err := a.loadManagedCatalog()
 	if err != nil {
-		return fmt.Errorf("load adapter registry: %w", err)
+		return err
 	}
 
 	listenerConfig := config.listener
@@ -217,6 +219,21 @@ func (a *app) serveDaemon(config daemonServeConfig) error {
 	defer stop()
 
 	return runtime.Serve(ctx, listener)
+}
+
+func (a *app) loadManagedCatalog() (service.ManagedCatalog, error) {
+	catalog, err := service.NewManagedCatalogFromRoot(".", adapter.LocalDiscoveryOptions())
+	if err == nil {
+		return catalog, nil
+	}
+
+	var notFound *reporoot.NotFoundError
+	if errors.As(err, &notFound) {
+		_, _ = fmt.Fprintf(a.stderr, "rein: warning: %v; continuing with built-in adapters only\n", err)
+		return service.NewManagedCatalog(nil), nil
+	}
+
+	return nil, fmt.Errorf("load adapter registry: %w", err)
 }
 
 type dashboardsApplyConfig struct {

--- a/cmd/rein/app_test.go
+++ b/cmd/rein/app_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	muxadapter "github.com/earchibald/rein/internal/adapter/muxiterm"
+)
+
+func TestLoadManagedCatalogWarnsWhenMarketplaceDiscoveryMissing(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	app := newApp(&bytes.Buffer{}, &stderr, func(string) (string, bool) { return "", false }, nil, nil)
+
+	catalog, err := app.loadManagedCatalog()
+	if err != nil {
+		t.Fatalf("loadManagedCatalog() error = %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("loadManagedCatalog() catalog = nil, want built-in catalog")
+	}
+
+	managed, ok := catalog.Lookup(muxadapter.AdapterID)
+	if !ok {
+		t.Fatalf("Lookup(%q) = !ok", muxadapter.AdapterID)
+	}
+	if managed == nil {
+		t.Fatalf("Lookup(%q) = nil, want built-in adapter", muxadapter.AdapterID)
+	}
+	if !strings.Contains(stderr.String(), `continuing with built-in adapters only`) {
+		t.Fatalf("stderr = %q, want missing-marketplace warning", stderr.String())
+	}
+}

--- a/cmd/rein/doctor.go
+++ b/cmd/rein/doctor.go
@@ -75,7 +75,9 @@ type doctorRPCDiagnostic struct {
 }
 
 type doctorPluginDiagnostic struct {
-	Root             string                      `json:"root"`
+	Start            string                      `json:"start"`
+	Root             string                      `json:"root,omitempty"`
+	RootFound        bool                        `json:"rootFound"`
 	DaemonAPIVersion string                      `json:"daemonApiVersion"`
 	RegistryReady    bool                        `json:"registryReady"`
 	AvailableCount   int                         `json:"availableCount"`
@@ -278,7 +280,7 @@ func diagnoseSocket(path string) doctorSocketDiagnostic {
 }
 
 func diagnosePlugins(root string) doctorPluginDiagnostic {
-	diagnostic := adapter.Diagnose(root, adapter.LocalDiscoveryOptions())
+	diagnostic := adapter.DiagnoseFromWorkingDir(root, adapter.LocalDiscoveryOptions())
 
 	adapters := make([]doctorAdapterDiagnostic, 0, len(diagnostic.Adapters))
 	availableCount := 0
@@ -300,7 +302,9 @@ func diagnosePlugins(root string) doctorPluginDiagnostic {
 	}
 
 	return doctorPluginDiagnostic{
-		Root:             root,
+		Start:            diagnostic.Start,
+		Root:             diagnostic.Root,
+		RootFound:        diagnostic.RootFound,
 		DaemonAPIVersion: adapter.CurrentDaemonAPIVersion,
 		RegistryReady:    diagnostic.RegistryReady,
 		AvailableCount:   availableCount,

--- a/cmd/rein/doctor_test.go
+++ b/cmd/rein/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -88,6 +89,7 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 	}
 
 	var payload struct {
+		OK       bool `json:"ok"`
 		Instance struct {
 			Name    string `json:"name"`
 			PIDPath string `json:"pidPath"`
@@ -104,7 +106,12 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 			} `json:"rpc"`
 		} `json:"daemon"`
 		Plugins struct {
-			Marketplace struct {
+			Start         string `json:"start"`
+			Root          string `json:"root"`
+			RootFound     bool   `json:"rootFound"`
+			RegistryReady bool   `json:"registryReady"`
+			Error         string `json:"error"`
+			Marketplace   struct {
 				Present bool `json:"present"`
 			} `json:"marketplace"`
 			ConfiguredCount int `json:"configuredCount"`
@@ -139,6 +146,21 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 	if !payload.Daemon.Reachable || !payload.Daemon.RPC.OK {
 		t.Fatalf("daemon diagnostic = %+v, want reachable rpc ok", payload.Daemon)
 	}
+	if payload.OK {
+		t.Fatalf("ok = true, want false when plugin marketplace discovery is missing")
+	}
+	if payload.Plugins.Start != worktree {
+		t.Fatalf("plugins.start = %q, want %q", payload.Plugins.Start, worktree)
+	}
+	if payload.Plugins.RootFound {
+		t.Fatalf("plugins.rootFound = true, want false")
+	}
+	if payload.Plugins.RegistryReady {
+		t.Fatalf("plugins.registryReady = true, want false")
+	}
+	if payload.Plugins.Error == "" {
+		t.Fatal("plugins.error = empty, want missing marketplace message")
+	}
 	if payload.Plugins.Marketplace.Present {
 		t.Fatalf("marketplace.present = true, want false")
 	}
@@ -151,4 +173,69 @@ func TestDoctorCommandEmitsStructuredJSON(t *testing.T) {
 	if !payload.Storage.Migrations.Ready || payload.Storage.Migrations.CurrentVersion == 0 || payload.Storage.Migrations.LatestVersion == 0 {
 		t.Fatalf("migration diagnostic = %+v, want ready migrated database", payload.Storage.Migrations)
 	}
+}
+
+func TestDiagnosePluginsDiscoversMarketplaceFromSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	root := writeDoctorPluginFixture(t)
+	start := filepath.Join(root, "nested", "deeper")
+	if err := os.MkdirAll(start, 0o755); err != nil {
+		t.Fatalf("MkdirAll(start) error = %v", err)
+	}
+
+	diagnostic := diagnosePlugins(start)
+	if diagnostic.Start != start {
+		t.Fatalf("diagnosePlugins().Start = %q, want %q", diagnostic.Start, start)
+	}
+	if !diagnostic.RootFound {
+		t.Fatalf("diagnosePlugins().RootFound = false, want true: %+v", diagnostic)
+	}
+	if diagnostic.Root != root {
+		t.Fatalf("diagnosePlugins().Root = %q, want %q", diagnostic.Root, root)
+	}
+	if !diagnostic.RegistryReady {
+		t.Fatalf("diagnosePlugins().RegistryReady = false, want true: %+v", diagnostic)
+	}
+	if !diagnostic.Marketplace.Present {
+		t.Fatalf("diagnosePlugins().Marketplace.Present = false, want true: %+v", diagnostic)
+	}
+	if diagnostic.ConfiguredCount != 1 || diagnostic.AvailableCount != 1 {
+		t.Fatalf("diagnosePlugins() counts = configured %d available %d, want 1/1", diagnostic.ConfiguredCount, diagnostic.AvailableCount)
+	}
+}
+
+func writeDoctorPluginFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "plugins", "messaging-local", ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(plugin manifest dir) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), []byte(`{
+  "name": "doctor-fixture",
+  "plugins": [
+    {
+      "name": "messaging-local",
+      "source": "./plugins/messaging-local",
+      "version": "0.1.0",
+      "category": "messaging",
+      "daemonApiVersion": "rein.v1"
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugins", "messaging-local", ".claude-plugin", "plugin.json"), []byte(`{
+  "name": "messaging-local",
+  "version": "0.1.0",
+  "category": "messaging",
+  "daemonApiVersion": "rein.v1"
+}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(plugin.json) error = %v", err)
+	}
+	return root
 }

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -14,7 +14,7 @@ All examples below use `./bin/rein`, but the same commands work if you place the
 
 ## 2. Start the daemon
 
-By default, rein talks to the `live` instance over that instance's unix socket:
+By default, rein talks to the `live` instance over that instance's unix socket. When you run from a rein checkout, the daemon also walks upward to the repo root so bundled adapters stay visible from child directories:
 
 ```bash
 ./bin/rein daemon serve
@@ -34,7 +34,7 @@ For example, to run a second instance explicitly:
 
 ## 3. Confirm local health
 
-`rein doctor` is the fastest way to confirm the selected instance is wired correctly:
+`rein doctor` is the fastest way to confirm the selected instance is wired correctly. It also reports whether repo-local adapter marketplace discovery succeeded for the current working directory:
 
 ```bash
 ./bin/rein doctor

--- a/internal/adapter/diagnostics.go
+++ b/internal/adapter/diagnostics.go
@@ -8,7 +8,9 @@ import (
 )
 
 type Diagnostic struct {
+	Start            string
 	Root             string
+	RootFound        bool
 	MarketplacePath  string
 	MarketplaceName  string
 	MarketplaceFound bool
@@ -40,9 +42,10 @@ type AdapterDiagnostic struct {
 
 func Diagnose(root string, options DiscoveryOptions) Diagnostic {
 	diagnostic := Diagnostic{
-		Root:            root,
-		MarketplacePath: filepath.Join(root, ".claude-plugin", "marketplace.json"),
-		RegistryReady:   true,
+		Start:         root,
+		Root:          root,
+		RootFound:     true,
+		RegistryReady: true,
 	}
 
 	var err error
@@ -53,13 +56,11 @@ func Diagnose(root string, options DiscoveryOptions) Diagnostic {
 		return diagnostic
 	}
 
-	raw, err := os.ReadFile(diagnostic.MarketplacePath)
+	raw, marketplacePath, err := readMarketplaceIndex(root)
+	diagnostic.MarketplacePath = marketplacePath
 	if err != nil {
-		if os.IsNotExist(err) {
-			return diagnostic
-		}
 		diagnostic.RegistryReady = false
-		diagnostic.Error = fmt.Sprintf("read marketplace index: %v", err)
+		diagnostic.Error = err.Error()
 		return diagnostic
 	}
 	diagnostic.MarketplaceFound = true
@@ -89,6 +90,24 @@ func Diagnose(root string, options DiscoveryOptions) Diagnostic {
 		diagnostic.Adapters = append(diagnostic.Adapters, adapterDiagnostic)
 	}
 
+	return diagnostic
+}
+
+func DiagnoseFromWorkingDir(start string, options DiscoveryOptions) Diagnostic {
+	root, err := FindRoot(start)
+	if err != nil {
+		return Diagnostic{
+			Start:           start,
+			MarketplacePath: filepath.Join(start, MarketplaceIndexPath),
+			RegistryReady:   false,
+			Error:           err.Error(),
+		}
+	}
+
+	diagnostic := Diagnose(root, options)
+	diagnostic.Start = start
+	diagnostic.Root = root
+	diagnostic.RootFound = true
 	return diagnostic
 }
 

--- a/internal/adapter/diagnostics_test.go
+++ b/internal/adapter/diagnostics_test.go
@@ -1,6 +1,9 @@
 package adapter
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestDiagnoseReportsPluginCompatibilityFailures(t *testing.T) {
 	t.Parallel()
@@ -30,5 +33,23 @@ func TestDiagnoseReportsPluginCompatibilityFailures(t *testing.T) {
 	}
 	if mismatch.Error == "" {
 		t.Fatalf("Error = empty, want mismatch diagnostic: %+v", *mismatch)
+	}
+}
+
+func TestDiagnoseFromWorkingDirReportsMissingMarketplace(t *testing.T) {
+	t.Parallel()
+
+	start := filepath.Join(t.TempDir(), "nested", "deeper")
+	diagnostic := DiagnoseFromWorkingDir(start, DiscoveryOptions{AllowUnsignedIndex: true})
+
+	if diagnostic.RootFound {
+		t.Fatalf("RootFound = true, want false: %+v", diagnostic)
+	}
+	if diagnostic.RegistryReady {
+		t.Fatalf("RegistryReady = true, want false: %+v", diagnostic)
+	}
+	want := `adapter marketplace ".claude-plugin/marketplace.json" was not found from "` + start + `"`
+	if diagnostic.Error != want {
+		t.Fatalf("Error = %q, want %q", diagnostic.Error, want)
 	}
 }

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -131,19 +131,19 @@ type pluginRecord struct {
 }
 
 func Load(root string, options DiscoveryOptions) (*Registry, error) {
-	var err error
-	options, err = options.withRootDefaults(root)
+	resolvedRoot, err := FindRoot(root)
+	if err != nil {
+		return nil, err
+	}
+
+	options, err = options.withRootDefaults(resolvedRoot)
 	if err != nil {
 		return nil, fmt.Errorf("load trusted keys: %w", err)
 	}
 
-	marketplacePath := filepath.Join(root, ".claude-plugin", "marketplace.json")
-	raw, err := os.ReadFile(marketplacePath)
+	raw, _, err := readMarketplaceIndex(resolvedRoot)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &Registry{entries: map[string]Entry{}}, nil
-		}
-		return nil, fmt.Errorf("read marketplace index: %w", err)
+		return nil, err
 	}
 
 	if err := verifyIndexSignature(raw, options); err != nil {
@@ -161,7 +161,7 @@ func Load(root string, options DiscoveryOptions) (*Registry, error) {
 	}
 
 	for _, plugin := range document.Plugins {
-		entry, err := loadPlugin(root, plugin, options)
+		entry, err := loadPlugin(resolvedRoot, plugin, options)
 		if err != nil {
 			return nil, fmt.Errorf("load plugin %q: %w", plugin.Name, err)
 		}
@@ -172,6 +172,18 @@ func Load(root string, options DiscoveryOptions) (*Registry, error) {
 	}
 
 	return registry, nil
+}
+
+func readMarketplaceIndex(root string) (raw []byte, marketplacePath string, err error) {
+	marketplacePath = filepath.Join(root, MarketplaceIndexPath)
+	raw, err = os.ReadFile(marketplacePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, marketplacePath, fmt.Errorf("read marketplace index: %q was not found", marketplacePath)
+		}
+		return nil, marketplacePath, fmt.Errorf("read marketplace index: %w", err)
+	}
+	return raw, marketplacePath, nil
 }
 
 func NormalizeCategory(value string) (Taxonomy, error) {

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -189,6 +189,31 @@ func TestLoadRepositoryMarketplaceMuxitermEntry(t *testing.T) {
 	}
 }
 
+func TestLoadRepositoryMarketplaceFromSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	registry, err := Load(filepath.Join(root, "plugins", "tracker-github"), DiscoveryOptions{})
+	if err != nil {
+		t.Fatalf("Load(subdirectory) error = %v", err)
+	}
+
+	if _, ok := registry.Entry("muxiterm"); !ok {
+		t.Fatal(`Entry("muxiterm") = !ok`)
+	}
+}
+
+func TestLoadMissingMarketplaceFailsClearly(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	_, err := Load(root, DiscoveryOptions{AllowUnsignedIndex: true})
+	want := `adapter marketplace ".claude-plugin/marketplace.json" was not found from "` + root + `"`
+	if err == nil || err.Error() != want {
+		t.Fatalf("Load() error = %v, want %q", err, want)
+	}
+}
+
 func adapterIDs(adapters []*reinv1.Adapter) []string {
 	ids := make([]string, 0, len(adapters))
 	for _, adapter := range adapters {

--- a/internal/adapter/root.go
+++ b/internal/adapter/root.go
@@ -1,0 +1,9 @@
+package adapter
+
+import "github.com/earchibald/rein/internal/reporoot"
+
+const MarketplaceIndexPath = ".claude-plugin/marketplace.json"
+
+func FindRoot(start string) (string, error) {
+	return reporoot.Find(start, MarketplaceIndexPath, "adapter marketplace")
+}

--- a/internal/dashboards/registry.go
+++ b/internal/dashboards/registry.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/earchibald/rein/internal/reporoot"
 )
 
 const (
@@ -93,19 +95,7 @@ func Load(root string) (*Registry, error) {
 }
 
 func FindRoot(start string) (string, error) {
-	current := filepath.Clean(start)
-	for {
-		marketplacePath := filepath.Join(current, defaultMarketplacePath)
-		if _, err := os.Stat(marketplacePath); err == nil {
-			return current, nil
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-		current = parent
-	}
-	return "", fmt.Errorf("dashboards marketplace %q was not found from %q", defaultMarketplacePath, start)
+	return reporoot.Find(start, defaultMarketplacePath, "dashboards marketplace")
 }
 
 func (r *Registry) Entry(name string) (Entry, bool) {

--- a/internal/reporoot/find.go
+++ b/internal/reporoot/find.go
@@ -1,0 +1,52 @@
+package reporoot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type NotFoundError struct {
+	Start       string
+	Marker      string
+	Description string
+}
+
+func (e *NotFoundError) Error() string {
+	label := strings.TrimSpace(e.Description)
+	if label == "" {
+		label = "repository marker"
+	}
+	return fmt.Sprintf("%s %q was not found from %q", label, e.Marker, e.Start)
+}
+
+func Find(start, marker, description string) (string, error) {
+	current := filepath.Clean(start)
+	label := strings.TrimSpace(description)
+	if label == "" {
+		label = "repository marker"
+	}
+
+	for {
+		candidate := filepath.Join(current, marker)
+		if _, err := os.Stat(candidate); err == nil {
+			return current, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("stat %q: %w", candidate, err)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	return "", &NotFoundError{
+		Start:       start,
+		Marker:      marker,
+		Description: label,
+	}
+}

--- a/internal/reporoot/find_test.go
+++ b/internal/reporoot/find_test.go
@@ -1,0 +1,39 @@
+package reporoot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindWalksUpToMarker(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude-plugin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.claude-plugin) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude-plugin", "marketplace.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("WriteFile(marketplace.json) error = %v", err)
+	}
+
+	start := filepath.Join(root, "nested", "deeper")
+	got, err := Find(start, ".claude-plugin/marketplace.json", "adapter marketplace")
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	if got != root {
+		t.Fatalf("Find() root = %q, want %q", got, root)
+	}
+}
+
+func TestFindReturnsHelpfulErrorWhenMarkerMissing(t *testing.T) {
+	t.Parallel()
+
+	start := filepath.Join(t.TempDir(), "nested", "deeper")
+	_, err := Find(start, ".claude-plugin/marketplace.json", "adapter marketplace")
+	want := `adapter marketplace ".claude-plugin/marketplace.json" was not found from ` + `"` + start + `"`
+	if err == nil || err.Error() != want {
+		t.Fatalf("Find() error = %v, want %q", err, want)
+	}
+}

--- a/internal/service/adapter_server.go
+++ b/internal/service/adapter_server.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -18,7 +19,12 @@ type AdapterServer struct {
 }
 
 func NewAdapterServerFromRoot(root string, options adapter.DiscoveryOptions) (*AdapterServer, error) {
-	registry, err := adapter.Load(root, options)
+	resolvedRoot, err := adapter.FindRoot(root)
+	if err != nil {
+		err = fmt.Errorf("discover adapter marketplace root: %w", err)
+		return &AdapterServer{loadErr: err}, err
+	}
+	registry, err := adapter.Load(resolvedRoot, options)
 	server := &AdapterServer{
 		registry: registry,
 		loadErr:  err,

--- a/internal/service/managed_catalog.go
+++ b/internal/service/managed_catalog.go
@@ -15,11 +15,15 @@ import (
 )
 
 func NewManagedCatalogFromRoot(root string, options adapter.DiscoveryOptions) (ManagedCatalog, error) {
-	registry, err := adapter.Load(root, options)
+	resolvedRoot, err := adapter.FindRoot(root)
+	if err != nil {
+		return nil, fmt.Errorf("discover adapter marketplace root: %w", err)
+	}
+	registry, err := adapter.Load(resolvedRoot, options)
 	if err != nil {
 		return nil, err
 	}
-	return newManagedCatalog(root, registry), nil
+	return newManagedCatalog(resolvedRoot, registry), nil
 }
 
 func NewManagedCatalog(registry *adapter.Registry) ManagedCatalog {

--- a/internal/service/managed_catalog_test.go
+++ b/internal/service/managed_catalog_test.go
@@ -200,6 +200,54 @@ func TestManagedCatalogWrapsBuiltInGitHubTracker(t *testing.T) {
 	}
 }
 
+func TestNewManagedCatalogFromRootDiscoversRepositoryRootFromSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeManagedCatalogMarketplace(t, root, map[string]any{
+		"name": "rein-fixture",
+		"plugins": []any{
+			map[string]any{
+				"name":             githubTrackerAdapterID,
+				"source":           "./plugins/" + githubTrackerAdapterID,
+				"version":          "0.1.0",
+				"description":      "Fixture GitHub tracker adapter",
+				"category":         "tracker",
+				"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+			},
+		},
+	})
+	writeManagedCatalogManifest(t, root, githubTrackerAdapterID, map[string]any{
+		"name":             githubTrackerAdapterID,
+		"version":          "0.1.0",
+		"description":      "Fixture GitHub tracker adapter",
+		"category":         "tracker",
+		"daemonApiVersion": adapter.CurrentDaemonAPIVersion,
+	})
+
+	start := filepath.Join(root, "nested", "deeper")
+	if err := os.MkdirAll(start, 0o755); err != nil {
+		t.Fatalf("MkdirAll(start) error = %v", err)
+	}
+
+	catalog, err := NewManagedCatalogFromRoot(start, adapter.DiscoveryOptions{AllowUnsignedIndex: true})
+	if err != nil {
+		t.Fatalf("NewManagedCatalogFromRoot(subdirectory) error = %v", err)
+	}
+
+	managed, ok := catalog.Lookup(githubTrackerAdapterID)
+	if !ok {
+		t.Fatalf("Lookup(%q) = !ok", githubTrackerAdapterID)
+	}
+	tracker, ok := managed.(*githubTrackerAdapter)
+	if !ok {
+		t.Fatalf("Lookup(%q) type = %T, want *githubTrackerAdapter", githubTrackerAdapterID, managed)
+	}
+	if tracker.root != root {
+		t.Fatalf("githubTrackerAdapter.root = %q, want %q", tracker.root, root)
+	}
+}
+
 func managedCatalogIDs(adapters []*reinv1.Adapter) []string {
 	ids := make([]string, 0, len(adapters))
 	for _, descriptor := range adapters {


### PR DESCRIPTION
## Summary
- add a shared repo-root discovery helper and use it for adapter marketplace, managed catalog, adapter server, and dashboards discovery
- make doctor report repo-local plugin discovery explicitly and add focused subdirectory/missing-marketplace tests
- keep daemon startup behavior safe by warning and falling back to built-in adapters when repo-local marketplace discovery is absent

## Validation
- go test -count=1 -p 1 ./...
- go build ./cmd/rein