### PR TITLE
RN-39: UpdateProject preserves issue_prefix (immutable) and repo_path

### DIFF
--- a/internal/service/managed.go
+++ b/internal/service/managed.go
@@ -277,6 +277,22 @@ func (s *ManagedProjectServer) UpdateProject(ctx context.Context, req *reinv1.Up
 	if project.Labels == nil {
 		project.Labels = map[string]string{}
 	}
+
+	// issue_prefix is immutable: once assigned it cannot be changed because all
+	// existing issue IDs depend on it. Always carry the stored value forward.
+	if current.GetIssuePrefix() != "" {
+		if project.GetIssuePrefix() != "" && project.GetIssuePrefix() != current.GetIssuePrefix() {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"project.issue_prefix cannot be changed after creation (current: %q)", current.GetIssuePrefix())
+		}
+		project.IssuePrefix = current.GetIssuePrefix()
+	}
+
+	// repo_path: preserve current value when the caller omits it.
+	if strings.TrimSpace(project.GetRepoPath()) == "" {
+		project.RepoPath = current.GetRepoPath()
+	}
+
 	project.UpdatedTime = timestamppb.Now()
 
 	if err := updateStoredProto(ctx, s.store, sqlite.ProjectKind, project.GetId(), record.LockVersion, project); err != nil {

--- a/internal/service/managed_test.go
+++ b/internal/service/managed_test.go
@@ -743,3 +743,65 @@ func TestCreateIssueAutoID(t *testing.T) {
 		t.Errorf("auto id after gap = %q, want RD-100", got)
 	}
 }
+
+func TestUpdateProjectPreservesIssuePrefixAndRepoPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store, err := sqlite.OpenInMemoryAndMigrate(ctx, t.Name())
+	if err != nil {
+		t.Fatalf("OpenInMemoryAndMigrate() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := &ManagedProjectServer{store: store}
+
+	// Create with auto-derived prefix and a repo_path.
+	createResp, err := svc.CreateProject(ctx, &reinv1.CreateProjectRequest{
+		Project: &reinv1.Project{
+			Id:       "rein-demo",
+			RepoPath: "/tmp/rein-demo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+	if got := createResp.GetProject().GetIssuePrefix(); got != "RD" {
+		t.Fatalf("create: issue_prefix = %q, want RD", got)
+	}
+
+	// Update omitting both issue_prefix and repo_path — both should be preserved.
+	updateResp, err := svc.UpdateProject(ctx, &reinv1.UpdateProjectRequest{
+		Project: &reinv1.Project{
+			Id:          "rein-demo",
+			DisplayName: "Rein Demo Updated",
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateProject() error = %v", err)
+	}
+	if got := updateResp.GetProject().GetIssuePrefix(); got != "RD" {
+		t.Errorf("update: issue_prefix = %q, want RD", got)
+	}
+	if got := updateResp.GetProject().GetRepoPath(); got != "/tmp/rein-demo" {
+		t.Errorf("update: repo_path = %q, want /tmp/rein-demo", got)
+	}
+
+	// Attempting to change issue_prefix should be rejected.
+	_, err = svc.UpdateProject(ctx, &reinv1.UpdateProjectRequest{
+		Project: &reinv1.Project{Id: "rein-demo", IssuePrefix: "XX"},
+	})
+	if err == nil {
+		t.Fatal("expected error when changing issue_prefix, got nil")
+	}
+
+	// repo_path can be changed via update.
+	updateResp2, err := svc.UpdateProject(ctx, &reinv1.UpdateProjectRequest{
+		Project: &reinv1.Project{Id: "rein-demo", RepoPath: "/projects/rein-demo"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateProject(new repo_path) error = %v", err)
+	}
+	if got := updateResp2.GetProject().GetRepoPath(); got != "/projects/rein-demo" {
+		t.Errorf("update: repo_path = %q, want /projects/rein-demo", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `issue_prefix` is now immutable after creation: `UpdateProject` always carries the stored prefix forward; attempts to change it return `InvalidArgument` since all existing issue IDs depend on the prefix.
- `repo_path` is preserved from the stored record when the caller omits it (can still be changed by supplying a new value).
- Added `TestUpdateProjectPreservesIssuePrefixAndRepoPath` covering preservation and the immutability guard.
- Fixes the gap where `project create` correctly included `issue_prefix` in its response but any subsequent `project update` call without the field would silently clear it.

216 tests passing, CI green.