### PR TITLE
Add first-run rein operator training flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ docs/book/
 
 # rein backups
 backups/
+
+# Local scratch state used by docs and demo bootstrap flows
+.tmp/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Re-running the command skips unchanged bundled dashboards and reports `createdId
 Longer user guides live under `docs/` and can be read directly in the repo or served as an mdBook:
 
 - [Docs overview](docs/src/README.md)
+- [First-run operator walkthrough](docs/src/first-run-operator-walkthrough.md)
 - [CLI quickstart](docs/src/cli-quickstart.md)
 - [TUI quickstart](docs/src/tui-quickstart.md)
 - [Metrics, logs, and OTLP](docs/src/metrics-logs-otlp.md)

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -21,8 +21,9 @@ It also deliberately keeps some work out of tree:
 
 ## Start here
 
-- New operator? Read the [CLI quickstart](cli-quickstart.md).
-- Prefer a terminal UI? Read the [TUI quickstart](tui-quickstart.md).
+- Totally fresh to rein? Start with the [first-run operator walkthrough](first-run-operator-walkthrough.md).
+- Need the canonical command flow in more detail? Read the [CLI quickstart](cli-quickstart.md).
+- Prefer a terminal UI after the first run? Read the [TUI quickstart](tui-quickstart.md).
 - Wiring observability? Read [Metrics, logs, and OTLP](metrics-logs-otlp.md).
 - Adding marketplace entries or local manifests? Read the [Plugin author guide](plugin-author-guide.md).
 - Moving data over from op-obsidian? Read the [Migration guide](migration-guide.md).
@@ -57,3 +58,4 @@ These docs intentionally describe the shipped behavior in this tree today:
 - remote adapters can be discovered through the marketplace, but remote managed execution is still a stub
 - remote dashboard plugin sources are parsed by the loader, but `rein dashboards apply` currently installs bundled local plugins only
 - looking-glass tail support is surfaced in CLI/TUI status, but the daemon does not yet stream live tails
+- a browser/web operator UI is not shipped yet; the HTTP/SSE gateway remains a stub

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Overview](README.md)
+- [First-run operator walkthrough](first-run-operator-walkthrough.md)
 - [CLI quickstart](cli-quickstart.md)
 - [TUI quickstart](tui-quickstart.md)
 - [Metrics, logs, and OTLP](metrics-logs-otlp.md)

--- a/docs/src/cli-quickstart.md
+++ b/docs/src/cli-quickstart.md
@@ -2,6 +2,8 @@
 
 This guide assumes you are working from a checkout of `earchibald/rein` and want to exercise the current daemon + CLI flow without guessing at the request shape.
 
+If you are totally fresh to rein and want a disposable first run with sample data, start with the [first-run operator walkthrough](first-run-operator-walkthrough.md) before using this deeper CLI reference.
+
 ## 1. Build the binary
 
 Rein currently builds from source with Go 1.25:

--- a/docs/src/first-run-operator-walkthrough.md
+++ b/docs/src/first-run-operator-walkthrough.md
@@ -1,0 +1,164 @@
+# First-run operator walkthrough
+
+This is the best place to start if you are totally fresh to `rein` and want a repeatable, low-risk first run. It keeps state inside the checkout, uses a disposable `demo` instance instead of the default `live` instance, and walks through the shipped operator surfaces in the order they make sense today.
+
+Rein currently ships two operator HMIs:
+
+- the canonical CLI
+- the terminal UI (`rein tui`)
+
+It does **not** ship a browser UI yet. The future HTTP/SSE gateway is still a stub, so first-time operator training should stop at CLI + TUI for now.
+
+## 1. Open a clean checkout and isolate the state home
+
+From the repo root:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+go build -o bin/rein ./cmd/rein
+```
+
+Using a repo-local `XDG_STATE_HOME` makes teardown easy: once you stop the daemon, removing `.tmp/rein-state` returns you to a clean slate.
+
+## 2. Start a disposable daemon instance
+
+Keep this terminal open:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+./bin/rein --instance demo daemon serve
+```
+
+The `demo` instance is intentional. It keeps first-run exploration separate from the default `live` instance and makes the walkthrough safe to repeat.
+
+## 3. Explore the CLI from a second terminal
+
+In another terminal, from the same checkout:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+
+./bin/rein --instance demo doctor
+./bin/rein --instance demo version
+./bin/rein --instance demo project list
+./bin/rein --instance demo issue list
+./bin/rein --instance demo describe-as=cli
+./bin/rein --instance demo project --help
+./bin/rein --instance demo issue create --help
+```
+
+That sequence shows the core first-run checkpoints:
+
+1. `doctor` proves the instance layout, socket, SQLite database, and bundled adapter discovery are healthy.
+2. `version` confirms which tree you built.
+3. `project list` and `issue list` show that the fresh instance is empty.
+4. `describe-as=cli` exposes the authoritative shipped command surface.
+5. subgroup help confirms how request payloads are passed.
+
+For deeper CLI details after this pass, continue with the [CLI quickstart](cli-quickstart.md).
+
+## 4. Seed a tiny repeatable training dataset
+
+Create one project and one issue so the lists and TUI have something real to show:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+
+./bin/rein --instance demo project create --project '{
+  "id": "rein-demo",
+  "slug": "rein-demo",
+  "displayName": "rein-demo",
+  "summary": "Repeatable first-run training project",
+  "status": "PROJECT_STATUS_ACTIVE"
+}'
+
+./bin/rein --instance demo issue create --issue '{
+  "id": "RD-1",
+  "projectId": "rein-demo",
+  "title": "Scaffold the demo project with an agent prompt",
+  "summary": "Seed the repeatable training loop for the lightweight Rust demo repository.",
+  "status": "ISSUE_STATUS_OPEN",
+  "priority": "ISSUE_PRIORITY_HIGH",
+  "assignee": "operator"
+}'
+
+./bin/rein --instance demo project list
+./bin/rein --instance demo issue list --project_id rein-demo
+./bin/rein --instance demo issue get --id RD-1
+```
+
+This gives you a stable first issue for repeated operator training: `RD-1` is always the bootstrap issue for the demo project.
+
+## 5. Launch the TUI against the same instance
+
+Still from the same checkout:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+./bin/rein --instance demo tui
+```
+
+At this point you should be able to browse:
+
+1. the `rein-demo` project
+2. the `RD-1` issue
+3. an otherwise clean execution list
+
+Use the [TUI quickstart](tui-quickstart.md) for the keymap and drilldown behavior once the screen is open.
+
+## 6. Know where the walkthrough stops today
+
+Current operator training should include these boundaries explicitly:
+
+- the CLI is the canonical automation surface
+- the TUI is the shipped inspection surface
+- the browser/web experience is **not** shipped yet
+- `describe-as=mcp` and related output can describe the planned gateway shape, but the HTTP/SSE gateway itself is still not implemented
+
+That means first-time training should focus on build, daemon health, CLI discovery, sample data, and TUI browsing.
+
+## 7. Bootstrap the repeatable `rein-demo` training loop
+
+For the cross-tool training loop, the base demo should stay as small as possible. The repo now ships a helper that uses a tiny Rust binary project as the seed and mirrors it into rein with a fixed `RD-*` issue set.
+
+From the rein repo root, after the `demo` daemon is already running:
+
+```bash
+export XDG_STATE_HOME="$PWD/.tmp/rein-state"
+
+./scripts/bootstrap-rein-demo.sh \
+  --state-home "$XDG_STATE_HOME" \
+  --instance demo \
+  --repo-dir /Users/earchibald/Projects/rein-demo
+```
+
+That command:
+
+1. creates or reuses `/Users/earchibald/Projects/rein-demo`
+2. uses `cargo new --bin` as the lightweight Rust seed when the repo does not exist yet
+3. seeds rein project `rein-demo`
+4. seeds the fixed repeatable issue set `RD-1` through `RD-5`
+
+If you also want the matching GitHub repository created or reused, add `--github`:
+
+```bash
+./scripts/bootstrap-rein-demo.sh \
+  --state-home "$XDG_STATE_HOME" \
+  --instance demo \
+  --repo-dir /Users/earchibald/Projects/rein-demo \
+  --github
+```
+
+The bootstrap defaults to a private GitHub repo. Pass `--github-visibility public` if you intentionally want the demo repository to be public.
+
+## 8. Fixed repeatable issue set
+
+The seeded backlog is intentionally small and stable:
+
+1. `RD-1` — scaffold the demo project with an agent prompt
+2. `RD-2` — replace the hello-world print with a reusable greet helper
+3. `RD-3` — accept a name argument for a personalized greeting
+4. `RD-4` — add a README quickstart for build and run
+5. `RD-5` — add a unit test for the greeting helper
+
+This keeps the training loop lightweight enough to tear down and rebuild whenever the docs or operator flow change.

--- a/docs/src/tui-quickstart.md
+++ b/docs/src/tui-quickstart.md
@@ -2,6 +2,8 @@
 
 `rein tui` is the terminal-native view over the same daemon API that the CLI uses. It is best when you want to browse projects, issues, executions, workflow drilldown, and adapter capability state without manually issuing several list/get commands.
 
+If this is your very first rein session, start with the [first-run operator walkthrough](first-run-operator-walkthrough.md) so the daemon, instance, and sample data are already in place before you open the TUI.
+
 ## 1. Start the daemon first
 
 The TUI is a client, not a standalone store browser, so it needs a running daemon:

--- a/scripts/bootstrap-rein-demo.sh
+++ b/scripts/bootstrap-rein-demo.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/bootstrap-rein-demo.sh [options]
+
+Create or reuse the lightweight Rust rein-demo repository and seed the matching
+rein training project/issues into a running daemon instance.
+
+Options:
+  --repo-dir <path>              Local demo repository path.
+                                 Default: /Users/earchibald/Projects/rein-demo
+  --state-home <path>            XDG state home used by rein.
+                                 Default: $XDG_STATE_HOME or ~/.local/state
+  --instance <name>              Rein instance to seed. Default: demo
+  --rein-bin <path>              Rein binary path. Default: ./bin/rein
+  --reset-repo                   Remove and recreate the local demo repository.
+  --github                       Create or reuse the matching GitHub repository.
+  --github-owner <owner>         GitHub owner. Default: active gh account
+  --github-visibility <value>    private or public. Default: private
+  -h, --help                     Show this help text.
+
+Notes:
+  - The target rein daemon must already be running for the selected instance.
+  - The seeded issue set is:
+      RD-1 scaffold the project with an agent prompt
+      RD-2 replace the hello-world print with a greet helper
+      RD-3 accept a name argument
+      RD-4 add a README quickstart
+      RD-5 add a unit test for the greeting helper
+EOF
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+repo_dir="/Users/earchibald/Projects/rein-demo"
+state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+instance="demo"
+rein_bin="$repo_root/bin/rein"
+reset_repo=false
+publish_github=false
+github_owner=""
+github_visibility="private"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-dir)
+      repo_dir="$2"
+      shift 2
+      ;;
+    --state-home)
+      state_home="$2"
+      shift 2
+      ;;
+    --instance)
+      instance="$2"
+      shift 2
+      ;;
+    --rein-bin)
+      rein_bin="$2"
+      shift 2
+      ;;
+    --reset-repo)
+      reset_repo=true
+      shift
+      ;;
+    --github)
+      publish_github=true
+      shift
+      ;;
+    --github-owner)
+      github_owner="$2"
+      shift 2
+      ;;
+    --github-visibility)
+      github_visibility="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$github_visibility" in
+  private|public) ;;
+  *)
+    echo "github visibility must be private or public" >&2
+    exit 2
+    ;;
+esac
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+run_rein() {
+  XDG_STATE_HOME="$state_home" "$rein_bin" --instance "$instance" "$@"
+}
+
+repo_name=$(basename "$repo_dir")
+project_id="rein-demo"
+
+ensure_rein_ready() {
+  if [[ ! -x "$rein_bin" ]]; then
+    echo "rein binary not found at $rein_bin; build it first with: go build -o bin/rein ./cmd/rein" >&2
+    exit 1
+  fi
+  if ! run_rein doctor >/dev/null 2>&1; then
+    echo "rein daemon for instance '$instance' is not reachable under XDG_STATE_HOME=$state_home" >&2
+    echo "start it first, for example:" >&2
+    echo "  XDG_STATE_HOME=\"$state_home\" \"$rein_bin\" --instance \"$instance\" daemon serve" >&2
+    exit 1
+  fi
+}
+
+ensure_local_repo() {
+  if [[ "$reset_repo" == true && -e "$repo_dir" ]]; then
+    rm -rf "$repo_dir"
+  fi
+
+  if [[ -d "$repo_dir/.git" ]]; then
+    return
+  fi
+
+  if [[ -e "$repo_dir" ]]; then
+    echo "repo path exists but is not a git repository: $repo_dir" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$repo_dir")"
+
+  if [[ "$publish_github" == true ]]; then
+    require_command gh
+    if [[ -z "$github_owner" ]]; then
+      github_owner=$(gh api user --jq .login)
+    fi
+    if gh repo view "$github_owner/$repo_name" >/dev/null 2>&1; then
+      gh repo clone "$github_owner/$repo_name" "$repo_dir"
+      return
+    fi
+  fi
+
+  require_command cargo
+  cargo new --vcs git --bin "$repo_dir"
+}
+
+ensure_initial_commit() {
+  if git -C "$repo_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+    return
+  fi
+  git -C "$repo_dir" add .
+  git -C "$repo_dir" commit -m "Initial cargo scaffold"
+}
+
+ensure_github_repo() {
+  if [[ "$publish_github" != true ]]; then
+    return
+  fi
+
+  require_command gh
+  if [[ -z "$github_owner" ]]; then
+    github_owner=$(gh api user --jq .login)
+  fi
+
+  local full_repo="$github_owner/$repo_name"
+
+  if gh repo view "$full_repo" >/dev/null 2>&1; then
+    if ! git -C "$repo_dir" remote get-url origin >/dev/null 2>&1; then
+      git -C "$repo_dir" remote add origin "https://github.com/$full_repo.git"
+    fi
+    return
+  fi
+
+  ensure_initial_commit
+  gh repo create "$full_repo" "--$github_visibility" \
+    --description "Lightweight repeatable rein operator training demo" \
+    --source "$repo_dir" \
+    --remote origin \
+    --push
+}
+
+upsert_project() {
+  local payload="$1"
+  if run_rein project get --id "$project_id" >/dev/null 2>&1; then
+    run_rein project update --project "$payload" >/dev/null
+  else
+    run_rein project create --project "$payload" >/dev/null
+  fi
+}
+
+upsert_issue() {
+  local issue_id="$1"
+  local payload="$2"
+  if run_rein issue get --id "$issue_id" >/dev/null 2>&1; then
+    run_rein issue update --issue "$payload" >/dev/null
+  else
+    run_rein issue create --issue "$payload" >/dev/null
+  fi
+}
+
+seed_rein_project() {
+  local project_payload
+  project_payload=$(cat <<'EOF'
+{"id":"rein-demo","slug":"rein-demo","displayName":"rein-demo","summary":"Repeatable first-run training project backed by a tiny Rust binary repo.","status":"PROJECT_STATUS_ACTIVE"}
+EOF
+)
+  upsert_project "$project_payload"
+
+  upsert_issue "RD-1" "$(cat <<'EOF'
+{"id":"RD-1","projectId":"rein-demo","title":"Scaffold the demo project with an agent prompt","summary":"Seed the repeatable training loop for the lightweight Rust demo repository.","status":"ISSUE_STATUS_OPEN","priority":"ISSUE_PRIORITY_HIGH","assignee":"operator"}
+EOF
+)"
+  upsert_issue "RD-2" "$(cat <<'EOF'
+{"id":"RD-2","projectId":"rein-demo","title":"Replace the hello-world print with a reusable greet helper","summary":"Refactor the default cargo scaffold so greeting logic is reusable and ready for tests.","status":"ISSUE_STATUS_OPEN","priority":"ISSUE_PRIORITY_MEDIUM","assignee":"operator"}
+EOF
+)"
+  upsert_issue "RD-3" "$(cat <<'EOF'
+{"id":"RD-3","projectId":"rein-demo","title":"Accept a name argument for a personalized greeting","summary":"Extend the tiny Rust binary to accept one name argument without adding heavy dependencies.","status":"ISSUE_STATUS_OPEN","priority":"ISSUE_PRIORITY_MEDIUM","assignee":"operator"}
+EOF
+)"
+  upsert_issue "RD-4" "$(cat <<'EOF'
+{"id":"RD-4","projectId":"rein-demo","title":"Add a README quickstart for build and run","summary":"Document how to build and run the tiny Rust demo so the training repo has an obvious landing page.","status":"ISSUE_STATUS_OPEN","priority":"ISSUE_PRIORITY_MEDIUM","assignee":"operator"}
+EOF
+)"
+  upsert_issue "RD-5" "$(cat <<'EOF'
+{"id":"RD-5","projectId":"rein-demo","title":"Add a unit test for the greeting helper","summary":"Introduce one small automated test so the training loop exercises a trivial code-plus-test change.","status":"ISSUE_STATUS_OPEN","priority":"ISSUE_PRIORITY_MEDIUM","assignee":"operator"}
+EOF
+)"
+}
+
+print_summary() {
+  local github_url=""
+  if [[ "$publish_github" == true ]]; then
+    github_url="https://github.com/$github_owner/$repo_name"
+  fi
+
+  cat <<EOF
+rein-demo bootstrap complete
+  repo_dir: $repo_dir
+  state_home: $state_home
+  instance: $instance
+  project_id: $project_id
+  seeded_issues: RD-1 RD-2 RD-3 RD-4 RD-5
+EOF
+  if [[ -n "$github_url" ]]; then
+    echo "  github_repo: $github_url"
+  fi
+}
+
+ensure_rein_ready
+ensure_local_repo
+ensure_github_repo
+seed_rein_project
+print_summary


### PR DESCRIPTION
## Summary
- add a first-run operator walkthrough for rein
- add a repeatable rein-demo bootstrap script and ignore repo-local scratch state
- wire the new walkthrough into the docs entry points

## Testing
- mdbook build docs
- scripts/bootstrap-rein-demo.sh --help
- scripts/bootstrap-rein-demo.sh --state-home <throwaway> --instance demo --repo-dir /Users/earchibald/Projects/rein-demo --github
- cargo test --manifest-path /Users/earchibald/Projects/rein-demo/Cargo.toml