### PR TITLE
RN-38: add docs wikilink crosslinks

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -26,6 +26,18 @@ It also deliberately keeps some work out of tree:
 - Wiring observability? Read [Metrics, logs, and OTLP](metrics-logs-otlp.md).
 - Adding marketplace entries or local manifests? Read the [Plugin author guide](plugin-author-guide.md).
 - Moving data over from op-obsidian? Read the [Migration guide](migration-guide.md).
+- Need the full table of contents? See the [Docs summary](SUMMARY.md).
+
+<div hidden>
+
+[[cli-quickstart|CLI quickstart]]
+[[tui-quickstart|TUI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[plugin-author-guide|Plugin author guide]]
+[[migration-guide|Migration guide]]
+[[SUMMARY|Docs summary]]
+
+</div>
 
 ## Serving the docs site locally
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,3 +6,14 @@
 - [Metrics, logs, and OTLP](metrics-logs-otlp.md)
 - [Plugin author guide](plugin-author-guide.md)
 - [Migration guide](migration-guide.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[cli-quickstart|CLI quickstart]]
+[[tui-quickstart|TUI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[plugin-author-guide|Plugin author guide]]
+[[migration-guide|Migration guide]]
+
+</div>

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -175,3 +175,23 @@ Once the daemon has enough project/issue/execution state to browse, launch:
 ```
 
 See the [TUI quickstart](tui-quickstart.md) for the keymap and drilldown behavior.
+
+## Related docs
+
+- [Overview](README.md)
+- [TUI quickstart](tui-quickstart.md)
+- [Metrics, logs, and OTLP](metrics-logs-otlp.md)
+- [Plugin author guide](plugin-author-guide.md)
+- [Migration guide](migration-guide.md)
+- [Docs summary](SUMMARY.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[tui-quickstart|TUI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[plugin-author-guide|Plugin author guide]]
+[[migration-guide|Migration guide]]
+[[SUMMARY|Docs summary]]
+
+</div>

--- a/docs/src/metrics-logs-otlp.md
+++ b/docs/src/metrics-logs-otlp.md
@@ -132,3 +132,23 @@ The dashboards marketplace currently points at the bundled local `rein-dashboard
 - OTLP export is daemon-only; the CLI itself does not expose a separate observability pipeline
 - `rein dashboards apply` supports bundled local dashboard plugins today, not remote bootstrap
 - the TUI can show looking-glass/tail support state, but rein does not yet stream live tails
+
+## Related docs
+
+- [Overview](README.md)
+- [CLI quickstart](cli-quickstart.md)
+- [TUI quickstart](tui-quickstart.md)
+- [Plugin author guide](plugin-author-guide.md)
+- [Migration guide](migration-guide.md)
+- [Docs summary](SUMMARY.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[cli-quickstart|CLI quickstart]]
+[[tui-quickstart|TUI quickstart]]
+[[plugin-author-guide|Plugin author guide]]
+[[migration-guide|Migration guide]]
+[[SUMMARY|Docs summary]]
+
+</div>

--- a/docs/src/migration-guide.md
+++ b/docs/src/migration-guide.md
@@ -60,3 +60,23 @@ This split is deliberate:
 - the rein daemon stays free of source-system-specific dependencies once the migration is done
 
 If you need migration behavior beyond projects/issues, track that work in the external migration repo rather than assuming the core daemon already supports it.
+
+## Related docs
+
+- [Overview](README.md)
+- [CLI quickstart](cli-quickstart.md)
+- [TUI quickstart](tui-quickstart.md)
+- [Metrics, logs, and OTLP](metrics-logs-otlp.md)
+- [Plugin author guide](plugin-author-guide.md)
+- [Docs summary](SUMMARY.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[cli-quickstart|CLI quickstart]]
+[[tui-quickstart|TUI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[plugin-author-guide|Plugin author guide]]
+[[SUMMARY|Docs summary]]
+
+</div>

--- a/docs/src/plugin-author-guide.md
+++ b/docs/src/plugin-author-guide.md
@@ -143,3 +143,23 @@ Today:
 - `rein dashboards apply` only installs bundled local dashboard plugins
 
 If you are documenting or shipping a plugin, be explicit about which parts are discovery metadata versus actually executable bootstrap today.
+
+## Related docs
+
+- [Overview](README.md)
+- [CLI quickstart](cli-quickstart.md)
+- [TUI quickstart](tui-quickstart.md)
+- [Metrics, logs, and OTLP](metrics-logs-otlp.md)
+- [Migration guide](migration-guide.md)
+- [Docs summary](SUMMARY.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[cli-quickstart|CLI quickstart]]
+[[tui-quickstart|TUI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[migration-guide|Migration guide]]
+[[SUMMARY|Docs summary]]
+
+</div>

--- a/docs/src/tui-quickstart.md
+++ b/docs/src/tui-quickstart.md
@@ -89,3 +89,23 @@ Prefer the CLI when you need:
 - SigNoz dashboard installation
 
 The TUI is for inspection and drilldown; the CLI remains the canonical automation surface.
+
+## Related docs
+
+- [Overview](README.md)
+- [CLI quickstart](cli-quickstart.md)
+- [Metrics, logs, and OTLP](metrics-logs-otlp.md)
+- [Plugin author guide](plugin-author-guide.md)
+- [Migration guide](migration-guide.md)
+- [Docs summary](SUMMARY.md)
+
+<div hidden>
+
+[[README|Overview]]
+[[cli-quickstart|CLI quickstart]]
+[[metrics-logs-otlp|Metrics, logs, and OTLP]]
+[[plugin-author-guide|Plugin author guide]]
+[[migration-guide|Migration guide]]
+[[SUMMARY|Docs summary]]
+
+</div>


### PR DESCRIPTION
## Summary
- add related-doc crosslinks across every file in docs/src
- keep mdBook-visible navigation in normal Markdown links while adding hidden source wikilinks
- update the RN-38 vault note and validate with `mdbook build docs`

Closes #70